### PR TITLE
Build and publish docker images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,8 +9,8 @@ on:
     - cron: "30 12 * * *"  # runs everyday at 12h30
 
 env:
-  PUBLISH_IMAGE: ${{ (github.ref == 'main' || github.ref_type == 'branch') && 'TRUE' || 'FALSE'}}
-  IMAGE_TAG: ${{ github.ref == 'main' && 'latest' || github.ref }}
+  PUBLISH_IMAGE: ${{ (github.ref == 'main' || github.ref_type == 'tag') && 'TRUE' || 'FALSE'}}
+  IMAGE_TAG: ${{ github.ref == 'main' && 'latest' || github.ref_name }}
   IMAGE_NAME: ghcr.io/${{ github.repository }}/arpav-ppcv-backend
 
 jobs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "30 12 * * *"  # runs everyday at 12h30
 
+env:
+  PUBLISH_IMAGE: ${{ if (github.ref == 'main' || github.ref_type == 'branch') && 'TRUE' || 'FALSE'}}
+  IMAGE_NAME: ghcr.io/${{ github.repository }}/arpav-ppcv-backend:${{ github.ref }}
 
 jobs:
   run-dagger-ci:
@@ -29,11 +32,22 @@ jobs:
         with:
           packages: dagger-io==0.9.8
 
+      - name: login to container registry
+        if: ${{ env.PUBLISH_IMAGE == 'TRUE' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: run dagger
         uses: dagger/dagger-for-github@v5
         with:
           verb: run
-          args: python tests/ci/main.py --with-tests
+          args: |
+             python tests/ci/main.py 
+            --with-tests 
+            ${{ if (env.PUBLISH_IMAGE == 'TRUE' && format('--image-registry {0}', env.IMAGE_NAME)  || ''}}
           version: 0.9.9
 
       # Periodically scan built image for vulnerabilities

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
         uses: dagger/dagger-for-github@v5
         with:
           verb: run
-          args: |
+          args: >-
              python tests/ci/main.py 
             --with-tests 
             ${{ if (env.PUBLISH_IMAGE == 'TRUE' && format('--image-registry {0}', env.IMAGE_NAME)  || ''}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ on:
 env:
   PUBLISH_IMAGE: ${{ (github.ref == 'main' || github.ref_type == 'branch') && 'TRUE' || 'FALSE'}}
   IMAGE_TAG: ${{ github.ref == 'main' && 'latest' || github.ref }}
-  IMAGE_NAME: ghcr.io/${{ github.repository }}/arpav-ppcv-backend:${{ IMAGE_TAG }}
+  IMAGE_NAME: ghcr.io/${{ github.repository }}/arpav-ppcv-backend:${{ env.IMAGE_TAG }}
 
 jobs:
   run-dagger-ci:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
   PUBLISH_IMAGE: ${{ if (github.ref == 'main' || github.ref_type == 'branch') && 'TRUE' || 'FALSE'}}
-  IMAGE_TAG: ${{ if github.ref == 'main' && 'latest' || github.ref }}
+  IMAGE_TAG: ${{ github.ref == 'main' && 'latest' || github.ref }}
   IMAGE_NAME: ghcr.io/${{ github.repository }}/arpav-ppcv-backend:${{ IMAGE_TAG }}
 
 jobs:
@@ -48,7 +48,7 @@ jobs:
           args: >-
             python tests/ci/main.py 
             --with-tests 
-            ${{ if (env.PUBLISH_IMAGE == 'TRUE' && format('--image-registry {0}', env.IMAGE_NAME)  || ''}}
+            ${{ env.PUBLISH_IMAGE == 'TRUE' && format('--image-registry {0}', env.IMAGE_NAME)  || ''}}
           version: 0.9.9
 
       # Periodically scan built image for vulnerabilities

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ on:
 env:
   PUBLISH_IMAGE: ${{ (github.ref == 'main' || github.ref_type == 'branch') && 'TRUE' || 'FALSE'}}
   IMAGE_TAG: ${{ github.ref == 'main' && 'latest' || github.ref }}
-  IMAGE_NAME: ghcr.io/${{ github.repository }}/arpav-ppcv-backend:${{ env.IMAGE_TAG }}
+  IMAGE_NAME: ghcr.io/${{ github.repository }}/arpav-ppcv-backend
 
 jobs:
   run-dagger-ci:
@@ -48,7 +48,7 @@ jobs:
           args: >-
             python tests/ci/main.py 
             --with-tests 
-            ${{ env.PUBLISH_IMAGE == 'TRUE' && format('--image-registry {0}', env.IMAGE_NAME)  || ''}}
+            ${{ env.PUBLISH_IMAGE == 'TRUE' && format('--image-registry {0}:{1}', env.IMAGE_NAME, env.IMAGE_TAG)  || ''}}
           version: 0.9.9
 
       # Periodically scan built image for vulnerabilities

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
         with:
           verb: run
           args: >-
-             python tests/ci/main.py 
+            python tests/ci/main.py 
             --with-tests 
             ${{ if (env.PUBLISH_IMAGE == 'TRUE' && format('--image-registry {0}', env.IMAGE_NAME)  || ''}}
           version: 0.9.9

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,8 @@ on:
 
 env:
   PUBLISH_IMAGE: ${{ if (github.ref == 'main' || github.ref_type == 'branch') && 'TRUE' || 'FALSE'}}
-  IMAGE_NAME: ghcr.io/${{ github.repository }}/arpav-ppcv-backend:${{ github.ref }}
+  IMAGE_TAG: {{ if github.ref == 'main' && 'latest' || github.ref }}
+  IMAGE_NAME: ghcr.io/${{ github.repository }}/arpav-ppcv-backend:${{ IMAGE_TAG }}
 
 jobs:
   run-dagger-ci:
@@ -40,7 +41,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: run dagger
+      - name: run ci
         uses: dagger/dagger-for-github@v5
         with:
           verb: run

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
   PUBLISH_IMAGE: ${{ if (github.ref == 'main' || github.ref_type == 'branch') && 'TRUE' || 'FALSE'}}
-  IMAGE_TAG: {{ if github.ref == 'main' && 'latest' || github.ref }}
+  IMAGE_TAG: ${{ if github.ref == 'main' && 'latest' || github.ref }}
   IMAGE_NAME: ghcr.io/${{ github.repository }}/arpav-ppcv-backend:${{ IMAGE_TAG }}
 
 jobs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
     - cron: "30 12 * * *"  # runs everyday at 12h30
 
 env:
-  PUBLISH_IMAGE: ${{ if (github.ref == 'main' || github.ref_type == 'branch') && 'TRUE' || 'FALSE'}}
+  PUBLISH_IMAGE: ${{ (github.ref == 'main' || github.ref_type == 'branch') && 'TRUE' || 'FALSE'}}
   IMAGE_TAG: ${{ github.ref == 'main' && 'latest' || github.ref }}
   IMAGE_NAME: ghcr.io/${{ github.repository }}/arpav-ppcv-backend:${{ IMAGE_TAG }}
 

--- a/tests/ci/main.py
+++ b/tests/ci/main.py
@@ -147,12 +147,27 @@ async def run_pipeline(
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--with-security-scan", action="store_true")
-    parser.add_argument("--with-tests", action="store_true")
+    parser.add_argument(
+        "--with-security-scan",
+        action="store_true",
+        help=(
+            "Run the trivy security scanner on the built container image in order "
+            "to find known vulnerabilities of level HIGH and CRITICAL. Exits with "
+            "an error if any vulnerabilities are found."
+        )
+    )
+    parser.add_argument(
+        "--with-tests",
+        action="store_true",
+        help=(
+            "Run automated tests on the built container and exit with an error if a "
+            "test fails."
+        )
+    )
     parser.add_argument(
         "--image-registry",
         help=(
-            "Full URL to an image registry where the built container image should be "
+            "Full URI to an image registry where the built container image should be "
             "published, including the image tag. This assumes that logging in to the "
             "registry has already been made (for example by running the "
             "`docker login` command beforehand)."

--- a/tests/ci/main.py
+++ b/tests/ci/main.py
@@ -115,6 +115,7 @@ async def run_pipeline(
         *,
         with_tests: bool,
         with_security_scan: bool,
+        image_registry: str | None = None
 ):
     env_variables = get_env_variables()
     conf = dagger.Config(
@@ -129,22 +130,40 @@ async def run_pipeline(
                 context=src,
                 dockerfile="Dockerfile"
             )
+            .with_label(
+                "org.opencontainers.image.source",
+                "https://github.com/geobeyond/Arpav-PPCV-backend"
+            )
         )
         if with_security_scan:
             await run_security_scan(built_container)
         if with_tests:
             await run_tests(client, built_container, env_variables)
-        print("Done!")
+        if image_registry is not None:
+            await built_container.publish(image_registry)
+
+        print("Done")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--with-security-scan", action="store_true")
     parser.add_argument("--with-tests", action="store_true")
+    parser.add_argument(
+        "--image-registry",
+        help=(
+            "Full URL to an image registry where the built container image should be "
+            "published, including the image tag. This assumes that logging in to the "
+            "registry has already been made (for example by running the "
+            "`docker login` command beforehand)."
+            "Example: ghcr.io/geobeyond/arpav-ppcv-backend:latest"
+        )
+    )
     args = parser.parse_args()
     asyncio.run(
         run_pipeline(
             with_tests=args.with_tests,
-            with_security_scan=args.with_security_scan
+            with_security_scan=args.with_security_scan,
+            image_registry=args.image_registry,
         )
     )


### PR DESCRIPTION
This PR adds automated publishing of the built container image during CI to the github container registry.

Images are published automatically during CI if one of these conditions is met:

- The current worklow is running for the `main` branch (in which case the image is tagged with `latest`)
- The current workflow is running for a git tag

Images are published to `ghcr.io/geobeyond/arpav-ppcv-backend:<latest | tag_name>`

- fixes #3