### PR TITLE
fix docker image publishing not working

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,8 +9,8 @@ on:
     - cron: "30 12 * * *"  # runs everyday at 12h30
 
 env:
-  PUBLISH_IMAGE: ${{ (github.ref == 'main' || github.ref_type == 'tag') && 'TRUE' || 'FALSE'}}
-  IMAGE_TAG: ${{ github.ref == 'main' && 'latest' || github.ref_name }}
+  PUBLISH_IMAGE: ${{ (github.ref_name == 'main' || github.ref_type == 'tag') && 'TRUE' || 'FALSE'}}
+  IMAGE_TAG: ${{ github.ref_name == 'main' && 'latest' || github.ref_name }}
   IMAGE_NAME: ghcr.io/${{ github.repository }}/arpav-ppcv-backend
 
 jobs:


### PR DESCRIPTION
This PR fixes the bug described in #20 which is preventing the CI workflow from publishing built docker images to the registry when running against a commit to `main`.

- fixes #20