### PR TITLE
Add command to download test thredds data

### DIFF
--- a/arpav_ppcv/main.py
+++ b/arpav_ppcv/main.py
@@ -1,0 +1,132 @@
+"""Command-line interface for the project."""
+
+import dataclasses
+import enum
+import itertools
+from pathlib import Path
+
+import requests
+import typer
+
+
+@dataclasses.dataclass
+class ForecastTemporalPeriodMetadata:
+    name: str
+    code: str
+
+
+class ForecastTemporalPeriod(enum.Enum):
+    TW1 = ForecastTemporalPeriodMetadata(name="2021 - 2050", code="tw1")
+    TW2 = ForecastTemporalPeriodMetadata(name="2071 - 2100", code="tw2")
+
+
+@dataclasses.dataclass
+class ForecastSeasonMetadata:
+    name: str
+    code: str
+
+
+class ForecastSeason(enum.Enum):
+    DJF = ForecastSeasonMetadata(name="Winter", code="DJF")
+    MAM = ForecastSeasonMetadata(name="Spring", code="MAM")
+    JJA = ForecastSeasonMetadata(name="Summer", code="JJA")
+    SON = ForecastSeasonMetadata(name="Autumn", code="SON")
+
+
+@dataclasses.dataclass
+class ForecastModelMetadata:
+    name: str
+    code: str
+    thredds_base_path: str
+
+
+@dataclasses.dataclass
+class ForecastScenarioMetadata:
+    name: str
+    code: str
+
+
+class ForecastScenario(enum.Enum):
+    RCP26 = ForecastScenarioMetadata(name="RCP26", code="rcp26")
+    RCP45 = ForecastScenarioMetadata(name="RCP45", code="rcp45")
+    RCP85 = ForecastScenarioMetadata(name="RCP85", code="rcp85")
+
+
+class ForecastAnomalyVariablePathPattern(enum.Enum):
+    TAS_ENSEMBLE = "ensembletwbc/clipped/tas_avg_anom_{period}_{scenario}_{season}_VFVGTAA.nc"
+    TASMIN_ENSEMBLE = "ensembletwbc/clipped/tasmin_avg_anom_{period}_{scenario}_{season}_VFVGTAA.nc"
+    TASMAX_ENSEMBLE = "ensembletwbc/clipped/tasmax_avg_anom_{period}_{scenario}_{season}_VFVGTAA.nc"
+    PR_ENSEMBLE = "ensembletwbc/clipped/pr_avg_percentage_{period}_{scenario}_{season}_VFVGTAA.nc"
+    TR_ENSEMBLE = "ensembletwbc/clipped/ecatran_20_avg_{period}_{scenario}_ls_VFVG.nc"
+    SU30_ENSEMBLE = "ensembletwbc/clipped/ecasuan_30_avg_{period}_{scenario}_ls_VFVG.nc"
+    FD_ENSEMBLE = "ensembletwbc/clipped/ecafdan_0_avg_{period}_{scenario}_ls_VFVG.nc"
+    HWDI_ENSEMBLE = "ensembletwbc/clipped/heat_waves_anom_avg_55_{period}_{scenario}_JJA_VFVGTAA.nc"
+    TAS_ECEARTHCCLM4817 = "taspr5rcm/clipped/tas_EC-EARTH_CCLM4-8-17_{scenario}_seas_{period}{season}_VFVGTAA.nc"
+    TASMIN_ECEARTHCCLM4817 = "taspr5rcm/clipped/tasmin_EC-EARTH_CCLM4-8-17_{scenario}_seas_{period}{season}_VFVGTAA.nc"
+    TASMAX_ECEARTHCCLM4817 = "taspr5rcm/clipped/tasmax_EC-EARTH_CCLM4-8-17_{scenario}_seas_{period}{season}_VFVGTAA.nc"
+    HWDI_ECEARTHCCLM4817 = "indici5rcm/clipped/heat_waves_anom_EC-EARTH_CCLM4-8-17_{scenario}_JJA_55_{period}_VFVGTAA.nc"
+
+
+app = typer.Typer()
+
+
+@app.command()
+def import_anomaly_forecast_datasets(target_dir: Path):
+    download_url_pattern = (
+        "https://thredds.arpa.veneto.it/thredds/fileServer/{path}"
+    )
+    session = requests.Session()
+    seasonal_patterns = []
+    annual_patterns = []
+    for pattern in ForecastAnomalyVariablePathPattern:
+        if all(
+                (
+                        "{season}" in pattern.value,
+                        "{scenario}" in pattern.value,
+                        "{period}" in pattern.value,
+                )
+        ):
+            seasonal_patterns.append(pattern)
+        else:
+            annual_patterns.append(pattern)
+
+    paths = []
+    for seasonal_pattern in seasonal_patterns:
+        combinator = itertools.product(
+            ForecastScenario,
+            ForecastTemporalPeriod,
+            ForecastSeason,
+        )
+        for scenario, period, season in combinator:
+            path = seasonal_pattern.value.format(
+                scenario=scenario.value.code,
+                period=period.value.code,
+                season=season.value.code
+            )
+            paths.append((seasonal_pattern, path))
+    for annual_pattern in annual_patterns:
+        combinator = itertools.product(
+            ForecastScenario,
+            ForecastTemporalPeriod,
+        )
+        for scenario, period in combinator:
+            path = annual_pattern.value.format(
+                scenario=scenario.value.code,
+                period=period.value.code,
+            )
+            paths.append((annual_pattern, path))
+    for pattern, path in paths:
+        print(f"Processing {pattern.name!r}...")
+        output_path = target_dir / path
+        if not output_path.exists():
+            print(f"Saving {output_path!r}...")
+            download_url = download_url_pattern.format(path=path)
+            response = session.get(download_url, stream=True)
+            response.raise_for_status()
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            with output_path.open("wb") as fh:
+                for chunk in response.iter_content():
+                    fh.write(chunk)
+        else:
+            print(f"path already exists ({output_path!r}) - skipping")
+    print("Done!")

--- a/arpav_ppcv/main.py
+++ b/arpav_ppcv/main.py
@@ -1,6 +1,7 @@
 """Command-line interface for the project."""
 
 import enum
+import logging
 from typing import (
     Annotated,
     Optional
@@ -18,6 +19,19 @@ class KnownCatalogIdentifier(enum.Enum):
     THIRTY_YEAR_ANOMALY_5_MODEL_AVERAGE = "30y-anomaly-ensemble"
     THIRTY_YEAR_ANOMALY_TEMPERATURE_PRECIPITATION = "30y-anomaly-tas-pr"
     THIRTY_YEAR_ANOMALY_CLIMATIC_INDICES = "30y-anomaly-climate-idx"
+    YEARLY_ANOMALY_5_MODEL_AVERAGE_TAS_PR = "anomaly-ensemble-tas-pr"
+    YEARLY_ABSOLUTE_5_MODEL_AVERAGE = "yearly-ensemble-absolute"
+    YEARLY_ANOMALY_EC_EARTH_CCLM4_8_17 = "anomaly-ec-earth-cclm4-8-17"
+    YEARLY_ABSOLUTE_EC_EARTH_CCLM4_8_17 = "yearly-ec-earth-cclm4-8-17-absolute"
+    YEARLY_ANOMALY_EC_EARTH_RACM022E = "anomaly-ec-earth-racm022e"
+    YEARLY_ABSOLUTE_EC_EARTH_RACM022E = "yearly-ec-earth-racm022e-absolute"
+    YEARLY_ANOMALY_EC_EARTH_RCA4 = "anomaly-ec-earth-rca4"
+    YEARLY_ABSOLUTE_EC_EARTH_RCA4 = "yearly-ec-earth-rca4-absolute"
+    YEARLY_ANOMALY_HADGEM2_ES_RACMO22E = "anomaly-hadgem2-es-racmo22e"
+    YEARLY_ABSOLUTE_HADGEM2_ES_RACMO22E = "yearly-hadgem2-es-racmo22e-absolute"
+    YEARLY_ANOMALY_MPI_ESM_LR_REMO2009 = "anomaly-mpi-esm-lr-remo2009"
+    YEARLY_ABSOLUTE_MPI_ESM_LR_REMO2009 = "yearly-mpi-esm-lr-remo2009-absolute"
+
 
 
 def _get_catalog_url(catalog_identifier: KnownCatalogIdentifier) -> str:
@@ -28,6 +42,30 @@ def _get_catalog_url(catalog_identifier: KnownCatalogIdentifier) -> str:
             "https://thredds.arpa.veneto.it/thredds/catalog/taspr5rcm/clipped"),
         KnownCatalogIdentifier.THIRTY_YEAR_ANOMALY_CLIMATIC_INDICES: (
             "https://thredds.arpa.veneto.it/thredds/catalog/indici5rcm/clipped"),
+        KnownCatalogIdentifier.YEARLY_ANOMALY_5_MODEL_AVERAGE_TAS_PR: (
+            "https://thredds.arpa.veneto.it/thredds/catalog/ens5ym/clipped"),
+        KnownCatalogIdentifier.YEARLY_ABSOLUTE_5_MODEL_AVERAGE: (
+            "https://thredds.arpa.veneto.it/thredds/catalog/ensymbc/clipped"),
+        KnownCatalogIdentifier.YEARLY_ANOMALY_EC_EARTH_CCLM4_8_17: (
+            "https://thredds.arpa.veneto.it/thredds/catalog/EC-EARTH_CCLM4-8-17ym/clipped"),
+        KnownCatalogIdentifier.YEARLY_ABSOLUTE_EC_EARTH_CCLM4_8_17: (
+            "https://thredds.arpa.veneto.it/thredds/catalog/EC-EARTH_CCLM4-8-17ymbc/clipped"),
+        KnownCatalogIdentifier.YEARLY_ANOMALY_EC_EARTH_RACM022E: (
+            "https://thredds.arpa.veneto.it/thredds/catalog/EC-EARTH_RACMO22Eym/clipped"),
+        KnownCatalogIdentifier.YEARLY_ABSOLUTE_EC_EARTH_RACM022E: (
+            "https://thredds.arpa.veneto.it/thredds/catalog/EC-EARTH_RACMO22Eymbc/clipped"),
+        KnownCatalogIdentifier.YEARLY_ANOMALY_EC_EARTH_RCA4: (
+            "https://thredds.arpa.veneto.it/thredds/catalog/EC-EARTH_RCA4ym/clipped"),
+        KnownCatalogIdentifier.YEARLY_ABSOLUTE_EC_EARTH_RCA4: (
+            "https://thredds.arpa.veneto.it/thredds/catalog/EC-EARTH_RCA4ymbc/clipped"),
+        KnownCatalogIdentifier.YEARLY_ANOMALY_HADGEM2_ES_RACMO22E: (
+            "https://thredds.arpa.veneto.it/thredds/catalog/HadGEM2-ES_RACMO22Eym/clipped"),
+        KnownCatalogIdentifier.YEARLY_ABSOLUTE_HADGEM2_ES_RACMO22E: (
+            "https://thredds.arpa.veneto.it/thredds/catalog/HadGEM2-ES_RACMO22Eymbc/clipped"),
+        KnownCatalogIdentifier.YEARLY_ANOMALY_MPI_ESM_LR_REMO2009: (
+            "https://thredds.arpa.veneto.it/thredds/catalog/MPI-ESM-LR_REMO2009ym/clipped"),
+        KnownCatalogIdentifier.YEARLY_ABSOLUTE_MPI_ESM_LR_REMO2009: (
+            "https://thredds.arpa.veneto.it/thredds/catalog/MPI-ESM-LR_REMO2009ymbc/clipped"),
     }[catalog_identifier]
 
 
@@ -49,8 +87,27 @@ def import_thredds_datasets(
         wildcard_filter: Annotated[
             str,
             typer.Option(help="Wildcard filter for selecting only relevant datasets")
-        ] = "*"
+        ] = "*",
+        force_download: Annotated[
+            Optional[bool],
+            typer.Option(
+                help=(
+                        "Whether to re-download a dataset even if it is already "
+                        "present locally."
+                )
+            )
+        ] = False,
+        verbose: Annotated[
+            Optional[bool],
+            typer.Option(
+                help=(
+                        "Verbose output"
+                )
+            )
+        ] = False
 ):
+    if verbose:
+        logging.basicConfig(level=logging.INFO)
     catalog_url = _get_catalog_url(catalog)
     client = httpx.Client()
     print(f"Parsing catalog contents...")
@@ -62,5 +119,6 @@ def import_thredds_datasets(
             crawler.download_datasets,
             output_base_dir,
             contents,
-            wildcard_filter
+            wildcard_filter,
+            force_download,
         )

--- a/arpav_ppcv/main.py
+++ b/arpav_ppcv/main.py
@@ -1,386 +1,66 @@
 """Command-line interface for the project."""
 
-import dataclasses
-import datetime as dt
 import enum
-import itertools
-import typing
+from typing import (
+    Annotated,
+    Optional
+)
 from pathlib import Path
-from xml.etree import ElementTree as et
 
-import requests
+import anyio
+import httpx
 import typer
 
-
-@dataclasses.dataclass
-class ForecastTemporalPeriodMetadata:
-    name: str
-    code: str
+from .thredds import crawler
 
 
-class ForecastTemporalPeriod(enum.Enum):
-    TW1 = ForecastTemporalPeriodMetadata(name="2021 - 2050", code="tw1")
-    TW2 = ForecastTemporalPeriodMetadata(name="2071 - 2100", code="tw2")
+class KnownCatalogIdentifier(enum.Enum):
+    THIRTY_YEAR_ANOMALY_5_MODEL_AVERAGE = "30y-anomaly-ensemble"
+    THIRTY_YEAR_ANOMALY_TEMPERATURE_PRECIPITATION = "30y-anomaly-tas-pr"
+    THIRTY_YEAR_ANOMALY_CLIMATIC_INDICES = "30y-anomaly-climate-idx"
 
 
-@dataclasses.dataclass
-class ForecastSeasonMetadata:
-    name: str
-    code: str
-
-
-class ForecastSeason(enum.Enum):
-    DJF = ForecastSeasonMetadata(name="Winter", code="DJF")
-    MAM = ForecastSeasonMetadata(name="Spring", code="MAM")
-    JJA = ForecastSeasonMetadata(name="Summer", code="JJA")
-    SON = ForecastSeasonMetadata(name="Autumn", code="SON")
-
-
-@dataclasses.dataclass
-class ForecastModelMetadata:
-    name: str
-    code: str
-    thredds_base_path: str
-
-
-@dataclasses.dataclass
-class ForecastScenarioMetadata:
-    name: str
-    code: str
-
-
-class ForecastScenario(enum.Enum):
-    RCP26 = ForecastScenarioMetadata(name="RCP26", code="rcp26")
-    RCP45 = ForecastScenarioMetadata(name="RCP45", code="rcp45")
-    RCP85 = ForecastScenarioMetadata(name="RCP85", code="rcp85")
-
-
-class ForecastAnomalyVariablePathPattern(enum.Enum):
-    TAS_ENSEMBLE = "ensembletwbc/clipped/tas_avg_anom_{period}_{scenario}_{season}_VFVGTAA.nc"
-    TASMIN_ENSEMBLE = "ensembletwbc/clipped/tasmin_avg_anom_{period}_{scenario}_{season}_VFVGTAA.nc"
-    TASMAX_ENSEMBLE = "ensembletwbc/clipped/tasmax_avg_anom_{period}_{scenario}_{season}_VFVGTAA.nc"
-    PR_ENSEMBLE = "ensembletwbc/clipped/pr_avg_percentage_{period}_{scenario}_{season}_VFVGTAA.nc"
-    TR_ENSEMBLE = "ensembletwbc/clipped/ecatran_20_avg_{period}_{scenario}_ls_VFVG.nc"
-    SU30_ENSEMBLE = "ensembletwbc/clipped/ecasuan_30_avg_{period}_{scenario}_ls_VFVG.nc"
-    FD_ENSEMBLE = "ensembletwbc/clipped/ecafdan_0_avg_{period}_{scenario}_ls_VFVG.nc"
-    HWDI_ENSEMBLE = "ensembletwbc/clipped/heat_waves_anom_avg_55_{period}_{scenario}_JJA_VFVGTAA.nc"
-    TAS_ECEARTHCCLM4817 = "taspr5rcm/clipped/tas_EC-EARTH_CCLM4-8-17_{scenario}_seas_{period}{season}_VFVGTAA.nc"
-    TASMIN_ECEARTHCCLM4817 = "taspr5rcm/clipped/tasmin_EC-EARTH_CCLM4-8-17_{scenario}_seas_{period}{season}_VFVGTAA.nc"
-    TASMAX_ECEARTHCCLM4817 = "taspr5rcm/clipped/tasmax_EC-EARTH_CCLM4-8-17_{scenario}_seas_{period}{season}_VFVGTAA.nc"
-    HWDI_ECEARTHCCLM4817 = "indici5rcm/clipped/heat_waves_anom_EC-EARTH_CCLM4-8-17_{scenario}_JJA_55_{period}_VFVGTAA.nc"
+def _get_catalog_url(catalog_identifier: KnownCatalogIdentifier) -> str:
+    return {
+        KnownCatalogIdentifier.THIRTY_YEAR_ANOMALY_5_MODEL_AVERAGE: (
+            "https://thredds.arpa.veneto.it/thredds/catalog/ensembletwbc/clipped"),
+        KnownCatalogIdentifier.THIRTY_YEAR_ANOMALY_TEMPERATURE_PRECIPITATION: (
+            "https://thredds.arpa.veneto.it/thredds/catalog/taspr5rcm/clipped"),
+        KnownCatalogIdentifier.THIRTY_YEAR_ANOMALY_CLIMATIC_INDICES: (
+            "https://thredds.arpa.veneto.it/thredds/catalog/indici5rcm/clipped"),
+    }[catalog_identifier]
 
 
 app = typer.Typer()
 
-
 @app.command()
-def import_anomaly_forecast_datasets(target_dir: Path):
-    download_url_pattern = (
-        "https://thredds.arpa.veneto.it/thredds/fileServer/{path}"
-    )
-    session = requests.Session()
-    seasonal_patterns = []
-    annual_patterns = []
-    for pattern in ForecastAnomalyVariablePathPattern:
-        if all(
-                (
-                        "{season}" in pattern.value,
-                        "{scenario}" in pattern.value,
-                        "{period}" in pattern.value,
+def import_thredds_datasets(
+        catalog: Annotated[KnownCatalogIdentifier, typer.Argument(...)],
+        output_base_dir: Annotated[
+            Optional[Path],
+            typer.Option(
+                help=(
+                        "Where datasets should be downloaded to. If this parameter is "
+                        "not provided, only the total number of found datasets "
+                        "is shown."
                 )
-        ):
-            seasonal_patterns.append(pattern)
-        else:
-            annual_patterns.append(pattern)
-
-    paths = []
-    for seasonal_pattern in seasonal_patterns:
-        combinator = itertools.product(
-            ForecastScenario,
-            ForecastTemporalPeriod,
-            ForecastSeason,
-        )
-        for scenario, period, season in combinator:
-            path = seasonal_pattern.value.format(
-                scenario=scenario.value.code,
-                period=period.value.code,
-                season=season.value.code
             )
-            paths.append((seasonal_pattern, path))
-    for annual_pattern in annual_patterns:
-        combinator = itertools.product(
-            ForecastScenario,
-            ForecastTemporalPeriod,
+        ] = None,
+        wildcard_filter: Annotated[
+            str,
+            typer.Option(help="Wildcard filter for selecting only relevant datasets")
+        ] = "*"
+):
+    catalog_url = _get_catalog_url(catalog)
+    client = httpx.Client()
+    print(f"Parsing catalog contents...")
+    contents = crawler.discover_catalog_contents(catalog_url, client)
+    print(f"Found {len(contents.get_public_datasets(wildcard_filter))} datasets")
+    if output_base_dir is not None:
+        print("Downloading datasets...")
+        anyio.run(
+            crawler.download_datasets,
+            output_base_dir,
+            contents,
+            wildcard_filter
         )
-        for scenario, period in combinator:
-            path = annual_pattern.value.format(
-                scenario=scenario.value.code,
-                period=period.value.code,
-            )
-            paths.append((annual_pattern, path))
-    for pattern, path in paths:
-        print(f"Processing {pattern.name!r}...")
-        output_path = target_dir / path
-        if not output_path.exists():
-            print(f"Saving {output_path!r}...")
-            download_url = download_url_pattern.format(path=path)
-            response = session.get(download_url, stream=True)
-            response.raise_for_status()
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            with output_path.open("wb") as fh:
-                for chunk in response.iter_content():
-                    fh.write(chunk)
-        else:
-            print(f"path already exists ({output_path!r}) - skipping")
-    print("Done!")
-
-#
-#
-# @dataclasses.dataclass
-# class ThreddsWildcardFilterSelector:
-#     type_: typing.Literal["wildcard", "regexp"]
-#     value: str
-#     applies_to_datasets: bool = True
-#     applies_to_collections: bool = False
-#
-#
-# @dataclasses.dataclass
-# class ThreddsDatasetScanFilter:
-#     includes: list[ThreddsWildcardFilterSelector] = dataclasses.field(
-#         default_factory=list)
-#     excludes: list[ThreddsWildcardFilterSelector] = dataclasses.field(
-#         default_factory=list)
-
-
-@dataclasses.dataclass
-class ThreddsClientService:
-    name: str
-    service_type: str
-    base: str
-
-
-@dataclasses.dataclass
-class ThreddsClientPublicDataset:
-    name: str
-    id: str
-    url_path: str
-
-
-@dataclasses.dataclass
-class ThreddsClientCatalogRef:
-    title: str
-    id: str
-    name: str
-    href: str
-
-
-@dataclasses.dataclass
-class ThreddsClientDataset:
-    name: str
-    properties: dict[str, str]
-    metadata: dict[str, str]
-    public_datasets: list[ThreddsClientPublicDataset]
-    catalog_refs: list[ThreddsClientCatalogRef]
-
-
-@dataclasses.dataclass
-class ThreddsClientCatalog:
-    url: str
-    services: dict[str, ThreddsClientService]
-    dataset: ThreddsClientDataset
-
-
-_NAMESPACES: typing.Final = {
-    "thredds": "http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0",
-    "xlink": "http://www.w3.org/1999/xlink",
-}
-
-
-def discover_catalog_contents(
-        catalog_host: str,
-        catalog_ref: str,
-        http_client: requests.Session,
-        use_https: bool = True,
-) -> ThreddsClientCatalog:
-    """
-    host: thredds.arpa.veneto.it
-    catalog_ref: /thredds/catalog/ensembletwbc/clipped
-    """
-
-
-    url = _build_catalog_url(catalog_host, catalog_ref, use_https)
-    response = http_client.get(url)
-    response.raise_for_status()
-    raw_catalog_description = response.content
-    parsed_services, parsed_dataset = _parse_catalog_client_description(
-        raw_catalog_description)
-    return ThreddsClientCatalog(
-        url=url,
-        services={service.service_type: service for service in parsed_services},
-        dataset=parsed_dataset
-    )
-
-
-def build_download_urls(
-        catalog_host: str,
-        catalog_contents: ThreddsClientCatalog,
-        use_https: bool = True
-) -> dict[str, str]:
-    urls = {}
-    url_pattern = "{scheme}://{host}/{service_base}/{dataset_path}"
-    for dataset in catalog_contents.dataset.public_datasets:
-        urls[dataset.id] = url_pattern.format(
-            scheme="https" if use_https else "http",
-            host=catalog_host,
-            service_base=catalog_contents.services["HTTPServer"].base.strip("/"),
-            dataset_path=dataset.url_path.strip("/")
-        )
-    return urls
-
-
-
-def _build_catalog_url(host: str, catalog_ref: str, use_https: bool = True) -> str:
-    return "{scheme}://{host}/{path}/catalog.xml".format(
-        scheme="https" if use_https else "http",
-        host=host,
-        path=catalog_ref.strip("/")
-    )
-
-
-def _parse_catalog_client_description(
-        catalog_description: bytes
-) -> tuple[list[ThreddsClientService], ThreddsClientDataset]:
-    root_element = et.fromstring(catalog_description)
-    service_qn = et.QName(_NAMESPACES["thredds"], "service")
-    dataset_qn = et.QName(_NAMESPACES["thredds"], "dataset")
-    services = []
-    for service_element in root_element.findall(f"./{service_qn}/"):
-        service = _parse_service_element(service_element)
-        services.append(service)
-    dataset = _parse_dataset_element(
-        root_element.findall(f"./{dataset_qn}")[0])
-    return services, dataset
-
-
-def _parse_service_element(service_el: et.Element) -> ThreddsClientService:
-    return ThreddsClientService(
-        name=service_el.get("name", default=""),
-        service_type=service_el.get("serviceType", default=""),
-        base=service_el.get("base", default="")
-    )
-
-
-def _parse_dataset_element(dataset_el: et.Element) -> ThreddsClientDataset:
-    prop_qname = et.QName(_NAMESPACES["thredds"], "property")
-    meta_qname = et.QName(_NAMESPACES["thredds"], "metadata")
-    ds_qname = et.QName(_NAMESPACES["thredds"], "dataset")
-    cat_ref_qname = et.QName(_NAMESPACES["thredds"], "catalogRef")
-    properties = {}
-    metadata = {}
-    public_datasets = []
-    catalog_references = []
-    for element in dataset_el.findall("./"):
-        match element.tag:
-            case prop_qname.text:
-                properties[element.get("name")] = element.get("value")
-            case meta_qname.text:
-                for metadata_element in element.findall("./"):
-                    key = metadata_element.tag.replace(
-                        f"{{{_NAMESPACES['thredds']}}}", "")
-                    metadata[key] = metadata_element.text
-            case ds_qname.text:
-                public_ds = ThreddsClientPublicDataset(
-                    name=element.get("name", ""),
-                    id=element.get("ID", ""),
-                    url_path=element.get("urlPath", ""),
-                )
-                public_datasets.append(public_ds)
-            case cat_ref_qname.text:
-                title_qname = et.QName(_NAMESPACES["xlink"], "title")
-                href_qname = et.QName(_NAMESPACES["xlink"], "href")
-                catalog_ref = ThreddsClientCatalogRef(
-                    title=element.get(title_qname.text, ""),
-                    id=element.get("ID", ""),
-                    name=element.get("name", ""),
-                    href=element.get(href_qname.text, ""),
-                )
-                catalog_references.append(catalog_ref)
-    return ThreddsClientDataset(
-        name=dataset_el.get("name", default=""),
-        properties=properties,
-        metadata=metadata,
-        public_datasets=public_datasets,
-        catalog_refs=catalog_references,
-    )
-#
-#
-# @dataclasses.dataclass
-# class ThreddsDatasetScan:
-#     """DatasetScan defines a single mapping between a URL base path and a directory.
-#
-#     DatasetScan configuration enables TDS to discover and serve some or all of the
-#     datasets found in the mapped directory. It generates nested catalogs by scanning
-#     the directory named in the `location` property and creating a `Dataset` for each
-#     file found and a `CatalogRef` for each subdirectory
-#
-#     In the THREDDS configuration, a DatasetScan element can be used wherever a Dataset
-#     is expected.
-#
-#     In the client view, DatasetScan elements get converted to CatalogRef elements
-#
-#     """
-#
-#     name: str
-#     id: str
-#     path: str  # is used to create the URL for files and catalogs, must be globally unique and must not contain leading or trailing slashes
-#     location: str  # must be an absolute path to a directory
-#     filter_: ThreddsDatasetScanFilter | None = None
-#
-#     def build_client_catalog_url(self):
-#         ...
-#
-#     def build_download_url(self) -> str:
-#         ...
-#
-#
-# ensemble_5rcm_bc = ThreddsDatasetScan(
-#     name="ENSEMBLE 5rcm BC",
-#     id="ensembletwbc",
-#     path="",
-#     location="",
-#     filter_=ThreddsDatasetScanFilter(
-#         excludes=[
-#             ThreddsWildcardFilterSelector(type_="wildcard", value="heat_waves_avg_*.nc"),
-#             ThreddsWildcardFilterSelector(type_="wildcard", value="heat_waves_*DJF.nc"),
-#             ThreddsWildcardFilterSelector(type_="wildcard", value="ecasuan_25_*.nc"),
-#             ThreddsWildcardFilterSelector(
-#                 type_="wildcard", value="ts",
-#                 applies_to_datasets=False,
-#                 applies_to_collections=True,
-#             ),
-#             ThreddsWildcardFilterSelector(
-#                 type_="wildcard", value="thralert",
-#                 applies_to_datasets=False,
-#                 applies_to_collections=True,
-#             ),
-#             ThreddsWildcardFilterSelector(
-#                 type_="w_null", value="thralert",
-#                 applies_to_datasets=False,
-#                 applies_to_collections=True,
-#             ),
-#         ]
-#     )
-# )
-#
-#
-# @dataclasses.dataclass
-# class AnomalyModelMetadata:
-#     name: str
-#     id: str
-#     path: Path
-#     location: str
-#
-#
-# @app.command()
-# def get_anomaly_data(target_dir: Path):
-#     ...

--- a/arpav_ppcv/main.py
+++ b/arpav_ppcv/main.py
@@ -23,15 +23,14 @@ class KnownCatalogIdentifier(enum.Enum):
     YEARLY_ABSOLUTE_5_MODEL_AVERAGE = "yearly-ensemble-absolute"
     YEARLY_ANOMALY_EC_EARTH_CCLM4_8_17 = "anomaly-ec-earth-cclm4-8-17"
     YEARLY_ABSOLUTE_EC_EARTH_CCLM4_8_17 = "yearly-ec-earth-cclm4-8-17-absolute"
-    YEARLY_ANOMALY_EC_EARTH_RACM022E = "anomaly-ec-earth-racm022e"
-    YEARLY_ABSOLUTE_EC_EARTH_RACM022E = "yearly-ec-earth-racm022e-absolute"
+    YEARLY_ANOMALY_EC_EARTH_RACM022E = "anomaly-ec-earth-racm022e"  # noqa
+    YEARLY_ABSOLUTE_EC_EARTH_RACM022E = "yearly-ec-earth-racm022e-absolute"  # noqa
     YEARLY_ANOMALY_EC_EARTH_RCA4 = "anomaly-ec-earth-rca4"
     YEARLY_ABSOLUTE_EC_EARTH_RCA4 = "yearly-ec-earth-rca4-absolute"
-    YEARLY_ANOMALY_HADGEM2_ES_RACMO22E = "anomaly-hadgem2-es-racmo22e"
-    YEARLY_ABSOLUTE_HADGEM2_ES_RACMO22E = "yearly-hadgem2-es-racmo22e-absolute"
+    YEARLY_ANOMALY_HADGEM2_ES_RACMO22E = "anomaly-hadgem2-es-racmo22e"  # noqa
+    YEARLY_ABSOLUTE_HADGEM2_ES_RACMO22E = "yearly-hadgem2-es-racmo22e-absolute"  # noqa
     YEARLY_ANOMALY_MPI_ESM_LR_REMO2009 = "anomaly-mpi-esm-lr-remo2009"
     YEARLY_ABSOLUTE_MPI_ESM_LR_REMO2009 = "yearly-mpi-esm-lr-remo2009-absolute"
-
 
 
 def _get_catalog_url(catalog_identifier: KnownCatalogIdentifier) -> str:
@@ -70,6 +69,7 @@ def _get_catalog_url(catalog_identifier: KnownCatalogIdentifier) -> str:
 
 
 app = typer.Typer()
+
 
 @app.command()
 def import_thredds_datasets(
@@ -122,7 +122,7 @@ def import_thredds_datasets(
         if output_base_dir is not None:
             print("Downloading datasets...")
             anyio.run(
-                crawler.download_datasets,
+                crawler.download_datasets,  # noqa
                 output_base_dir,
                 contents,
                 wildcard_filter,

--- a/arpav_ppcv/thredds/crawler.py
+++ b/arpav_ppcv/thredds/crawler.py
@@ -1,0 +1,163 @@
+import logging
+import typing
+import urllib.parse
+from itertools import islice
+from pathlib import Path
+from xml.etree import ElementTree as et
+
+import anyio
+import httpx
+
+from . import models
+
+logger = logging.getLogger(__name__)
+
+
+_NAMESPACES: typing.Final = {
+    "thredds": "http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0",
+    "xlink": "http://www.w3.org/1999/xlink",
+}
+
+
+def discover_catalog_contents(
+        catalog_reference_url: str,
+        http_client: httpx.Client,
+) -> models.ThreddsClientCatalog:
+    """
+    catalog_reference_url:
+        https://thredds.arpa.veneto.it/thredds/catalog/ensembletwbc/clipped
+    """
+
+    response = http_client.get(catalog_reference_url)
+    response.raise_for_status()
+    raw_catalog_description = response.content
+    parsed_services, parsed_dataset = _parse_catalog_client_description(
+        raw_catalog_description)
+    return models.ThreddsClientCatalog(
+        url=urllib.parse.urlparse(catalog_reference_url),
+        services={service.service_type: service for service in parsed_services},
+        dataset=parsed_dataset
+    )
+
+
+async def download_datasets(
+        output_base_directory: Path,
+        catalog_contents: models.ThreddsClientCatalog,
+        dataset_wildcard_filter: str
+) -> None:
+    client = httpx.AsyncClient()
+    relevant_datasets = catalog_contents.get_public_datasets(
+        dataset_wildcard_filter)
+    for batch in _batched(relevant_datasets.values(), 10):
+        logger.info(f"processing new batch")
+        async with anyio.create_task_group() as tg:
+            for public_dataset in batch:
+                logger.info(f"processing dataset {public_dataset.id!r}...")
+                tg.start_soon(
+                    download_individual_dataset,
+                    public_dataset.id,
+                    catalog_contents,
+                    output_base_directory,
+                    client
+                )
+
+
+async def download_individual_dataset(
+        dataset_id: str,
+        catalog_contents: models.ThreddsClientCatalog,
+        output_base_directory: Path,
+        http_client: httpx.AsyncClient
+) -> None:
+    url = catalog_contents.build_dataset_download_url(dataset_id)
+    async with http_client.stream("GET", url) as response:
+        response.raise_for_status()
+        output_path = output_base_directory / dataset_id
+        output_dir = output_path.parent
+        output_dir.mkdir(parents=True, exist_ok=True)
+        with output_path.open("wb") as fh:
+            async for chunk in response.aiter_bytes():
+                fh.write(chunk)
+
+
+def _parse_catalog_client_description(
+        catalog_description: bytes
+) -> tuple[list[models.ThreddsClientService], models.ThreddsClientDataset]:
+    root_element = et.fromstring(catalog_description)
+    service_qn = et.QName(_NAMESPACES["thredds"], "service")
+    dataset_qn = et.QName(_NAMESPACES["thredds"], "dataset")
+    services = []
+    for service_element in root_element.findall(f"./{service_qn}/"):
+        service = _parse_service_element(service_element)
+        services.append(service)
+    dataset = _parse_dataset_element(
+        root_element.findall(f"./{dataset_qn}")[0])
+    return services, dataset
+
+
+def _parse_service_element(service_el: et.Element) -> models.ThreddsClientService:
+    return models.ThreddsClientService(
+        name=service_el.get("name", default=""),
+        service_type=service_el.get("serviceType", default=""),
+        base=service_el.get("base", default="")
+    )
+
+
+def _parse_dataset_element(dataset_el: et.Element) -> models.ThreddsClientDataset:
+    prop_qname = et.QName(_NAMESPACES["thredds"], "property")
+    meta_qname = et.QName(_NAMESPACES["thredds"], "metadata")
+    ds_qname = et.QName(_NAMESPACES["thredds"], "dataset")
+    cat_ref_qname = et.QName(_NAMESPACES["thredds"], "catalogRef")
+    properties = {}
+    metadata = {}
+    public_datasets = {}
+    catalog_references = {}
+    for element in dataset_el.findall("./"):
+        match element.tag:
+            case prop_qname.text:
+                properties[element.get("name")] = element.get("value")
+            case meta_qname.text:
+                for metadata_element in element.findall("./"):
+                    key = metadata_element.tag.replace(
+                        f"{{{_NAMESPACES['thredds']}}}", "")
+                    metadata[key] = metadata_element.text
+            case ds_qname.text:
+                public_ds = models.ThreddsClientPublicDataset(
+                    name=element.get("name", ""),
+                    id=element.get("ID", ""),
+                    url_path=element.get("urlPath", ""),
+                )
+                public_datasets[public_ds.id] = public_ds
+            case cat_ref_qname.text:
+                title_qname = et.QName(_NAMESPACES["xlink"], "title")
+                href_qname = et.QName(_NAMESPACES["xlink"], "href")
+                catalog_ref = models.ThreddsClientCatalogRef(
+                    title=element.get(title_qname.text, ""),
+                    id=element.get("ID", ""),
+                    name=element.get("name", ""),
+                    href=element.get(href_qname.text, ""),
+                )
+                catalog_references[catalog_ref.id] = catalog_ref
+    return models.ThreddsClientDataset(
+        name=dataset_el.get("name", default=""),
+        properties=properties,
+        metadata=metadata,
+        public_datasets=public_datasets,
+        catalog_refs=catalog_references,
+    )
+
+
+def _batched(iterable, n):
+    """Custom implementation of `itertools.batched()`.
+
+    This is a custom implementation of `itertools.batched()`, which is only availble
+    on Python 3.12+. This is copied verbatim from the python docs at:
+
+    https://docs.python.org/3/library/itertools.html#itertools.batched
+
+    """
+    # batched('ABCDEFG', 3) --> ABC DEF G
+    if n < 1:
+        raise ValueError('n must be at least one')
+    it = iter(iterable)
+    while batch := tuple(islice(it, n)):
+        yield batch

--- a/arpav_ppcv/thredds/models.py
+++ b/arpav_ppcv/thredds/models.py
@@ -1,0 +1,102 @@
+import dataclasses
+import enum
+import fnmatch
+import urllib.parse
+
+
+@dataclasses.dataclass
+class ForecastTemporalPeriodMetadata:
+    name: str
+    code: str
+
+
+class ForecastTemporalPeriod(enum.Enum):
+    TW1 = ForecastTemporalPeriodMetadata(name="2021 - 2050", code="tw1")
+    TW2 = ForecastTemporalPeriodMetadata(name="2071 - 2100", code="tw2")
+
+
+@dataclasses.dataclass
+class ForecastSeasonMetadata:
+    name: str
+    code: str
+
+
+class ForecastSeason(enum.Enum):
+    DJF = ForecastSeasonMetadata(name="Winter", code="DJF")
+    MAM = ForecastSeasonMetadata(name="Spring", code="MAM")
+    JJA = ForecastSeasonMetadata(name="Summer", code="JJA")
+    SON = ForecastSeasonMetadata(name="Autumn", code="SON")
+
+
+@dataclasses.dataclass
+class ForecastScenarioMetadata:
+    name: str
+    code: str
+
+
+class ForecastScenario(enum.Enum):
+    RCP26 = ForecastScenarioMetadata(name="RCP26", code="rcp26")
+    RCP45 = ForecastScenarioMetadata(name="RCP45", code="rcp45")
+    RCP85 = ForecastScenarioMetadata(name="RCP85", code="rcp85")
+
+
+class AveragingPeriod(enum.Enum):
+    YEAR = "year"
+    THIRTY_YEAR = "thirty-year"
+
+
+
+@dataclasses.dataclass
+class ThreddsClientService:
+    name: str
+    service_type: str
+    base: str
+
+
+@dataclasses.dataclass
+class ThreddsClientPublicDataset:
+    name: str
+    id: str
+    url_path: str
+
+
+@dataclasses.dataclass
+class ThreddsClientCatalogRef:
+    title: str
+    id: str
+    name: str
+    href: str
+
+
+@dataclasses.dataclass
+class ThreddsClientDataset:
+    name: str
+    properties: dict[str, str]
+    metadata: dict[str, str]
+    public_datasets: dict[str, ThreddsClientPublicDataset]
+    catalog_refs: dict[str, ThreddsClientCatalogRef]
+
+
+@dataclasses.dataclass
+class ThreddsClientCatalog:
+    url: urllib.parse.ParseResult
+    services: dict[str, ThreddsClientService]
+    dataset: ThreddsClientDataset
+
+    def build_dataset_download_url(self, dataset_id: str) -> str:
+        dataset = self.dataset.public_datasets[dataset_id]
+        url_pattern = "{scheme}://{host}/{service_base}/{dataset_path}"
+        return url_pattern.format(
+            scheme=self.url.scheme,
+            host=self.url.netloc,
+            service_base=self.services["HTTPServer"].base.strip("/"),
+            dataset_path=dataset.url_path.strip("/")
+        )
+
+    def get_public_datasets(
+            self,
+            wildcard_pattern: str = "*"
+    ) -> dict[str, ThreddsClientPublicDataset]:
+        relevant_ids = fnmatch.filter(
+            self.dataset.public_datasets.keys(), wildcard_pattern)
+        return {id_: self.dataset.public_datasets[id_] for id_ in relevant_ids}

--- a/docker/compose.dev.yaml
+++ b/docker/compose.dev.yaml
@@ -53,20 +53,23 @@ services:
       TDS_HOST: "http://localhost:8081"
     volumes:
       - type: bind
-        source: $PWD/thredds/content-root/catalog.xml
+        source: $PWD/docker/thredds/content-root/catalog.xml
         target: /usr/local/tomcat/content/thredds/catalog.xml
       - type: bind
-        source: $PWD/thredds/content-root/catalog_rcm.xml
+        source: $PWD/docker/thredds/content-root/catalog_rcm.xml
         target: /usr/local/tomcat/content/thredds/catalog_rcm.xml
       - type: bind
-        source: $PWD/thredds/content-root/threddsConfig.xml
+        source: $PWD/docker/thredds/content-root/threddsConfig.xml
         target: /usr/local/tomcat/content/thredds/threddsConfig.xml
       - type: bind
-        source: $PWD/thredds/content-root/wmsConfig.xml
+        source: $PWD/docker/thredds/content-root/wmsConfig.xml
         target: /usr/local/tomcat/content/thredds/wmsConfig.xml
       - type: bind
         source: /datadisk/data/geobeyond/arpav-ppcv/datasets
         target: /datasets
+      - type: bind
+        source: /datadisk/data/geobeyond/arpav-ppcv/netcdf-uncertainty-example
+        target: /additional
 
 #  martin:
 #    image: ghcr.io/maplibre/martin:v0.13.0

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -1,0 +1,75 @@
+name: arpav-ppcv
+
+x-backend-image: &backend-image "ghcr.io/geobeyond/arpav_ppcv:develop"
+x-postgis-image: &postgis-image "postgis/postgis:16-3.4"
+x-postgres-db-healthcheck: &postgres-db-healthcheck
+  interval: 10s
+  timeout: 3s
+  start_period: 1m
+  retries: 10
+  test: |
+    export PGPASSWORD=$${POSTGRES_PASSWORD:-}
+    args="--host 127.0.0.1 --username $${POSTGRES_USER} --dbname $${POSTGRES_DB} --quiet --no-align --tuples-only"
+    response=$$(echo 'SELECT 1' | psql $${args})
+    if [ $${response} = '1' ];
+    then exit 0;
+    else echo "+++++++++++++DB $${POSTGRES_DB} is not up+++++++++++++"; exit 1;
+    fi
+
+services:
+
+  web:
+    image: *backend-image
+    depends_on:
+      web-db:
+        condition: service_healthy
+
+  worker:
+    image: *backend-image
+
+  message-broker:
+    image: redis
+
+  web-db:
+    image: *postgis-image
+    ports:
+      - target: "5432"
+        published: "55432"
+    environment:
+      PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_DB: "arpavppcv"
+      POSTGRES_PASSWORD: "pass"
+      POSTGRES_USER: "arpavppcv"
+    healthcheck: *postgres-db-healthcheck
+
+  thredds:
+    image: unidata/thredds-docker:5.4
+    ports:
+      - target: "80"
+        published: "8080"
+    environment:
+      TDS_CONTENT_ROOT_PATH: /usr/local/tomcat/content
+      TDM_PW: "arpavppcvthredds"
+
+  martin:
+    image: ghcr.io/maplibre/martin:v0.13.0
+    ports:
+      - target: "3000"
+        published: "3000"
+    environment:
+      - DATABASE_URL=postgres://arpavppcv_tiles:pass@martin-db/arpavppcv_tiles
+    depends_on:
+      martin-db:
+        condition: service_healthy
+
+  martin-db:
+    image: *postgis-image
+    ports:
+      - target: "5432"
+        published: "55433"
+    environment:
+      PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_DB: "arpavppcv_tiles"
+      POSTGRES_PASSWORD: "pass"
+      POSTGRES_USER: "arpavppcv_tiles"
+    healthcheck: *postgres-db-healthcheck

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -18,58 +18,75 @@ x-postgres-db-healthcheck: &postgres-db-healthcheck
 
 services:
 
-  web:
-    image: *backend-image
-    depends_on:
-      web-db:
-        condition: service_healthy
+#  web:
+#    image: *backend-image
+#    depends_on:
+#      web-db:
+#        condition: service_healthy
 
-  worker:
-    image: *backend-image
+#  worker:
+#    image: *backend-image
 
-  message-broker:
-    image: redis
+#  message-broker:
+#    image: redis
 
-  web-db:
-    image: *postgis-image
-    ports:
-      - target: "5432"
-        published: "55432"
-    environment:
-      PGDATA: /var/lib/postgresql/data/pgdata
-      POSTGRES_DB: "arpavppcv"
-      POSTGRES_PASSWORD: "pass"
-      POSTGRES_USER: "arpavppcv"
-    healthcheck: *postgres-db-healthcheck
+#  web-db:
+#    image: *postgis-image
+#    ports:
+#      - target: "5432"
+#        published: "55432"
+#    environment:
+#      PGDATA: /var/lib/postgresql/data/pgdata
+#      POSTGRES_DB: "arpavppcv"
+#      POSTGRES_PASSWORD: "pass"
+#      POSTGRES_USER: "arpavppcv"
+#    healthcheck: *postgres-db-healthcheck
 
   thredds:
     image: unidata/thredds-docker:5.4
     ports:
-      - target: "80"
-        published: "8080"
+      - target: "8080"
+        published: "8081"
     environment:
       TDS_CONTENT_ROOT_PATH: /usr/local/tomcat/content
       TDM_PW: "arpavppcvthredds"
+      TDS_HOST: "http://localhost:8081"
+    volumes:
+      - type: bind
+        source: $PWD/thredds/content-root/catalog.xml
+        target: /usr/local/tomcat/content/thredds/catalog.xml
+      - type: bind
+        source: $PWD/thredds/content-root/catalog_rcm.xml
+        target: /usr/local/tomcat/content/thredds/catalog_rcm.xml
+      - type: bind
+        source: $PWD/thredds/content-root/threddsConfig.xml
+        target: /usr/local/tomcat/content/thredds/threddsConfig.xml
+      - type: bind
+        source: $PWD/thredds/content-root/wmsConfig.xml
+        target: /usr/local/tomcat/content/thredds/wmsConfig.xml
+      - type: bind
+        source: /datadisk/data/geobeyond/arpav-ppcv/datasets
+        target: /datasets
 
-  martin:
-    image: ghcr.io/maplibre/martin:v0.13.0
-    ports:
-      - target: "3000"
-        published: "3000"
-    environment:
-      - DATABASE_URL=postgres://arpavppcv_tiles:pass@martin-db/arpavppcv_tiles
-    depends_on:
-      martin-db:
-        condition: service_healthy
+#  martin:
+#    image: ghcr.io/maplibre/martin:v0.13.0
+#    ports:
+#      - target: "3000"
+#        published: "3000"
+#    environment:
+#      - DATABASE_URL=postgres://arpavppcv_tiles:pass@martin-db/arpavppcv_tiles
+#    depends_on:
+#      martin-db:
+#        condition: service_healthy
 
-  martin-db:
-    image: *postgis-image
-    ports:
-      - target: "5432"
-        published: "55433"
-    environment:
-      PGDATA: /var/lib/postgresql/data/pgdata
-      POSTGRES_DB: "arpavppcv_tiles"
-      POSTGRES_PASSWORD: "pass"
-      POSTGRES_USER: "arpavppcv_tiles"
-    healthcheck: *postgres-db-healthcheck
+#  martin-db:
+#    image: *postgis-image
+#    ports:
+#      - target: "5432"
+#        published: "55433"
+#    environment:
+#      PGDATA: /var/lib/postgresql/data/pgdata
+#      POSTGRES_DB: "arpavppcv_tiles"
+#      POSTGRES_PASSWORD: "pass"
+#      POSTGRES_USER: "arpavppcv_tiles"
+#    healthcheck: *postgres-db-healthcheck

--- a/docker/thredds/content-root/catalog.xml
+++ b/docker/thredds/content-root/catalog.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog name="THREDDS ARPAV Clima Server Catalog"
+         xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0
+           http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.6.xsd">
+
+  <catalogRef xlink:title="Catalogo modelli climatici" xlink:href="catalog_rcm.xml" name=""/>
+</catalog>
+

--- a/docker/thredds/content-root/catalog_rcm.xml
+++ b/docker/thredds/content-root/catalog_rcm.xml
@@ -15,546 +15,108 @@
         <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
     </service>
 
-    <!--ECMWF GRIB files  (send by AM)  -->
     <dataset name="CORDEX RCM Triveneto">
-        <!--restrictAccess="dati_accordo"-->
-
         <metadata inherited="true">
             <serviceName>all</serviceName>
             <dataType>Grid</dataType>
             <authority>Arpav</authority>
         </metadata>
+        <dataset name="test-data">
 
-        <dataset name="Variabili giornaliere"> <!-- restrictAccess="dati_accordo">-->
-
-            <datasetScan name="EC-EARTH_CCLM4-8-17" ID="EC-EARTH_CCLM4-8-17"
-                         path="EC-EARTH_CCLM4-8-17"
-                         location="/data/VM/clima_lavoro/EC-EARTH_CCLM4-8-17/triveneto2"> <!-- restrictAccess="userA">-->
-
+            <datasetScan name="Ensemble 5rcm BC" ID="ensembletwbc"
+                         path="ensembletwbc"
+                         location="/datasets/ensembletwbc">
                 <metadata inherited="true">
                     <serviceName>all</serviceName>
                     <dataType>Grid</dataType>
                     <authority>Arpav</authority>
                 </metadata>
-
-                <filter>
-                    <include wildcard="*_19702100.nc"/>
-                    <exclude wildcard="pr*_19702100.nc"/>
-                    <include wildcard="*_mmday.nc"/>
-                </filter>
-
             </datasetScan>
-
-            <datasetScan name="EC-EARTH_RACMO22E" ID="EC-EARTH_RACMO22E"
-                         path="EC-EARTH_RACMO22E"
-                         location="/data/VM/clima_lavoro/EC-EARTH_RACMO22E/triveneto2"> <!-- restrictAccess="userA">-->
-
+            <datasetScan name="Temperatura e precipitazione 5rcm" ID="taspr5rcm"
+                         path="taspr5rcm"
+                         location="/datasets/taspr5rcm">
                 <metadata inherited="true">
                     <serviceName>all</serviceName>
                     <dataType>Grid</dataType>
                     <authority>Arpav</authority>
                 </metadata>
-
-                <filter>
-                    <include wildcard="*_19702100.nc"/>
-                    <exclude wildcard="pr*_19702100.nc"/>
-                    <include wildcard="*_mmday.nc"/>
-                </filter>
-
             </datasetScan>
-
-            <datasetScan name="EC-EARTH_RCA4" ID="EC-EARTH_RCA4"
-                         path="EC-EARTH_RCA4"
-                         location="/data/VM/clima_lavoro/EC-EARTH_RCA4/triveneto2"> <!-- restrictAccess="userA">-->
-
+            <datasetScan name="Indici climatici 5rcm" ID="indici5rcm"
+                         path="indici5rcm"
+                         location="/datasets/indici5rcm">
                 <metadata inherited="true">
                     <serviceName>all</serviceName>
                     <dataType>Grid</dataType>
                     <authority>Arpav</authority>
                 </metadata>
-
-                <filter>
-                    <include wildcard="*_19702100.nc"/>
-                    <exclude wildcard="pr*_19702100.nc"/>
-                    <include wildcard="*_mmday.nc"/>
-                </filter>
-
             </datasetScan>
-
-            <datasetScan name="HadGEM2-ES_RACMO22E" ID="HadGEM2-ES_RACMO22E"
-                         path="HadGEM2-ES_RACMO22E"
-                         location="/data/VM/clima_lavoro/HadGEM2-ES_RACMO22E/triveneto2"> <!-- restrictAccess="userA">-->
-
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
-
-                <filter>
-                    <include wildcard="*_19702100.nc"/>
-                    <exclude wildcard="pr*_19702100.nc"/>
-                    <include wildcard="*_mmday.nc"/>
-                </filter>
-
-            </datasetScan>
-
-            <datasetScan name="MPI-ESM-LR_REMO2009" ID="MPI-ESM-LR_REMO2009"
-                         path="MPI-ESM-LR_REMO2009"
-                         location="/data/VM/clima_lavoro/MPI-ESM-LR_REMO2009/triveneto2"> <!-- restrictAccess="userA">-->
-
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
-
-                <filter>
-                    <include wildcard="*_19702100.nc"/>
-                    <exclude wildcard="pr*_19702100.nc"/>
-                    <include wildcard="*_mmday.nc"/>
-                </filter>
-
-            </datasetScan>
-
-
-            <datasetScan name="CNRM-CM5_CCLM4-8-17" ID="CNRM-CM5_CCLM4-8-17"
-                         path="CNRM-CM5_CCLM4-8-17"
-                         location="/data/VM/clima_lavoro/CNRM-CM5_CCLM4-8-17/triveneto2"> <!-- restrictAccess="userA">-->
-
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
-
-                <filter>
-                    <include wildcard="*_19702100.nc"/>
-                    <exclude wildcard="pr*_19702100.nc"/>
-                    <include wildcard="*_mmday.nc"/>
-                </filter>
-
-            </datasetScan>
-
-            <datasetScan name="CNRM-CM5_RCA4" ID="CNRM-CM5_RCA4"
-                         path="CNRM-CM5_RCA4"
-                         location="/data/VM/clima_lavoro/CNRM-CM5_RCA4/triveneto2"> <!-- restrictAccess="userA">-->
-
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
-
-                <filter>
-                    <include wildcard="*_19702100.nc"/>
-                    <exclude wildcard="pr*_19702100.nc"/>
-                    <include wildcard="*_mmday.nc"/>
-                </filter>
-
-            </datasetScan>
-
-            <datasetScan name="EC-EARTH_HIRHAM5" ID="EC-EARTH_HIRHAM5"
-                         path="EC-EARTH_HIRHAM5"
-                         location="/data/VM/clima_lavoro/EC-EARTH_HIRHAM5/triveneto2"> <!-- restrictAccess="userA">-->
-
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
-
-                <filter>
-                    <include wildcard="*_19702100.nc"/>
-                    <exclude wildcard="pr*_19702100.nc"/>
-                    <include wildcard="*_mmday.nc"/>
-                </filter>
-
-            </datasetScan>
-
-            <datasetScan name="HadGEM2-ES_CCLM4-8-17" ID="HadGEM2-ES_CCLM4-8-17"
-                         path="HadGEM2-ES_CCLM4-8-17"
-                         location="/data/VM/clima_lavoro/HadGEM2-ES_CCLM4-8-17/triveneto2"> <!-- restrictAccess="userA">-->
-
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
-
-                <filter>
-                    <include wildcard="*_19702100.nc"/>
-                    <exclude wildcard="pr*_19702100.nc"/>
-                    <include wildcard="*_mmday.nc"/>
-                </filter>
-
-            </datasetScan>
-
-            <datasetScan name="HadGEM2-ES_RCA4" ID="HadGEM2-ES_RCA4"
-                         path="HadGEM2-ES_RCA4"
-                         location="/data/VM/clima_lavoro/HadGEM2-ES_RCA4/triveneto2"> <!-- restrictAccess="userA">-->
-
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
-
-                <filter>
-                    <include wildcard="*_19702100.nc"/>
-                    <exclude wildcard="pr*_19702100.nc"/>
-                    <include wildcard="*_mmday.nc"/>
-                </filter>
-
-            </datasetScan>
-
-            <datasetScan name="IPSL-CM5A-MR_INERIS-WRF331F" ID="IPSL-CM5A-MR_INERIS-WRF331F"
-                         path="IPSL-CM5A-MR_INERIS-WRF331F"
-                         location="/data/VM/clima_lavoro/IPSL-CM5A-MR_INERIS-WRF331F/triveneto2"> <!-- restrictAccess="userA">-->
-
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
-
-                <filter>
-                    <include wildcard="*_19702100.nc"/>
-                    <exclude wildcard="pr*_19702100.nc"/>
-                    <include wildcard="*_mmday.nc"/>
-                </filter>
-
-            </datasetScan>
-
-            <datasetScan name="IPSL-CM5A-MR_RCA4" ID="IPSL-CM5A-MR_RCA4"
-                         path="IPSL-CM5A-MR_RCA4"
-                         location="/data/VM/clima_lavoro/IPSL-CM5A-MR_RCA4/triveneto2"> <!-- restrictAccess="userA">-->
-
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
-
-                <filter>
-                    <include wildcard="*_19702100.nc"/>
-                    <exclude wildcard="pr*_19702100.nc"/>
-                    <include wildcard="*_mmday.nc"/>
-                </filter>
-
-            </datasetScan>
-
-            <datasetScan name="MPI-ESM-LR_CCLM4-8-17" ID="MPI-ESM-LR_CCLM4-8-17"
-                         path="MPI-ESM-LR_CCLM4-8-17"
-                         location="/data/VM/clima_lavoro/MPI-ESM-LR_CCLM4-8-17/triveneto2"> <!-- restrictAccess="userA">-->
-
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
-
-                <filter>
-                    <include wildcard="*_19702100.nc"/>
-                    <exclude wildcard="pr*_19702100.nc"/>
-                    <include wildcard="*_mmday.nc"/>
-                </filter>
-
-            </datasetScan>
-
-            <datasetScan name="MPI-ESM-LR_RCA4" ID="MPI-ESM-LR_RCA4"
-                         path="MPI-ESM-LR_RCA4"
-                         location="/data/VM/clima_lavoro/MPI-ESM-LR_RCA4/triveneto2"> <!-- restrictAccess="userA">-->
-
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
-
-                <filter>
-                    <include wildcard="*_19702100.nc"/>
-                    <exclude wildcard="pr*_19702100.nc"/>
-                    <include wildcard="*_mmday.nc"/>
-                </filter>
-
-            </datasetScan>
-
-            <datasetScan name="NCC-NorESM1-M_HIRHAM5" ID="NCC-NorESM1-M_HIRHAM5"
-                         path="NCC-NorESM1-M_HIRHAM5" location="/data/VM/clima_lavoro/NCC-NorESM1-M_HIRHAM5/triveneto2"
-                         restrictAccess="userA">
-
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
-
-                <filter>
-                    <include wildcard="*_19702100.nc"/>
-                    <exclude wildcard="pr*_19702100.nc"/>
-                    <include wildcard="*_mmday.nc"/>
-                </filter>
-
-            </datasetScan>
-
-
-        </dataset>
-
-        <dataset name="Variabili giornaliere BC"> <!-- restrictAccess="dati_accordo">-->
-
-            <datasetScan name="EC-EARTH_CCLM4-8-17bc" ID="EC-EARTH_CCLM4-8-17bc"
-                         path="EC-EARTH_CCLM4-8-17bc"
-                         location="/data/VM/clima_lavoro/EC-EARTH_CCLM4-8-17/biascorr"> <!-- restrictAccess="userA">-->
-
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
-
-                <filter>
-                    <include wildcard="*19702100*_ls.nc"/>
-                    <exclude wildcard="*nonull*.nc"/>
-                    <exclude wildcard="VFVG_mask" atomic="false" collection="true"/>
-                    <exclude wildcard="fldmean" atomic="false" collection="true"/>
-                </filter>
-
-            </datasetScan>
-
-            <datasetScan name="EC-EARTH_RACMO22Ebc" ID="EC-EARTH_RACMO22Ebc"
-                         path="EC-EARTH_RACMO22Ebc"
-                         location="/data/VM/clima_lavoro/EC-EARTH_RACMO22E/biascorr"> <!-- restrictAccess="userA">-->
-
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
-
-                <filter>
-                    <include wildcard="*19702100*_ls.nc"/>
-                    <exclude wildcard="*nonull*.nc"/>
-                    <exclude wildcard="VFVG_mask" atomic="false" collection="true"/>
-                    <exclude wildcard="fldmean" atomic="false" collection="true"/>
-                </filter>
-
-            </datasetScan>
-
-            <datasetScan name="EC-EARTH_RCA4bc" ID="EC-EARTH_RCA4bc"
-                         path="EC-EARTH_RCA4bc"
-                         location="/data/VM/clima_lavoro/EC-EARTH_RCA4/biascorr"> <!-- restrictAccess="userA">-->
-
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
-
-                <filter>
-                    <include wildcard="*19702100*_ls.nc"/>
-                    <exclude wildcard="*nonull*.nc"/>
-                    <exclude wildcard="VFVG_mask" atomic="false" collection="true"/>
-                    <exclude wildcard="fldmean" atomic="false" collection="true"/>
-                </filter>
-
-            </datasetScan>
-
-            <datasetScan name="HadGEM2-ES_RACMO22Ebc" ID="HadGEM2-ES_RACMO22Ebc"
-                         path="HadGEM2-ES_RACMO22Ebc"
-                         location="/data/VM/clima_lavoro/HadGEM2-ES_RACMO22E/biascorr"> <!-- restrictAccess="userA">-->
-
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
-
-                <filter>
-                    <include wildcard="*19702100*_ls.nc"/>
-                    <exclude wildcard="*nonull*.nc"/>
-                    <exclude wildcard="VFVG_mask" atomic="false" collection="true"/>
-                    <exclude wildcard="fldmean" atomic="false" collection="true"/>
-                </filter>
-
-            </datasetScan>
-
-            <datasetScan name="MPI-ESM-LR_REMO2009bc" ID="MPI-ESM-LR_REMO2009bc"
-                         path="MPI-ESM-LR_REMO2009bc"
-                         location="/data/VM/clima_lavoro/MPI-ESM-LR_REMO2009/biascorr"> <!-- restrictAccess="userA">-->
-
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
-
-                <filter>
-                    <include wildcard="*19702100*_ls.nc"/>
-                    <exclude wildcard="*nonull*.nc"/>
-                    <exclude wildcard="VFVG_mask" atomic="false" collection="true"/>
-                    <exclude wildcard="fldmean" atomic="false" collection="true"/>
-                </filter>
-
-            </datasetScan>
-
-        </dataset>
-
-
-        <dataset name="Serie annuali e stagionali"> <!-- restrictAccess="dati_accordo">-->
-
-
-            <datasetScan name="Ensemble 14rcm" ID="ens14ym"
-                         path="ens14ym" location="/data/VM/ensemble_14m/pp"> <!-- restrictAccess="userA">-->
-
-
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
-
-                <filter>
-                    <include wildcard="*_DJF.nc"/>
-                    <include wildcard="*_JJA.nc"/>
-                    <include wildcard="*_MAM.nc"/>
-                    <include wildcard="*_SON.nc"/>
-                </filter>
-
-            </datasetScan>
-
             <datasetScan name="Ensemble 5rcm" ID="ens5ym"
-                         path="ens5ym" location="/data/VM/ensemble_5m/pp"> <!-- restrictAccess="userA">-->
-
-
+                         path="ens5ym"
+                         location="/datasets/ens5ym">
                 <metadata inherited="true">
                     <serviceName>all</serviceName>
                     <dataType>Grid</dataType>
                     <authority>Arpav</authority>
                 </metadata>
-
-                <filter>
-                    <include wildcard="*_DJF*.nc"/>
-                    <include wildcard="*_JJA*.nc"/>
-                    <include wildcard="*_MAM*.nc"/>
-                    <include wildcard="*_SON*.nc"/>
-                </filter>
-
             </datasetScan>
-
             <datasetScan name="Ensemble 5rcm BC" ID="ensymbc"
-                         path="ensymbc" location="/data/VM/ensemble_5m/indiciens/ts"> <!-- restrictAccess="userA">-->
-
-
+                         path="ensymbc"
+                         location="/datasets/ensymbc">
                 <metadata inherited="true">
                     <serviceName>all</serviceName>
                     <dataType>Grid</dataType>
                     <authority>Arpav</authority>
                 </metadata>
-
-
-                <filter>
-                    <include wildcard="*.nc"/>
-                    <exclude wildcard="ecapd*.nc"/>
-                    <exclude wildcard="pp" atomic="false" collection="true"/>
-                </filter>
-
-
             </datasetScan>
-
             <datasetScan name="EC-EARTH_CCLM4-8-17" ID="EC-EARTH_CCLM4-8-17ym"
                          path="EC-EARTH_CCLM4-8-17ym"
-                         location="/data/VM/clima_lavoro/EC-EARTH_CCLM4-8-17/anomalia2"> <!-- restrictAccess="userA">-->
-
+                         location="/datasets/EC-EARTH_CCLM4-8-17ym">
                 <metadata inherited="true">
                     <serviceName>all</serviceName>
                     <dataType>Grid</dataType>
                     <authority>Arpav</authority>
                 </metadata>
-
-                <filter>
-                    <include wildcard="tas*_anomaly_pp*.nc"/>
-                    <include wildcard="pr*_anomaly_pp_percentage*.nc"/>
-                    <exclude wildcard="*ts19762100*"/>
-                </filter>
-
             </datasetScan>
-
             <datasetScan name="EC-EARTH_CCLM4-8-17bc" ID="EC-EARTH_CCLM4-8-17ymbc"
-                         path="EC-EARTH_CCLM4-8-17ymbc" location="/data/VM/clima_lavoro/EC-EARTH_CCLM4-8-17/indici_ts">
-
+                         path="EC-EARTH_CCLM4-8-17ymbc"
+                         location="/datasets/EC-EARTH_CCLM4-8-17ymbc">
                 <metadata inherited="true">
                     <serviceName>all</serviceName>
                     <dataType>Grid</dataType>
                     <authority>Arpav</authority>
                 </metadata>
-
-                <filter>
-                    <include wildcard="*ts*.nc"/>
-                    <exclude wildcard="ecapd*.nc"/>
-                </filter>
-
-
             </datasetScan>
-
             <datasetScan name="EC-EARTH_RACMO22E" ID="EC-EARTH_RACMO22Eym"
                          path="EC-EARTH_RACMO22Eym"
-                         location="/data/VM/clima_lavoro/EC-EARTH_RACMO22E/anomalia2"> <!-- restrictAccess="userA">-->
-
+                         location="/datasets/EC-EARTH_RACMO22Eym">
                 <metadata inherited="true">
                     <serviceName>all</serviceName>
                     <dataType>Grid</dataType>
                     <authority>Arpav</authority>
                 </metadata>
-
-                <filter>
-                    <include wildcard="tas*_anomaly_pp*.nc"/>
-                    <include wildcard="pr*_anomaly_pp_percentage*.nc"/>
-                    <exclude wildcard="*ts19762100*"/>
-
-                </filter>
-
             </datasetScan>
-
             <datasetScan name="EC-EARTH_RACMO22Ebc" ID="EC-EARTH_RACMO22Eymbc"
-                         path="EC-EARTH_RACMO22Eymbc" location="/data/VM/clima_lavoro/EC-EARTH_RACMO22E/indici_ts">
-
+                         path="EC-EARTH_RACMO22Eymbc"
+                         location="/datasets/EC-EARTH_RACMO22Eymbc">
                 <metadata inherited="true">
                     <serviceName>all</serviceName>
                     <dataType>Grid</dataType>
                     <authority>Arpav</authority>
                 </metadata>
-
-                <filter>
-                    <include wildcard="*ts*.nc"/>
-                    <exclude wildcard="ecapd*.nc"/>
-                </filter>
-
-
             </datasetScan>
-
             <datasetScan name="EC-EARTH_RCA4" ID="EC-EARTH_RCA4ym"
-                         path="EC-EARTH_RCA4ym" location="/data/VM/clima_lavoro/EC-EARTH_RCA4/anomalia2">
-                <!--location="/media/giovanni/Elements/VM/clima_lavoro/EC-EARTH_RCA4/ymean"> -->
-                <!-- restrictAccess="userA">-->
-
+                         path="EC-EARTH_RCA4ym"
+                         location="/datasets/EC-EARTH_RCA4ym">
                 <metadata inherited="true">
                     <serviceName>all</serviceName>
                     <dataType>Grid</dataType>
                     <authority>Arpav</authority>
                 </metadata>
-
-                <filter>
-                    <include wildcard="tas*_anomaly_pp*.nc"/>
-                    <include wildcard="pr*_anomaly_pp_percentage*.nc"/>
-                    <exclude wildcard="*ts19762100*"/>
-                </filter>
-
             </datasetScan>
 
             <datasetScan name="EC-EARTH_RCA4bc" ID="EC-EARTH_RCA4ymbc"
-                         path="EC-EARTH_RCA4ymbc" location="/data/VM/clima_lavoro/EC-EARTH_RCA4/indici_ts">
-
+                         path="EC-EARTH_RCA4ymbc"
+                         location="/datasets/EC-EARTH_RCA4ymbc">
                 <metadata inherited="true">
                     <serviceName>all</serviceName>
                     <dataType>Grid</dataType>
@@ -565,398 +127,979 @@
                     <include wildcard="*ts*.nc"/>
                     <exclude wildcard="ecapd*.nc"/>
                 </filter>
-
-
             </datasetScan>
-
             <datasetScan name="HadGEM2-ES_RACMO22E" ID="HadGEM2-ES_RACMO22Eym"
-                         path="HadGEM2-ES_RACMO22Eym" location="/data/VM/clima_lavoro/HadGEM2-ES_RACMO22E/anomalia2">
-                <!--location="/media/giovanni/Elements/VM/clima_lavoro/HadGEM2-ES_RACMO22E/ymean"> -->
-                <!-- restrictAccess="userA">-->
+                         path="HadGEM2-ES_RACMO22Eym"
+                         location="/datasets/HadGEM2-ES_RACMO22Eym">
 
                 <metadata inherited="true">
                     <serviceName>all</serviceName>
                     <dataType>Grid</dataType>
                     <authority>Arpav</authority>
                 </metadata>
-
-                <filter>
-                    <include wildcard="tas*_anomaly_pp*.nc"/>
-                    <include wildcard="pr*_anomaly_pp_percentage*.nc"/>
-                    <exclude wildcard="*ts19762100*"/>
-                </filter>
-
             </datasetScan>
-
             <datasetScan name="HadGEM2-ES_RACMO22Ebc" ID="HadGEM2-ES_RACMO22Eymbc"
-                         path="HadGEM2-ES_RACMO22Eymbc" location="/data/VM/clima_lavoro/HadGEM2-ES_RACMO22E/indici_ts">
-
+                         path="HadGEM2-ES_RACMO22Eymbc"
+                         location="/datasets/HadGEM2-ES_RACMO22Eymbc">
                 <metadata inherited="true">
                     <serviceName>all</serviceName>
                     <dataType>Grid</dataType>
                     <authority>Arpav</authority>
                 </metadata>
-
-                <filter>
-                    <include wildcard="*ts*.nc"/>
-                    <exclude wildcard="ecapd*.nc"/>
-                </filter>
-
-
             </datasetScan>
-
             <datasetScan name="MPI-ESM-LR_REMO2009" ID="MPI-ESM-LR_REMO2009ym"
-                         path="MPI-ESM-LR_REMO2009ym" location="/data/VM/clima_lavoro/MPI-ESM-LR_REMO2009/anomalia2">
-                <!--location="/media/giovanni/Elements/VM/clima_lavoro/MPI-ESM-LR_REMO2009/ymean">-->
-                <!-- restrictAccess="userA">-->
-
+                         path="MPI-ESM-LR_REMO2009ym"
+                         location="/datasets/MPI-ESM-LR_REMO2009ym">
                 <metadata inherited="true">
                     <serviceName>all</serviceName>
                     <dataType>Grid</dataType>
                     <authority>Arpav</authority>
                 </metadata>
-
-                <filter>
-                    <include wildcard="tas*_anomaly_pp*.nc"/>
-                    <include wildcard="pr*_anomaly_pp_percentage*.nc"/>
-                    <exclude wildcard="*ts19762100*"/>
-                </filter>
-
-
-                <!--
-                <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
-                -->
-
-                <!--publish only the latidude/longitude with step 4 (step4:0.5° step1:0.125°)-->
-                <!--
-                <variable name="lat">
-                 <logicalSection section="0:10:1"/>
-                </variable>
-
-                <variable name="lon">
-                 <logicalSection section="0:20:1"/>
-                </variable>
-
-
-               </netcdf>
-               -->
-
             </datasetScan>
-
             <datasetScan name="MPI-ESM-LR_REMO2009bc" ID="MPI-ESM-LR_REMO2009ymbc"
-                         path="MPI-ESM-LR_REMO2009ymbc" location="/data/VM/clima_lavoro/MPI-ESM-LR_REMO2009/indici_ts">
-
+                         path="MPI-ESM-LR_REMO2009ymbc"
+                         location="/datasets/MPI-ESM-LR_REMO2009ymbc">
                 <metadata inherited="true">
                     <serviceName>all</serviceName>
                     <dataType>Grid</dataType>
                     <authority>Arpav</authority>
                 </metadata>
-
-                <filter>
-                    <include wildcard="*ts*.nc"/>
-                    <exclude wildcard="ecapd*.nc"/>
-                </filter>
-
-
             </datasetScan>
-
-
-            <datasetScan name="CNRM-CM5_CCLM4-8-17" ID="CNRM-CM5_CCLM4-8-17ym"
-                         path="CNRM-CM5_CCLM4-8-17ym"
-                         location="/data/VM/clima_lavoro/CNRM-CM5_CCLM4-8-17/anomalia2"> <!-- restrictAccess="userA">-->
-
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
-
-                <filter>
-                    <include wildcard="tas*_anomaly_pp.nc"/>
-                    <include wildcard="pr*_anomaly_pp_percentage.nc"/>
-                </filter>
-
-
-            </datasetScan>
-
-            <datasetScan name="CNRM-CM5_RCA4" ID="CNRM-CM5_RCA4ym"
-                         path="CNRM-CM5_RCA4ym"
-                         location="/data/VM/clima_lavoro/CNRM-CM5_RCA4/anomalia2"> <!-- restrictAccess="userA">-->
-
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
-
-                <filter>
-                    <include wildcard="tas*_anomaly_pp.nc"/>
-                    <include wildcard="pr*_anomaly_pp_percentage.nc"/>
-                </filter>
-
-
-            </datasetScan>
-
-            <datasetScan name="EC-EARTH_HIRHAM5" ID="EC-EARTH_HIRHAM5ym"
-                         path="EC-EARTH_HIRHAM5ym"
-                         location="/data/VM/clima_lavoro/EC-EARTH_HIRHAM5/anomalia2"> <!-- restrictAccess="userA">-->
-
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
-
-                <filter>
-                    <include wildcard="tas*_anomaly_pp.nc"/>
-                    <include wildcard="pr*_anomaly_pp_percentage.nc"/>
-                </filter>
-
-
-            </datasetScan>
-
-            <datasetScan name="HadGEM2-ES_CCLM4-8-17" ID="HadGEM2-ES_CCLM4-8-17ym"
-                         path="HadGEM2-ES_CCLM4-8-17ym"
-                         location="/data/VM/clima_lavoro/HadGEM2-ES_CCLM4-8-17/anomalia2"> <!-- restrictAccess="userA">-->
-
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
-
-                <filter>
-                    <include wildcard="tas*_anomaly_pp.nc"/>
-                    <include wildcard="pr*_anomaly_pp_percentage.nc"/>
-                </filter>
-
-
-            </datasetScan>
-
-            <datasetScan name="HadGEM2-ES_RCA4" ID="HadGEM2-ES_RCA4ym"
-                         path="HadGEM2-ES_RCA4ym"
-                         location="/data/VM/clima_lavoro/HadGEM2-ES_RCA4/anomalia2"> <!-- restrictAccess="userA">-->
-
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
-
-                <filter>
-                    <include wildcard="tas*_anomaly_pp.nc"/>
-                    <include wildcard="pr*_anomaly_pp_percentage.nc"/>
-                </filter>
-
-
-            </datasetScan>
-
-            <datasetScan name="IPSL-CM5A-MR_RCA4" ID="IPSL-CM5A-MR_RCA4ym"
-                         path="IPSL-CM5A-MR_RCA4ym"
-                         location="/data/VM/clima_lavoro/IPSL-CM5A-MR_RCA4/anomalia2"> <!-- restrictAccess="userA">-->
-
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
-
-                <filter>
-                    <include wildcard="tas*_anomaly_pp.nc"/>
-                    <include wildcard="pr*_anomaly_pp_percentage.nc"/>
-                </filter>
-
-
-            </datasetScan>
-
-            <datasetScan name="MPI-ESM-LR_CCLM4-8-17" ID="MPI-ESM-LR_CCLM4-8-17ym"
-                         path="MPI-ESM-LR_CCLM4-8-17ym"
-                         location="/data/VM/clima_lavoro/MPI-ESM-LR_CCLM4-8-17/anomalia2"> <!-- restrictAccess="userA">-->
-
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
-
-                <filter>
-                    <include wildcard="tas*_anomaly_pp.nc"/>
-                    <include wildcard="pr*_anomaly_pp_percentage.nc"/>
-                </filter>
-
-
-            </datasetScan>
-
-            <datasetScan name="MPI-ESM-LR_RCA4" ID="MPI-ESM-LR_RCA4ym"
-                         path="MPI-ESM-LR_RCA4ym"
-                         location="/data/VM/clima_lavoro/MPI-ESM-LR_RCA4/anomalia2"> <!-- restrictAccess="userA">-->
-
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
-
-                <filter>
-                    <include wildcard="tas*_anomaly_pp.nc"/>
-                    <include wildcard="pr*_anomaly_pp_percentage.nc"/>
-                </filter>
-
-
-            </datasetScan>
-
-            <datasetScan name="NCC-NorESM1-M_HIRHAM5" ID="NCC-NorESM1-M_HIRHAM5ym"
-                         path="NCC-NorESM1-M_HIRHAM5ym"
-                         location="/data/VM/clima_lavoro/NCC-NorESM1-M_HIRHAM5/anomalia2"> <!-- restrictAccess="userA">-->
-
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
-
-                <filter>
-                    <include wildcard="tas*_anomaly_pp.nc"/>
-                    <include wildcard="pr*_anomaly_pp_percentage.nc"/>
-                </filter>
-
-
-            </datasetScan>
-
         </dataset>
 
-        <dataset name="Anomalie trentennali">  <!--restrictAccess="dati_accordo">-->
+        <!--        <dataset name="Variabili giornaliere"> &lt;!&ndash; restrictAccess="dati_accordo">&ndash;&gt;-->
 
-            <datasetScan name="Ensemble 14rcm" ID="ensemble14"
-                         path="ensemble14" location="/data/VM/ensemble_14m/indiciens">
-                <!--location="/media/giovanni/Elements/VM/ensemble_14m/indiciens">-->
-                <!-- restrictAccess="userA">-->
+        <!--            <datasetScan name="EC-EARTH_CCLM4-8-17" ID="EC-EARTH_CCLM4-8-17"-->
+        <!--                         path="EC-EARTH_CCLM4-8-17"-->
+        <!--                         location="/data/VM/clima_lavoro/EC-EARTH_CCLM4-8-17/triveneto2"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
 
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
 
-                <filter>
-                    <!--<include wildcard="*.nc" />-->
-                    <exclude wildcard="heat_waves_avg_*.nc"/>
-                    <exclude wildcard="pp" atomic="false" collection="true"/>
-                    <exclude wildcard="thralert" atomic="false" collection="true"/>
-                </filter>
+        <!--                <filter>-->
+        <!--                    <include wildcard="*_19702100.nc"/>-->
+        <!--                    <exclude wildcard="pr*_19702100.nc"/>-->
+        <!--                    <include wildcard="*_mmday.nc"/>-->
+        <!--                </filter>-->
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="EC-EARTH_RACMO22E" ID="EC-EARTH_RACMO22E"-->
+        <!--                         path="EC-EARTH_RACMO22E"-->
+        <!--                         location="/data/VM/clima_lavoro/EC-EARTH_RACMO22E/triveneto2"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="*_19702100.nc"/>-->
+        <!--                    <exclude wildcard="pr*_19702100.nc"/>-->
+        <!--                    <include wildcard="*_mmday.nc"/>-->
+        <!--                </filter>-->
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="EC-EARTH_RCA4" ID="EC-EARTH_RCA4"-->
+        <!--                         path="EC-EARTH_RCA4"-->
+        <!--                         location="/data/VM/clima_lavoro/EC-EARTH_RCA4/triveneto2"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="*_19702100.nc"/>-->
+        <!--                    <exclude wildcard="pr*_19702100.nc"/>-->
+        <!--                    <include wildcard="*_mmday.nc"/>-->
+        <!--                </filter>-->
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="HadGEM2-ES_RACMO22E" ID="HadGEM2-ES_RACMO22E"-->
+        <!--                         path="HadGEM2-ES_RACMO22E"-->
+        <!--                         location="/data/VM/clima_lavoro/HadGEM2-ES_RACMO22E/triveneto2"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="*_19702100.nc"/>-->
+        <!--                    <exclude wildcard="pr*_19702100.nc"/>-->
+        <!--                    <include wildcard="*_mmday.nc"/>-->
+        <!--                </filter>-->
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="MPI-ESM-LR_REMO2009" ID="MPI-ESM-LR_REMO2009"-->
+        <!--                         path="MPI-ESM-LR_REMO2009"-->
+        <!--                         location="/data/VM/clima_lavoro/MPI-ESM-LR_REMO2009/triveneto2"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="*_19702100.nc"/>-->
+        <!--                    <exclude wildcard="pr*_19702100.nc"/>-->
+        <!--                    <include wildcard="*_mmday.nc"/>-->
+        <!--                </filter>-->
+
+        <!--            </datasetScan>-->
 
 
-            </datasetScan>
+        <!--            <datasetScan name="CNRM-CM5_CCLM4-8-17" ID="CNRM-CM5_CCLM4-8-17"-->
+        <!--                         path="CNRM-CM5_CCLM4-8-17"-->
+        <!--                         location="/data/VM/clima_lavoro/CNRM-CM5_CCLM4-8-17/triveneto2"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
 
-            <datasetScan name="Ensemble 5rcm BC" ID="ensembletwbc"
-                         path="ensembletwbc" location="/data/VM/ensemble_5m/indiciens">
-                <!--location="/media/giovanni/Elements/VM/ensemble_14m/indiciens">-->
-                <!-- restrictAccess="userA">-->
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
 
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
+        <!--                <filter>-->
+        <!--                    <include wildcard="*_19702100.nc"/>-->
+        <!--                    <exclude wildcard="pr*_19702100.nc"/>-->
+        <!--                    <include wildcard="*_mmday.nc"/>-->
+        <!--                </filter>-->
 
-                <filter>
-                    <!--<include wildcard="*.nc" />-->
-                    <exclude wildcard="heat_waves_avg_*.nc"/>
-                    <exclude wildcard="heat_waves_*DJF.nc"/>
-                    <exclude wildcard="ecasuan_25_*.nc"/>
-                    <exclude wildcard="ts" atomic="false" collection="true"/>
-                    <exclude wildcard="thralert" atomic="false" collection="true"/>
-                    <exclude wildcard="w_null" atomic="false" collection="true"/>
-                    <!--<exclude wildcard="*tw0*.nc" />
-                    <include wildcard="sc_*tw0*.nc" />
-                    <include wildcard="snw*tw0*.nc" />
-                    <include wildcard="eca_cdd*tw0*.nc" />-->
-                </filter>
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="CNRM-CM5_RCA4" ID="CNRM-CM5_RCA4"-->
+        <!--                         path="CNRM-CM5_RCA4"-->
+        <!--                         location="/data/VM/clima_lavoro/CNRM-CM5_RCA4/triveneto2"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="*_19702100.nc"/>-->
+        <!--                    <exclude wildcard="pr*_19702100.nc"/>-->
+        <!--                    <include wildcard="*_mmday.nc"/>-->
+        <!--                </filter>-->
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="EC-EARTH_HIRHAM5" ID="EC-EARTH_HIRHAM5"-->
+        <!--                         path="EC-EARTH_HIRHAM5"-->
+        <!--                         location="/data/VM/clima_lavoro/EC-EARTH_HIRHAM5/triveneto2"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="*_19702100.nc"/>-->
+        <!--                    <exclude wildcard="pr*_19702100.nc"/>-->
+        <!--                    <include wildcard="*_mmday.nc"/>-->
+        <!--                </filter>-->
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="HadGEM2-ES_CCLM4-8-17" ID="HadGEM2-ES_CCLM4-8-17"-->
+        <!--                         path="HadGEM2-ES_CCLM4-8-17"-->
+        <!--                         location="/data/VM/clima_lavoro/HadGEM2-ES_CCLM4-8-17/triveneto2"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="*_19702100.nc"/>-->
+        <!--                    <exclude wildcard="pr*_19702100.nc"/>-->
+        <!--                    <include wildcard="*_mmday.nc"/>-->
+        <!--                </filter>-->
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="HadGEM2-ES_RCA4" ID="HadGEM2-ES_RCA4"-->
+        <!--                         path="HadGEM2-ES_RCA4"-->
+        <!--                         location="/data/VM/clima_lavoro/HadGEM2-ES_RCA4/triveneto2"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="*_19702100.nc"/>-->
+        <!--                    <exclude wildcard="pr*_19702100.nc"/>-->
+        <!--                    <include wildcard="*_mmday.nc"/>-->
+        <!--                </filter>-->
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="IPSL-CM5A-MR_INERIS-WRF331F" ID="IPSL-CM5A-MR_INERIS-WRF331F"-->
+        <!--                         path="IPSL-CM5A-MR_INERIS-WRF331F"-->
+        <!--                         location="/data/VM/clima_lavoro/IPSL-CM5A-MR_INERIS-WRF331F/triveneto2"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="*_19702100.nc"/>-->
+        <!--                    <exclude wildcard="pr*_19702100.nc"/>-->
+        <!--                    <include wildcard="*_mmday.nc"/>-->
+        <!--                </filter>-->
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="IPSL-CM5A-MR_RCA4" ID="IPSL-CM5A-MR_RCA4"-->
+        <!--                         path="IPSL-CM5A-MR_RCA4"-->
+        <!--                         location="/data/VM/clima_lavoro/IPSL-CM5A-MR_RCA4/triveneto2"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="*_19702100.nc"/>-->
+        <!--                    <exclude wildcard="pr*_19702100.nc"/>-->
+        <!--                    <include wildcard="*_mmday.nc"/>-->
+        <!--                </filter>-->
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="MPI-ESM-LR_CCLM4-8-17" ID="MPI-ESM-LR_CCLM4-8-17"-->
+        <!--                         path="MPI-ESM-LR_CCLM4-8-17"-->
+        <!--                         location="/data/VM/clima_lavoro/MPI-ESM-LR_CCLM4-8-17/triveneto2"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="*_19702100.nc"/>-->
+        <!--                    <exclude wildcard="pr*_19702100.nc"/>-->
+        <!--                    <include wildcard="*_mmday.nc"/>-->
+        <!--                </filter>-->
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="MPI-ESM-LR_RCA4" ID="MPI-ESM-LR_RCA4"-->
+        <!--                         path="MPI-ESM-LR_RCA4"-->
+        <!--                         location="/data/VM/clima_lavoro/MPI-ESM-LR_RCA4/triveneto2"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="*_19702100.nc"/>-->
+        <!--                    <exclude wildcard="pr*_19702100.nc"/>-->
+        <!--                    <include wildcard="*_mmday.nc"/>-->
+        <!--                </filter>-->
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="NCC-NorESM1-M_HIRHAM5" ID="NCC-NorESM1-M_HIRHAM5"-->
+        <!--                         path="NCC-NorESM1-M_HIRHAM5" location="/data/VM/clima_lavoro/NCC-NorESM1-M_HIRHAM5/triveneto2"-->
+        <!--                         restrictAccess="userA">-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="*_19702100.nc"/>-->
+        <!--                    <exclude wildcard="pr*_19702100.nc"/>-->
+        <!--                    <include wildcard="*_mmday.nc"/>-->
+        <!--                </filter>-->
+
+        <!--            </datasetScan>-->
 
 
-            </datasetScan>
+        <!--        </dataset>-->
 
-            <datasetScan name="Temperatura e precipitazione 14rcm" ID="taspr14rcm"
-                         path="taspr14rcm" location="/data/VM/anomaly_tw_14m">
-                <!--location="/media/giovanni/Elements/VM/anomaly_tw"> -->
-                <!-- restrictAccess="userA">-->
+        <!--        <dataset name="Variabili giornaliere BC"> &lt;!&ndash; restrictAccess="dati_accordo">&ndash;&gt;-->
 
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
+        <!--            <datasetScan name="EC-EARTH_CCLM4-8-17bc" ID="EC-EARTH_CCLM4-8-17bc"-->
+        <!--                         path="EC-EARTH_CCLM4-8-17bc"-->
+        <!--                         location="/data/VM/clima_lavoro/EC-EARTH_CCLM4-8-17/biascorr"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
 
-                <filter>
-                    <include wildcard="*.nc"/>
-                    <exclude wildcard="nonusare" atomic="false" collection="true"/>
-                </filter>
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
 
-            </datasetScan>
+        <!--                <filter>-->
+        <!--                    <include wildcard="*19702100*_ls.nc"/>-->
+        <!--                    <exclude wildcard="*nonull*.nc"/>-->
+        <!--                    <exclude wildcard="VFVG_mask" atomic="false" collection="true"/>-->
+        <!--                    <exclude wildcard="fldmean" atomic="false" collection="true"/>-->
+        <!--                </filter>-->
 
-            <datasetScan name="Temperatura e precipitazione 5rcm" ID="taspr5rcm"
-                         path="taspr5rcm" location="/data/VM/anomaly_tw_5m">
-                <!-- restrictAccess="userA">-->
+        <!--            </datasetScan>-->
 
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
+        <!--            <datasetScan name="EC-EARTH_RACMO22Ebc" ID="EC-EARTH_RACMO22Ebc"-->
+        <!--                         path="EC-EARTH_RACMO22Ebc"-->
+        <!--                         location="/data/VM/clima_lavoro/EC-EARTH_RACMO22E/biascorr"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
 
-                <filter>
-                    <include wildcard="*.nc"/>
-                    <exclude wildcard="nonusare" atomic="false" collection="true"/>
-                </filter>
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
 
-            </datasetScan>
+        <!--                <filter>-->
+        <!--                    <include wildcard="*19702100*_ls.nc"/>-->
+        <!--                    <exclude wildcard="*nonull*.nc"/>-->
+        <!--                    <exclude wildcard="VFVG_mask" atomic="false" collection="true"/>-->
+        <!--                    <exclude wildcard="fldmean" atomic="false" collection="true"/>-->
+        <!--                </filter>-->
 
-            <datasetScan name="Indici climatici 14rcm" ID="indici14rcm"
-                         path="indici14rcm" location="/data/VM/indici_14m">
-                <!-- restrictAccess="userA">-->
+        <!--            </datasetScan>-->
 
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
+        <!--            <datasetScan name="EC-EARTH_RCA4bc" ID="EC-EARTH_RCA4bc"-->
+        <!--                         path="EC-EARTH_RCA4bc"-->
+        <!--                         location="/data/VM/clima_lavoro/EC-EARTH_RCA4/biascorr"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
 
-                <filter>
-                    <exclude wildcard="ecatr_*.nc"/>
-                    <exclude wildcard="ecatr_*_20_tw1.nc"/>
-                    <exclude wildcard="ecatr_*_20_tw2.nc"/>
-                    <exclude wildcard="ecasuan_25_*.nc"/>
-                    <exclude wildcard="*tw0*.nc"/>
-                    <exclude wildcard="heat_waves_anom_*ls.nc"/>
-                </filter>
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
 
-            </datasetScan>
+        <!--                <filter>-->
+        <!--                    <include wildcard="*19702100*_ls.nc"/>-->
+        <!--                    <exclude wildcard="*nonull*.nc"/>-->
+        <!--                    <exclude wildcard="VFVG_mask" atomic="false" collection="true"/>-->
+        <!--                    <exclude wildcard="fldmean" atomic="false" collection="true"/>-->
+        <!--                </filter>-->
 
-            <datasetScan name="Indici climatici 5rcm" ID="indici5rcm"
-                         path="indici5rcm" location="/data/VM/indici_5m">
-                <!-- restrictAccess="userA">-->
+        <!--            </datasetScan>-->
 
-                <metadata inherited="true">
-                    <serviceName>all</serviceName>
-                    <dataType>Grid</dataType>
-                    <authority>Arpav</authority>
-                </metadata>
+        <!--            <datasetScan name="HadGEM2-ES_RACMO22Ebc" ID="HadGEM2-ES_RACMO22Ebc"-->
+        <!--                         path="HadGEM2-ES_RACMO22Ebc"-->
+        <!--                         location="/data/VM/clima_lavoro/HadGEM2-ES_RACMO22E/biascorr"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
 
-                <filter>
-                    <exclude wildcard="ecatr_*.nc"/>
-                    <exclude wildcard="ecatr_*_20_tw1.nc"/>
-                    <exclude wildcard="ecatr_*_20_tw2.nc"/>
-                    <exclude wildcard="ecasuan_25_*.nc"/>
-                    <exclude wildcard="*tw0*.nc"/>
-                    <exclude wildcard="heat_waves_anom_*ls.nc"/>
-                    <exclude wildcard="heat_waves_*DJF*.nc"/>
-                </filter>
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
 
-            </datasetScan>
+        <!--                <filter>-->
+        <!--                    <include wildcard="*19702100*_ls.nc"/>-->
+        <!--                    <exclude wildcard="*nonull*.nc"/>-->
+        <!--                    <exclude wildcard="VFVG_mask" atomic="false" collection="true"/>-->
+        <!--                    <exclude wildcard="fldmean" atomic="false" collection="true"/>-->
+        <!--                </filter>-->
 
-        </dataset>
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="MPI-ESM-LR_REMO2009bc" ID="MPI-ESM-LR_REMO2009bc"-->
+        <!--                         path="MPI-ESM-LR_REMO2009bc"-->
+        <!--                         location="/data/VM/clima_lavoro/MPI-ESM-LR_REMO2009/biascorr"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="*19702100*_ls.nc"/>-->
+        <!--                    <exclude wildcard="*nonull*.nc"/>-->
+        <!--                    <exclude wildcard="VFVG_mask" atomic="false" collection="true"/>-->
+        <!--                    <exclude wildcard="fldmean" atomic="false" collection="true"/>-->
+        <!--                </filter>-->
+
+        <!--            </datasetScan>-->
+
+        <!--        </dataset>-->
+
+
+        <!--        <dataset name="Serie annuali e stagionali"> &lt;!&ndash; restrictAccess="dati_accordo">&ndash;&gt;-->
+
+
+        <!--            <datasetScan name="Ensemble 14rcm" ID="ens14ym"-->
+        <!--                         path="ens14ym" location="/data/VM/ensemble_14m/pp"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="*_DJF.nc"/>-->
+        <!--                    <include wildcard="*_JJA.nc"/>-->
+        <!--                    <include wildcard="*_MAM.nc"/>-->
+        <!--                    <include wildcard="*_SON.nc"/>-->
+        <!--                </filter>-->
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="Ensemble 5rcm" ID="ens5ym"-->
+        <!--                         path="ens5ym" location="/data/VM/ensemble_5m/pp"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="*_DJF*.nc"/>-->
+        <!--                    <include wildcard="*_JJA*.nc"/>-->
+        <!--                    <include wildcard="*_MAM*.nc"/>-->
+        <!--                    <include wildcard="*_SON*.nc"/>-->
+        <!--                </filter>-->
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="Ensemble 5rcm BC" ID="ensymbc"-->
+        <!--                         path="ensymbc" location="/data/VM/ensemble_5m/indiciens/ts"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="*.nc"/>-->
+        <!--                    <exclude wildcard="ecapd*.nc"/>-->
+        <!--                    <exclude wildcard="pp" atomic="false" collection="true"/>-->
+        <!--                </filter>-->
+
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="EC-EARTH_CCLM4-8-17" ID="EC-EARTH_CCLM4-8-17ym"-->
+        <!--                         path="EC-EARTH_CCLM4-8-17ym"-->
+        <!--                         location="/data/VM/clima_lavoro/EC-EARTH_CCLM4-8-17/anomalia2"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="tas*_anomaly_pp*.nc"/>-->
+        <!--                    <include wildcard="pr*_anomaly_pp_percentage*.nc"/>-->
+        <!--                    <exclude wildcard="*ts19762100*"/>-->
+        <!--                </filter>-->
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="EC-EARTH_CCLM4-8-17bc" ID="EC-EARTH_CCLM4-8-17ymbc"-->
+        <!--                         path="EC-EARTH_CCLM4-8-17ymbc" location="/data/VM/clima_lavoro/EC-EARTH_CCLM4-8-17/indici_ts">-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="*ts*.nc"/>-->
+        <!--                    <exclude wildcard="ecapd*.nc"/>-->
+        <!--                </filter>-->
+
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="EC-EARTH_RACMO22E" ID="EC-EARTH_RACMO22Eym"-->
+        <!--                         path="EC-EARTH_RACMO22Eym"-->
+        <!--                         location="/data/VM/clima_lavoro/EC-EARTH_RACMO22E/anomalia2"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="tas*_anomaly_pp*.nc"/>-->
+        <!--                    <include wildcard="pr*_anomaly_pp_percentage*.nc"/>-->
+        <!--                    <exclude wildcard="*ts19762100*"/>-->
+
+        <!--                </filter>-->
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="EC-EARTH_RACMO22Ebc" ID="EC-EARTH_RACMO22Eymbc"-->
+        <!--                         path="EC-EARTH_RACMO22Eymbc" location="/data/VM/clima_lavoro/EC-EARTH_RACMO22E/indici_ts">-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="*ts*.nc"/>-->
+        <!--                    <exclude wildcard="ecapd*.nc"/>-->
+        <!--                </filter>-->
+
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="EC-EARTH_RCA4" ID="EC-EARTH_RCA4ym"-->
+        <!--                         path="EC-EARTH_RCA4ym" location="/data/VM/clima_lavoro/EC-EARTH_RCA4/anomalia2">-->
+        <!--                &lt;!&ndash;location="/media/giovanni/Elements/VM/clima_lavoro/EC-EARTH_RCA4/ymean"> &ndash;&gt;-->
+        <!--                &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="tas*_anomaly_pp*.nc"/>-->
+        <!--                    <include wildcard="pr*_anomaly_pp_percentage*.nc"/>-->
+        <!--                    <exclude wildcard="*ts19762100*"/>-->
+        <!--                </filter>-->
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="EC-EARTH_RCA4bc" ID="EC-EARTH_RCA4ymbc"-->
+        <!--                         path="EC-EARTH_RCA4ymbc" location="/data/VM/clima_lavoro/EC-EARTH_RCA4/indici_ts">-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="*ts*.nc"/>-->
+        <!--                    <exclude wildcard="ecapd*.nc"/>-->
+        <!--                </filter>-->
+
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="HadGEM2-ES_RACMO22E" ID="HadGEM2-ES_RACMO22Eym"-->
+        <!--                         path="HadGEM2-ES_RACMO22Eym" location="/data/VM/clima_lavoro/HadGEM2-ES_RACMO22E/anomalia2">-->
+        <!--                &lt;!&ndash;location="/media/giovanni/Elements/VM/clima_lavoro/HadGEM2-ES_RACMO22E/ymean"> &ndash;&gt;-->
+        <!--                &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="tas*_anomaly_pp*.nc"/>-->
+        <!--                    <include wildcard="pr*_anomaly_pp_percentage*.nc"/>-->
+        <!--                    <exclude wildcard="*ts19762100*"/>-->
+        <!--                </filter>-->
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="HadGEM2-ES_RACMO22Ebc" ID="HadGEM2-ES_RACMO22Eymbc"-->
+        <!--                         path="HadGEM2-ES_RACMO22Eymbc" location="/data/VM/clima_lavoro/HadGEM2-ES_RACMO22E/indici_ts">-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="*ts*.nc"/>-->
+        <!--                    <exclude wildcard="ecapd*.nc"/>-->
+        <!--                </filter>-->
+
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="MPI-ESM-LR_REMO2009" ID="MPI-ESM-LR_REMO2009ym"-->
+        <!--                         path="MPI-ESM-LR_REMO2009ym" location="/data/VM/clima_lavoro/MPI-ESM-LR_REMO2009/anomalia2">-->
+        <!--                &lt;!&ndash;location="/media/giovanni/Elements/VM/clima_lavoro/MPI-ESM-LR_REMO2009/ymean">&ndash;&gt;-->
+        <!--                &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="tas*_anomaly_pp*.nc"/>-->
+        <!--                    <include wildcard="pr*_anomaly_pp_percentage*.nc"/>-->
+        <!--                    <exclude wildcard="*ts19762100*"/>-->
+        <!--                </filter>-->
+
+
+        <!--                &lt;!&ndash;-->
+        <!--                <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">-->
+        <!--                &ndash;&gt;-->
+
+        <!--                &lt;!&ndash;publish only the latidude/longitude with step 4 (step4:0.5° step1:0.125°)&ndash;&gt;-->
+        <!--                &lt;!&ndash;-->
+        <!--                <variable name="lat">-->
+        <!--                 <logicalSection section="0:10:1"/>-->
+        <!--                </variable>-->
+
+        <!--                <variable name="lon">-->
+        <!--                 <logicalSection section="0:20:1"/>-->
+        <!--                </variable>-->
+
+
+        <!--               </netcdf>-->
+        <!--               &ndash;&gt;-->
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="MPI-ESM-LR_REMO2009bc" ID="MPI-ESM-LR_REMO2009ymbc"-->
+        <!--                         path="MPI-ESM-LR_REMO2009ymbc" location="/data/VM/clima_lavoro/MPI-ESM-LR_REMO2009/indici_ts">-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="*ts*.nc"/>-->
+        <!--                    <exclude wildcard="ecapd*.nc"/>-->
+        <!--                </filter>-->
+
+
+        <!--            </datasetScan>-->
+
+
+        <!--            <datasetScan name="CNRM-CM5_CCLM4-8-17" ID="CNRM-CM5_CCLM4-8-17ym"-->
+        <!--                         path="CNRM-CM5_CCLM4-8-17ym"-->
+        <!--                         location="/data/VM/clima_lavoro/CNRM-CM5_CCLM4-8-17/anomalia2"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="tas*_anomaly_pp.nc"/>-->
+        <!--                    <include wildcard="pr*_anomaly_pp_percentage.nc"/>-->
+        <!--                </filter>-->
+
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="CNRM-CM5_RCA4" ID="CNRM-CM5_RCA4ym"-->
+        <!--                         path="CNRM-CM5_RCA4ym"-->
+        <!--                         location="/data/VM/clima_lavoro/CNRM-CM5_RCA4/anomalia2"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="tas*_anomaly_pp.nc"/>-->
+        <!--                    <include wildcard="pr*_anomaly_pp_percentage.nc"/>-->
+        <!--                </filter>-->
+
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="EC-EARTH_HIRHAM5" ID="EC-EARTH_HIRHAM5ym"-->
+        <!--                         path="EC-EARTH_HIRHAM5ym"-->
+        <!--                         location="/data/VM/clima_lavoro/EC-EARTH_HIRHAM5/anomalia2"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="tas*_anomaly_pp.nc"/>-->
+        <!--                    <include wildcard="pr*_anomaly_pp_percentage.nc"/>-->
+        <!--                </filter>-->
+
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="HadGEM2-ES_CCLM4-8-17" ID="HadGEM2-ES_CCLM4-8-17ym"-->
+        <!--                         path="HadGEM2-ES_CCLM4-8-17ym"-->
+        <!--                         location="/data/VM/clima_lavoro/HadGEM2-ES_CCLM4-8-17/anomalia2"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="tas*_anomaly_pp.nc"/>-->
+        <!--                    <include wildcard="pr*_anomaly_pp_percentage.nc"/>-->
+        <!--                </filter>-->
+
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="HadGEM2-ES_RCA4" ID="HadGEM2-ES_RCA4ym"-->
+        <!--                         path="HadGEM2-ES_RCA4ym"-->
+        <!--                         location="/data/VM/clima_lavoro/HadGEM2-ES_RCA4/anomalia2"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="tas*_anomaly_pp.nc"/>-->
+        <!--                    <include wildcard="pr*_anomaly_pp_percentage.nc"/>-->
+        <!--                </filter>-->
+
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="IPSL-CM5A-MR_RCA4" ID="IPSL-CM5A-MR_RCA4ym"-->
+        <!--                         path="IPSL-CM5A-MR_RCA4ym"-->
+        <!--                         location="/data/VM/clima_lavoro/IPSL-CM5A-MR_RCA4/anomalia2"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="tas*_anomaly_pp.nc"/>-->
+        <!--                    <include wildcard="pr*_anomaly_pp_percentage.nc"/>-->
+        <!--                </filter>-->
+
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="MPI-ESM-LR_CCLM4-8-17" ID="MPI-ESM-LR_CCLM4-8-17ym"-->
+        <!--                         path="MPI-ESM-LR_CCLM4-8-17ym"-->
+        <!--                         location="/data/VM/clima_lavoro/MPI-ESM-LR_CCLM4-8-17/anomalia2"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="tas*_anomaly_pp.nc"/>-->
+        <!--                    <include wildcard="pr*_anomaly_pp_percentage.nc"/>-->
+        <!--                </filter>-->
+
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="MPI-ESM-LR_RCA4" ID="MPI-ESM-LR_RCA4ym"-->
+        <!--                         path="MPI-ESM-LR_RCA4ym"-->
+        <!--                         location="/data/VM/clima_lavoro/MPI-ESM-LR_RCA4/anomalia2"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="tas*_anomaly_pp.nc"/>-->
+        <!--                    <include wildcard="pr*_anomaly_pp_percentage.nc"/>-->
+        <!--                </filter>-->
+
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="NCC-NorESM1-M_HIRHAM5" ID="NCC-NorESM1-M_HIRHAM5ym"-->
+        <!--                         path="NCC-NorESM1-M_HIRHAM5ym"-->
+        <!--                         location="/data/VM/clima_lavoro/NCC-NorESM1-M_HIRHAM5/anomalia2"> &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="tas*_anomaly_pp.nc"/>-->
+        <!--                    <include wildcard="pr*_anomaly_pp_percentage.nc"/>-->
+        <!--                </filter>-->
+
+
+        <!--            </datasetScan>-->
+
+        <!--        </dataset>-->
+
+        <!--        <dataset name="Anomalie trentennali">  &lt;!&ndash;restrictAccess="dati_accordo">&ndash;&gt;-->
+
+        <!--            <datasetScan name="Ensemble 14rcm" ID="ensemble14"-->
+        <!--                         path="ensemble14" location="/data/VM/ensemble_14m/indiciens">-->
+        <!--                &lt;!&ndash;location="/media/giovanni/Elements/VM/ensemble_14m/indiciens">&ndash;&gt;-->
+        <!--                &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    &lt;!&ndash;<include wildcard="*.nc" />&ndash;&gt;-->
+        <!--                    <exclude wildcard="heat_waves_avg_*.nc"/>-->
+        <!--                    <exclude wildcard="pp" atomic="false" collection="true"/>-->
+        <!--                    <exclude wildcard="thralert" atomic="false" collection="true"/>-->
+        <!--                </filter>-->
+
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="Ensemble 5rcm BC" ID="ensembletwbc"-->
+        <!--                         path="ensembletwbc" location="/data/VM/ensemble_5m/indiciens">-->
+        <!--                &lt;!&ndash;location="/media/giovanni/Elements/VM/ensemble_14m/indiciens">&ndash;&gt;-->
+        <!--                &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    &lt;!&ndash;<include wildcard="*.nc" />&ndash;&gt;-->
+        <!--                    <exclude wildcard="heat_waves_avg_*.nc"/>-->
+        <!--                    <exclude wildcard="heat_waves_*DJF.nc"/>-->
+        <!--                    <exclude wildcard="ecasuan_25_*.nc"/>-->
+        <!--                    <exclude wildcard="ts" atomic="false" collection="true"/>-->
+        <!--                    <exclude wildcard="thralert" atomic="false" collection="true"/>-->
+        <!--                    <exclude wildcard="w_null" atomic="false" collection="true"/>-->
+        <!--                    &lt;!&ndash;<exclude wildcard="*tw0*.nc" />-->
+        <!--                    <include wildcard="sc_*tw0*.nc" />-->
+        <!--                    <include wildcard="snw*tw0*.nc" />-->
+        <!--                    <include wildcard="eca_cdd*tw0*.nc" />&ndash;&gt;-->
+        <!--                </filter>-->
+
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="Temperatura e precipitazione 14rcm" ID="taspr14rcm"-->
+        <!--                         path="taspr14rcm" location="/data/VM/anomaly_tw_14m">-->
+        <!--                &lt;!&ndash;location="/media/giovanni/Elements/VM/anomaly_tw"> &ndash;&gt;-->
+        <!--                &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="*.nc"/>-->
+        <!--                    <exclude wildcard="nonusare" atomic="false" collection="true"/>-->
+        <!--                </filter>-->
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="Temperatura e precipitazione 5rcm" ID="taspr5rcm"-->
+        <!--                         path="taspr5rcm" location="/data/VM/anomaly_tw_5m">-->
+        <!--                &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <include wildcard="*.nc"/>-->
+        <!--                    <exclude wildcard="nonusare" atomic="false" collection="true"/>-->
+        <!--                </filter>-->
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="Indici climatici 14rcm" ID="indici14rcm"-->
+        <!--                         path="indici14rcm" location="/data/VM/indici_14m">-->
+        <!--                &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <exclude wildcard="ecatr_*.nc"/>-->
+        <!--                    <exclude wildcard="ecatr_*_20_tw1.nc"/>-->
+        <!--                    <exclude wildcard="ecatr_*_20_tw2.nc"/>-->
+        <!--                    <exclude wildcard="ecasuan_25_*.nc"/>-->
+        <!--                    <exclude wildcard="*tw0*.nc"/>-->
+        <!--                    <exclude wildcard="heat_waves_anom_*ls.nc"/>-->
+        <!--                </filter>-->
+
+        <!--            </datasetScan>-->
+
+        <!--            <datasetScan name="Indici climatici 5rcm" ID="indici5rcm"-->
+        <!--                         path="indici5rcm" location="/data/VM/indici_5m">-->
+        <!--                &lt;!&ndash; restrictAccess="userA">&ndash;&gt;-->
+
+        <!--                <metadata inherited="true">-->
+        <!--                    <serviceName>all</serviceName>-->
+        <!--                    <dataType>Grid</dataType>-->
+        <!--                    <authority>Arpav</authority>-->
+        <!--                </metadata>-->
+
+        <!--                <filter>-->
+        <!--                    <exclude wildcard="ecatr_*.nc"/>-->
+        <!--                    <exclude wildcard="ecatr_*_20_tw1.nc"/>-->
+        <!--                    <exclude wildcard="ecatr_*_20_tw2.nc"/>-->
+        <!--                    <exclude wildcard="ecasuan_25_*.nc"/>-->
+        <!--                    <exclude wildcard="*tw0*.nc"/>-->
+        <!--                    <exclude wildcard="heat_waves_anom_*ls.nc"/>-->
+        <!--                    <exclude wildcard="heat_waves_*DJF*.nc"/>-->
+        <!--                </filter>-->
+
+        <!--            </datasetScan>-->
+
+        <!--        </dataset>-->
+
+        <!--    </dataset>-->
+
 
     </dataset>
-
-
 </catalog>

--- a/docker/thredds/content-root/catalog_rcm.xml
+++ b/docker/thredds/content-root/catalog_rcm.xml
@@ -1,0 +1,962 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog name="THREDDS ARPAV Clima Server Catalog"
+         xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0
+           http://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.6.xsd">
+
+    <service name="all" base="" serviceType="compound">
+        <service name="odap" serviceType="OpenDAP" base="/thredds/dodsC/"/>
+        <service name="dap4" serviceType="DAP4" base="/thredds/dap4/"/>
+        <service name="http" serviceType="HTTPServer" base="/thredds/fileServer/"/>
+        <service name="wcs" serviceType="WCS" base="/thredds/wcs/"/>
+        <service name="wms" serviceType="WMS" base="/thredds/wms/"/>
+        <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
+    </service>
+
+    <!--ECMWF GRIB files  (send by AM)  -->
+    <dataset name="CORDEX RCM Triveneto">
+        <!--restrictAccess="dati_accordo"-->
+
+        <metadata inherited="true">
+            <serviceName>all</serviceName>
+            <dataType>Grid</dataType>
+            <authority>Arpav</authority>
+        </metadata>
+
+        <dataset name="Variabili giornaliere"> <!-- restrictAccess="dati_accordo">-->
+
+            <datasetScan name="EC-EARTH_CCLM4-8-17" ID="EC-EARTH_CCLM4-8-17"
+                         path="EC-EARTH_CCLM4-8-17"
+                         location="/data/VM/clima_lavoro/EC-EARTH_CCLM4-8-17/triveneto2"> <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="*_19702100.nc"/>
+                    <exclude wildcard="pr*_19702100.nc"/>
+                    <include wildcard="*_mmday.nc"/>
+                </filter>
+
+            </datasetScan>
+
+            <datasetScan name="EC-EARTH_RACMO22E" ID="EC-EARTH_RACMO22E"
+                         path="EC-EARTH_RACMO22E"
+                         location="/data/VM/clima_lavoro/EC-EARTH_RACMO22E/triveneto2"> <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="*_19702100.nc"/>
+                    <exclude wildcard="pr*_19702100.nc"/>
+                    <include wildcard="*_mmday.nc"/>
+                </filter>
+
+            </datasetScan>
+
+            <datasetScan name="EC-EARTH_RCA4" ID="EC-EARTH_RCA4"
+                         path="EC-EARTH_RCA4"
+                         location="/data/VM/clima_lavoro/EC-EARTH_RCA4/triveneto2"> <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="*_19702100.nc"/>
+                    <exclude wildcard="pr*_19702100.nc"/>
+                    <include wildcard="*_mmday.nc"/>
+                </filter>
+
+            </datasetScan>
+
+            <datasetScan name="HadGEM2-ES_RACMO22E" ID="HadGEM2-ES_RACMO22E"
+                         path="HadGEM2-ES_RACMO22E"
+                         location="/data/VM/clima_lavoro/HadGEM2-ES_RACMO22E/triveneto2"> <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="*_19702100.nc"/>
+                    <exclude wildcard="pr*_19702100.nc"/>
+                    <include wildcard="*_mmday.nc"/>
+                </filter>
+
+            </datasetScan>
+
+            <datasetScan name="MPI-ESM-LR_REMO2009" ID="MPI-ESM-LR_REMO2009"
+                         path="MPI-ESM-LR_REMO2009"
+                         location="/data/VM/clima_lavoro/MPI-ESM-LR_REMO2009/triveneto2"> <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="*_19702100.nc"/>
+                    <exclude wildcard="pr*_19702100.nc"/>
+                    <include wildcard="*_mmday.nc"/>
+                </filter>
+
+            </datasetScan>
+
+
+            <datasetScan name="CNRM-CM5_CCLM4-8-17" ID="CNRM-CM5_CCLM4-8-17"
+                         path="CNRM-CM5_CCLM4-8-17"
+                         location="/data/VM/clima_lavoro/CNRM-CM5_CCLM4-8-17/triveneto2"> <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="*_19702100.nc"/>
+                    <exclude wildcard="pr*_19702100.nc"/>
+                    <include wildcard="*_mmday.nc"/>
+                </filter>
+
+            </datasetScan>
+
+            <datasetScan name="CNRM-CM5_RCA4" ID="CNRM-CM5_RCA4"
+                         path="CNRM-CM5_RCA4"
+                         location="/data/VM/clima_lavoro/CNRM-CM5_RCA4/triveneto2"> <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="*_19702100.nc"/>
+                    <exclude wildcard="pr*_19702100.nc"/>
+                    <include wildcard="*_mmday.nc"/>
+                </filter>
+
+            </datasetScan>
+
+            <datasetScan name="EC-EARTH_HIRHAM5" ID="EC-EARTH_HIRHAM5"
+                         path="EC-EARTH_HIRHAM5"
+                         location="/data/VM/clima_lavoro/EC-EARTH_HIRHAM5/triveneto2"> <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="*_19702100.nc"/>
+                    <exclude wildcard="pr*_19702100.nc"/>
+                    <include wildcard="*_mmday.nc"/>
+                </filter>
+
+            </datasetScan>
+
+            <datasetScan name="HadGEM2-ES_CCLM4-8-17" ID="HadGEM2-ES_CCLM4-8-17"
+                         path="HadGEM2-ES_CCLM4-8-17"
+                         location="/data/VM/clima_lavoro/HadGEM2-ES_CCLM4-8-17/triveneto2"> <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="*_19702100.nc"/>
+                    <exclude wildcard="pr*_19702100.nc"/>
+                    <include wildcard="*_mmday.nc"/>
+                </filter>
+
+            </datasetScan>
+
+            <datasetScan name="HadGEM2-ES_RCA4" ID="HadGEM2-ES_RCA4"
+                         path="HadGEM2-ES_RCA4"
+                         location="/data/VM/clima_lavoro/HadGEM2-ES_RCA4/triveneto2"> <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="*_19702100.nc"/>
+                    <exclude wildcard="pr*_19702100.nc"/>
+                    <include wildcard="*_mmday.nc"/>
+                </filter>
+
+            </datasetScan>
+
+            <datasetScan name="IPSL-CM5A-MR_INERIS-WRF331F" ID="IPSL-CM5A-MR_INERIS-WRF331F"
+                         path="IPSL-CM5A-MR_INERIS-WRF331F"
+                         location="/data/VM/clima_lavoro/IPSL-CM5A-MR_INERIS-WRF331F/triveneto2"> <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="*_19702100.nc"/>
+                    <exclude wildcard="pr*_19702100.nc"/>
+                    <include wildcard="*_mmday.nc"/>
+                </filter>
+
+            </datasetScan>
+
+            <datasetScan name="IPSL-CM5A-MR_RCA4" ID="IPSL-CM5A-MR_RCA4"
+                         path="IPSL-CM5A-MR_RCA4"
+                         location="/data/VM/clima_lavoro/IPSL-CM5A-MR_RCA4/triveneto2"> <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="*_19702100.nc"/>
+                    <exclude wildcard="pr*_19702100.nc"/>
+                    <include wildcard="*_mmday.nc"/>
+                </filter>
+
+            </datasetScan>
+
+            <datasetScan name="MPI-ESM-LR_CCLM4-8-17" ID="MPI-ESM-LR_CCLM4-8-17"
+                         path="MPI-ESM-LR_CCLM4-8-17"
+                         location="/data/VM/clima_lavoro/MPI-ESM-LR_CCLM4-8-17/triveneto2"> <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="*_19702100.nc"/>
+                    <exclude wildcard="pr*_19702100.nc"/>
+                    <include wildcard="*_mmday.nc"/>
+                </filter>
+
+            </datasetScan>
+
+            <datasetScan name="MPI-ESM-LR_RCA4" ID="MPI-ESM-LR_RCA4"
+                         path="MPI-ESM-LR_RCA4"
+                         location="/data/VM/clima_lavoro/MPI-ESM-LR_RCA4/triveneto2"> <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="*_19702100.nc"/>
+                    <exclude wildcard="pr*_19702100.nc"/>
+                    <include wildcard="*_mmday.nc"/>
+                </filter>
+
+            </datasetScan>
+
+            <datasetScan name="NCC-NorESM1-M_HIRHAM5" ID="NCC-NorESM1-M_HIRHAM5"
+                         path="NCC-NorESM1-M_HIRHAM5" location="/data/VM/clima_lavoro/NCC-NorESM1-M_HIRHAM5/triveneto2"
+                         restrictAccess="userA">
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="*_19702100.nc"/>
+                    <exclude wildcard="pr*_19702100.nc"/>
+                    <include wildcard="*_mmday.nc"/>
+                </filter>
+
+            </datasetScan>
+
+
+        </dataset>
+
+        <dataset name="Variabili giornaliere BC"> <!-- restrictAccess="dati_accordo">-->
+
+            <datasetScan name="EC-EARTH_CCLM4-8-17bc" ID="EC-EARTH_CCLM4-8-17bc"
+                         path="EC-EARTH_CCLM4-8-17bc"
+                         location="/data/VM/clima_lavoro/EC-EARTH_CCLM4-8-17/biascorr"> <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="*19702100*_ls.nc"/>
+                    <exclude wildcard="*nonull*.nc"/>
+                    <exclude wildcard="VFVG_mask" atomic="false" collection="true"/>
+                    <exclude wildcard="fldmean" atomic="false" collection="true"/>
+                </filter>
+
+            </datasetScan>
+
+            <datasetScan name="EC-EARTH_RACMO22Ebc" ID="EC-EARTH_RACMO22Ebc"
+                         path="EC-EARTH_RACMO22Ebc"
+                         location="/data/VM/clima_lavoro/EC-EARTH_RACMO22E/biascorr"> <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="*19702100*_ls.nc"/>
+                    <exclude wildcard="*nonull*.nc"/>
+                    <exclude wildcard="VFVG_mask" atomic="false" collection="true"/>
+                    <exclude wildcard="fldmean" atomic="false" collection="true"/>
+                </filter>
+
+            </datasetScan>
+
+            <datasetScan name="EC-EARTH_RCA4bc" ID="EC-EARTH_RCA4bc"
+                         path="EC-EARTH_RCA4bc"
+                         location="/data/VM/clima_lavoro/EC-EARTH_RCA4/biascorr"> <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="*19702100*_ls.nc"/>
+                    <exclude wildcard="*nonull*.nc"/>
+                    <exclude wildcard="VFVG_mask" atomic="false" collection="true"/>
+                    <exclude wildcard="fldmean" atomic="false" collection="true"/>
+                </filter>
+
+            </datasetScan>
+
+            <datasetScan name="HadGEM2-ES_RACMO22Ebc" ID="HadGEM2-ES_RACMO22Ebc"
+                         path="HadGEM2-ES_RACMO22Ebc"
+                         location="/data/VM/clima_lavoro/HadGEM2-ES_RACMO22E/biascorr"> <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="*19702100*_ls.nc"/>
+                    <exclude wildcard="*nonull*.nc"/>
+                    <exclude wildcard="VFVG_mask" atomic="false" collection="true"/>
+                    <exclude wildcard="fldmean" atomic="false" collection="true"/>
+                </filter>
+
+            </datasetScan>
+
+            <datasetScan name="MPI-ESM-LR_REMO2009bc" ID="MPI-ESM-LR_REMO2009bc"
+                         path="MPI-ESM-LR_REMO2009bc"
+                         location="/data/VM/clima_lavoro/MPI-ESM-LR_REMO2009/biascorr"> <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="*19702100*_ls.nc"/>
+                    <exclude wildcard="*nonull*.nc"/>
+                    <exclude wildcard="VFVG_mask" atomic="false" collection="true"/>
+                    <exclude wildcard="fldmean" atomic="false" collection="true"/>
+                </filter>
+
+            </datasetScan>
+
+        </dataset>
+
+
+        <dataset name="Serie annuali e stagionali"> <!-- restrictAccess="dati_accordo">-->
+
+
+            <datasetScan name="Ensemble 14rcm" ID="ens14ym"
+                         path="ens14ym" location="/data/VM/ensemble_14m/pp"> <!-- restrictAccess="userA">-->
+
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="*_DJF.nc"/>
+                    <include wildcard="*_JJA.nc"/>
+                    <include wildcard="*_MAM.nc"/>
+                    <include wildcard="*_SON.nc"/>
+                </filter>
+
+            </datasetScan>
+
+            <datasetScan name="Ensemble 5rcm" ID="ens5ym"
+                         path="ens5ym" location="/data/VM/ensemble_5m/pp"> <!-- restrictAccess="userA">-->
+
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="*_DJF*.nc"/>
+                    <include wildcard="*_JJA*.nc"/>
+                    <include wildcard="*_MAM*.nc"/>
+                    <include wildcard="*_SON*.nc"/>
+                </filter>
+
+            </datasetScan>
+
+            <datasetScan name="Ensemble 5rcm BC" ID="ensymbc"
+                         path="ensymbc" location="/data/VM/ensemble_5m/indiciens/ts"> <!-- restrictAccess="userA">-->
+
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+
+                <filter>
+                    <include wildcard="*.nc"/>
+                    <exclude wildcard="ecapd*.nc"/>
+                    <exclude wildcard="pp" atomic="false" collection="true"/>
+                </filter>
+
+
+            </datasetScan>
+
+            <datasetScan name="EC-EARTH_CCLM4-8-17" ID="EC-EARTH_CCLM4-8-17ym"
+                         path="EC-EARTH_CCLM4-8-17ym"
+                         location="/data/VM/clima_lavoro/EC-EARTH_CCLM4-8-17/anomalia2"> <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="tas*_anomaly_pp*.nc"/>
+                    <include wildcard="pr*_anomaly_pp_percentage*.nc"/>
+                    <exclude wildcard="*ts19762100*"/>
+                </filter>
+
+            </datasetScan>
+
+            <datasetScan name="EC-EARTH_CCLM4-8-17bc" ID="EC-EARTH_CCLM4-8-17ymbc"
+                         path="EC-EARTH_CCLM4-8-17ymbc" location="/data/VM/clima_lavoro/EC-EARTH_CCLM4-8-17/indici_ts">
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="*ts*.nc"/>
+                    <exclude wildcard="ecapd*.nc"/>
+                </filter>
+
+
+            </datasetScan>
+
+            <datasetScan name="EC-EARTH_RACMO22E" ID="EC-EARTH_RACMO22Eym"
+                         path="EC-EARTH_RACMO22Eym"
+                         location="/data/VM/clima_lavoro/EC-EARTH_RACMO22E/anomalia2"> <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="tas*_anomaly_pp*.nc"/>
+                    <include wildcard="pr*_anomaly_pp_percentage*.nc"/>
+                    <exclude wildcard="*ts19762100*"/>
+
+                </filter>
+
+            </datasetScan>
+
+            <datasetScan name="EC-EARTH_RACMO22Ebc" ID="EC-EARTH_RACMO22Eymbc"
+                         path="EC-EARTH_RACMO22Eymbc" location="/data/VM/clima_lavoro/EC-EARTH_RACMO22E/indici_ts">
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="*ts*.nc"/>
+                    <exclude wildcard="ecapd*.nc"/>
+                </filter>
+
+
+            </datasetScan>
+
+            <datasetScan name="EC-EARTH_RCA4" ID="EC-EARTH_RCA4ym"
+                         path="EC-EARTH_RCA4ym" location="/data/VM/clima_lavoro/EC-EARTH_RCA4/anomalia2">
+                <!--location="/media/giovanni/Elements/VM/clima_lavoro/EC-EARTH_RCA4/ymean"> -->
+                <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="tas*_anomaly_pp*.nc"/>
+                    <include wildcard="pr*_anomaly_pp_percentage*.nc"/>
+                    <exclude wildcard="*ts19762100*"/>
+                </filter>
+
+            </datasetScan>
+
+            <datasetScan name="EC-EARTH_RCA4bc" ID="EC-EARTH_RCA4ymbc"
+                         path="EC-EARTH_RCA4ymbc" location="/data/VM/clima_lavoro/EC-EARTH_RCA4/indici_ts">
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="*ts*.nc"/>
+                    <exclude wildcard="ecapd*.nc"/>
+                </filter>
+
+
+            </datasetScan>
+
+            <datasetScan name="HadGEM2-ES_RACMO22E" ID="HadGEM2-ES_RACMO22Eym"
+                         path="HadGEM2-ES_RACMO22Eym" location="/data/VM/clima_lavoro/HadGEM2-ES_RACMO22E/anomalia2">
+                <!--location="/media/giovanni/Elements/VM/clima_lavoro/HadGEM2-ES_RACMO22E/ymean"> -->
+                <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="tas*_anomaly_pp*.nc"/>
+                    <include wildcard="pr*_anomaly_pp_percentage*.nc"/>
+                    <exclude wildcard="*ts19762100*"/>
+                </filter>
+
+            </datasetScan>
+
+            <datasetScan name="HadGEM2-ES_RACMO22Ebc" ID="HadGEM2-ES_RACMO22Eymbc"
+                         path="HadGEM2-ES_RACMO22Eymbc" location="/data/VM/clima_lavoro/HadGEM2-ES_RACMO22E/indici_ts">
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="*ts*.nc"/>
+                    <exclude wildcard="ecapd*.nc"/>
+                </filter>
+
+
+            </datasetScan>
+
+            <datasetScan name="MPI-ESM-LR_REMO2009" ID="MPI-ESM-LR_REMO2009ym"
+                         path="MPI-ESM-LR_REMO2009ym" location="/data/VM/clima_lavoro/MPI-ESM-LR_REMO2009/anomalia2">
+                <!--location="/media/giovanni/Elements/VM/clima_lavoro/MPI-ESM-LR_REMO2009/ymean">-->
+                <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="tas*_anomaly_pp*.nc"/>
+                    <include wildcard="pr*_anomaly_pp_percentage*.nc"/>
+                    <exclude wildcard="*ts19762100*"/>
+                </filter>
+
+
+                <!--
+                <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+                -->
+
+                <!--publish only the latidude/longitude with step 4 (step4:0.5° step1:0.125°)-->
+                <!--
+                <variable name="lat">
+                 <logicalSection section="0:10:1"/>
+                </variable>
+
+                <variable name="lon">
+                 <logicalSection section="0:20:1"/>
+                </variable>
+
+
+               </netcdf>
+               -->
+
+            </datasetScan>
+
+            <datasetScan name="MPI-ESM-LR_REMO2009bc" ID="MPI-ESM-LR_REMO2009ymbc"
+                         path="MPI-ESM-LR_REMO2009ymbc" location="/data/VM/clima_lavoro/MPI-ESM-LR_REMO2009/indici_ts">
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="*ts*.nc"/>
+                    <exclude wildcard="ecapd*.nc"/>
+                </filter>
+
+
+            </datasetScan>
+
+
+            <datasetScan name="CNRM-CM5_CCLM4-8-17" ID="CNRM-CM5_CCLM4-8-17ym"
+                         path="CNRM-CM5_CCLM4-8-17ym"
+                         location="/data/VM/clima_lavoro/CNRM-CM5_CCLM4-8-17/anomalia2"> <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="tas*_anomaly_pp.nc"/>
+                    <include wildcard="pr*_anomaly_pp_percentage.nc"/>
+                </filter>
+
+
+            </datasetScan>
+
+            <datasetScan name="CNRM-CM5_RCA4" ID="CNRM-CM5_RCA4ym"
+                         path="CNRM-CM5_RCA4ym"
+                         location="/data/VM/clima_lavoro/CNRM-CM5_RCA4/anomalia2"> <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="tas*_anomaly_pp.nc"/>
+                    <include wildcard="pr*_anomaly_pp_percentage.nc"/>
+                </filter>
+
+
+            </datasetScan>
+
+            <datasetScan name="EC-EARTH_HIRHAM5" ID="EC-EARTH_HIRHAM5ym"
+                         path="EC-EARTH_HIRHAM5ym"
+                         location="/data/VM/clima_lavoro/EC-EARTH_HIRHAM5/anomalia2"> <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="tas*_anomaly_pp.nc"/>
+                    <include wildcard="pr*_anomaly_pp_percentage.nc"/>
+                </filter>
+
+
+            </datasetScan>
+
+            <datasetScan name="HadGEM2-ES_CCLM4-8-17" ID="HadGEM2-ES_CCLM4-8-17ym"
+                         path="HadGEM2-ES_CCLM4-8-17ym"
+                         location="/data/VM/clima_lavoro/HadGEM2-ES_CCLM4-8-17/anomalia2"> <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="tas*_anomaly_pp.nc"/>
+                    <include wildcard="pr*_anomaly_pp_percentage.nc"/>
+                </filter>
+
+
+            </datasetScan>
+
+            <datasetScan name="HadGEM2-ES_RCA4" ID="HadGEM2-ES_RCA4ym"
+                         path="HadGEM2-ES_RCA4ym"
+                         location="/data/VM/clima_lavoro/HadGEM2-ES_RCA4/anomalia2"> <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="tas*_anomaly_pp.nc"/>
+                    <include wildcard="pr*_anomaly_pp_percentage.nc"/>
+                </filter>
+
+
+            </datasetScan>
+
+            <datasetScan name="IPSL-CM5A-MR_RCA4" ID="IPSL-CM5A-MR_RCA4ym"
+                         path="IPSL-CM5A-MR_RCA4ym"
+                         location="/data/VM/clima_lavoro/IPSL-CM5A-MR_RCA4/anomalia2"> <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="tas*_anomaly_pp.nc"/>
+                    <include wildcard="pr*_anomaly_pp_percentage.nc"/>
+                </filter>
+
+
+            </datasetScan>
+
+            <datasetScan name="MPI-ESM-LR_CCLM4-8-17" ID="MPI-ESM-LR_CCLM4-8-17ym"
+                         path="MPI-ESM-LR_CCLM4-8-17ym"
+                         location="/data/VM/clima_lavoro/MPI-ESM-LR_CCLM4-8-17/anomalia2"> <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="tas*_anomaly_pp.nc"/>
+                    <include wildcard="pr*_anomaly_pp_percentage.nc"/>
+                </filter>
+
+
+            </datasetScan>
+
+            <datasetScan name="MPI-ESM-LR_RCA4" ID="MPI-ESM-LR_RCA4ym"
+                         path="MPI-ESM-LR_RCA4ym"
+                         location="/data/VM/clima_lavoro/MPI-ESM-LR_RCA4/anomalia2"> <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="tas*_anomaly_pp.nc"/>
+                    <include wildcard="pr*_anomaly_pp_percentage.nc"/>
+                </filter>
+
+
+            </datasetScan>
+
+            <datasetScan name="NCC-NorESM1-M_HIRHAM5" ID="NCC-NorESM1-M_HIRHAM5ym"
+                         path="NCC-NorESM1-M_HIRHAM5ym"
+                         location="/data/VM/clima_lavoro/NCC-NorESM1-M_HIRHAM5/anomalia2"> <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="tas*_anomaly_pp.nc"/>
+                    <include wildcard="pr*_anomaly_pp_percentage.nc"/>
+                </filter>
+
+
+            </datasetScan>
+
+        </dataset>
+
+        <dataset name="Anomalie trentennali">  <!--restrictAccess="dati_accordo">-->
+
+            <datasetScan name="Ensemble 14rcm" ID="ensemble14"
+                         path="ensemble14" location="/data/VM/ensemble_14m/indiciens">
+                <!--location="/media/giovanni/Elements/VM/ensemble_14m/indiciens">-->
+                <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <!--<include wildcard="*.nc" />-->
+                    <exclude wildcard="heat_waves_avg_*.nc"/>
+                    <exclude wildcard="pp" atomic="false" collection="true"/>
+                    <exclude wildcard="thralert" atomic="false" collection="true"/>
+                </filter>
+
+
+            </datasetScan>
+
+            <datasetScan name="Ensemble 5rcm BC" ID="ensembletwbc"
+                         path="ensembletwbc" location="/data/VM/ensemble_5m/indiciens">
+                <!--location="/media/giovanni/Elements/VM/ensemble_14m/indiciens">-->
+                <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <!--<include wildcard="*.nc" />-->
+                    <exclude wildcard="heat_waves_avg_*.nc"/>
+                    <exclude wildcard="heat_waves_*DJF.nc"/>
+                    <exclude wildcard="ecasuan_25_*.nc"/>
+                    <exclude wildcard="ts" atomic="false" collection="true"/>
+                    <exclude wildcard="thralert" atomic="false" collection="true"/>
+                    <exclude wildcard="w_null" atomic="false" collection="true"/>
+                    <!--<exclude wildcard="*tw0*.nc" />
+                    <include wildcard="sc_*tw0*.nc" />
+                    <include wildcard="snw*tw0*.nc" />
+                    <include wildcard="eca_cdd*tw0*.nc" />-->
+                </filter>
+
+
+            </datasetScan>
+
+            <datasetScan name="Temperatura e precipitazione 14rcm" ID="taspr14rcm"
+                         path="taspr14rcm" location="/data/VM/anomaly_tw_14m">
+                <!--location="/media/giovanni/Elements/VM/anomaly_tw"> -->
+                <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="*.nc"/>
+                    <exclude wildcard="nonusare" atomic="false" collection="true"/>
+                </filter>
+
+            </datasetScan>
+
+            <datasetScan name="Temperatura e precipitazione 5rcm" ID="taspr5rcm"
+                         path="taspr5rcm" location="/data/VM/anomaly_tw_5m">
+                <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <include wildcard="*.nc"/>
+                    <exclude wildcard="nonusare" atomic="false" collection="true"/>
+                </filter>
+
+            </datasetScan>
+
+            <datasetScan name="Indici climatici 14rcm" ID="indici14rcm"
+                         path="indici14rcm" location="/data/VM/indici_14m">
+                <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <exclude wildcard="ecatr_*.nc"/>
+                    <exclude wildcard="ecatr_*_20_tw1.nc"/>
+                    <exclude wildcard="ecatr_*_20_tw2.nc"/>
+                    <exclude wildcard="ecasuan_25_*.nc"/>
+                    <exclude wildcard="*tw0*.nc"/>
+                    <exclude wildcard="heat_waves_anom_*ls.nc"/>
+                </filter>
+
+            </datasetScan>
+
+            <datasetScan name="Indici climatici 5rcm" ID="indici5rcm"
+                         path="indici5rcm" location="/data/VM/indici_5m">
+                <!-- restrictAccess="userA">-->
+
+                <metadata inherited="true">
+                    <serviceName>all</serviceName>
+                    <dataType>Grid</dataType>
+                    <authority>Arpav</authority>
+                </metadata>
+
+                <filter>
+                    <exclude wildcard="ecatr_*.nc"/>
+                    <exclude wildcard="ecatr_*_20_tw1.nc"/>
+                    <exclude wildcard="ecatr_*_20_tw2.nc"/>
+                    <exclude wildcard="ecasuan_25_*.nc"/>
+                    <exclude wildcard="*tw0*.nc"/>
+                    <exclude wildcard="heat_waves_anom_*ls.nc"/>
+                    <exclude wildcard="heat_waves_*DJF*.nc"/>
+                </filter>
+
+            </datasetScan>
+
+        </dataset>
+
+    </dataset>
+
+
+</catalog>

--- a/docker/thredds/content-root/catalog_rcm.xml
+++ b/docker/thredds/content-root/catalog_rcm.xml
@@ -15,6 +15,28 @@
         <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
     </service>
 
+    <dataset name="netcdf tests">
+        <metadata inherited="true">
+            <serviceName>all</serviceName>
+            <dataType>Grid</dataType>
+            <authority>Arpav</authority>
+        </metadata>
+
+        <datasetScan
+                name="Tests"
+                ID="tests"
+                path="tests"
+                location="/additional"
+        >
+            <metadata inherited="true">
+                <serviceName>all</serviceName>
+                <dataType>Grid</dataType>
+                <authority>Arpav</authority>
+            </metadata>
+        </datasetScan>
+
+    </dataset>
+
     <dataset name="CORDEX RCM Triveneto">
         <metadata inherited="true">
             <serviceName>all</serviceName>

--- a/docker/thredds/content-root/threddsConfig.xml
+++ b/docker/thredds/content-root/threddsConfig.xml
@@ -1,0 +1,269 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<threddsConfig>
+
+  <!-- all options are commented out in standard install - meaning use default values -->
+  <!-- see https://www.unidata.ucar.edu/software/thredds/current/tds/reference/ThreddsConfigXMLFile.html -->
+  <serverInformation>
+    <name>ARPAV test server</name>
+    <logoUrl>/thredds/arpavridotto.png</logoUrl>
+    <logoAltText>THREDDS test server for ARPA Veneto</logoAltText>
+
+    <abstract>Regional climate models and data</abstract>
+    <keywords>meteorology, atmosphere, climate, ocean, earth science</keywords>
+    
+    <contact>
+      <name>Support</name>
+      <organization>Geobeyond</organization>
+      <email>info@geobeyond.it</email>
+      <!--phone></phone-->
+    </contact>
+    <hostInstitution>
+      <name>Geobeyond</name>
+      <webSite>http://www.geobeyond.it/</webSite>
+      <logoUrl>/thredds/myGroup.png</logoUrl>
+      <logoAltText></logoAltText>
+    </hostInstitution>
+  </serverInformation>
+
+  <!--
+  The <catalogRoot> element:
+  For catalogs you don't want visible from the /thredds/catalog.xml chain
+  of catalogs, you can use catalogRoot elements. Each catalog root config
+  catalog is crawled and used in configuring the TDS.
+
+  <catalogRoot>myExtraCatalog.xml</catalogRoot>
+  <catalogRoot>myOtherExtraCatalog.xml</catalogRoot>
+  -->
+
+  <!--
+   * Setup for generated HTML pages.
+    -->
+  <htmlSetup>
+    <!--
+     * CSS documents used in generated HTML pages.
+     * The CSS document given in the "catalogCssUrl" element is used for HTML catalog views,
+     * "datasetCssUrl" is used for the dataset access HTML view,
+     * and the CSS document given in the "standardCssUrl"element is used in all other generated HTML pages.
+     * The OPeNDAP HTML form is treated special - the only CSS document applied to this page is
+     * defined by the `openDapCssUrl` element.
+     *
+     * NOTE: CSS documents should be placed inside tds.content.root.path/thredds/public
+     *
+
+     <standardCssUrl>standard.css</standardCssUrl>
+     <catalogCssUrl>catalog.css</catalogCssUrl>
+     <datasetCssUrl>dataset.css</datasetCssUrl>
+     <openDapCssUrl>tdsDap.css</openDapCssUrl>
+     * -->
+
+    <!--
+     * The Google Analytics Tracking ID you would like to use for the
+     * webpages associated with THREDDS. This will not track WMS or DAP
+     * requests for data, only browsing the catalog.
+
+    <googleTrackingCode></googleTrackingCode>
+    -->
+
+    <!--
+     * Allow the TDS to generate JSON-LD in Dataset HTML pages following
+     * schema.org Dataset (https://schema.org/Dataset)
+     * The default is false, as this is experimental
+
+    <generateDatasetJsonLD>false</generateDatasetJsonLD>
+    -->
+
+  </htmlSetup>
+  
+  <!-- 
+    The <TdsUpdateConfig> element controls if and how the TDS checks
+    for updates. The default is for the TDS to check for the current
+    stable and development release versions, and to log that information
+    in the TDS serverStartup.log file as INFO entries.
+
+  <TdsUpdateConfig>
+     <logVersionInfo>true</logVersionInfo>
+  </TdsUpdateConfig>
+  -->
+
+  <!--
+   The <CatalogServices> element:
+   - Services on local TDS served catalogs are always on.
+   - Services on remote catalogs are set with the allowRemote element
+   below. They are off by default (recommended).
+   -->
+  <CatalogServices>
+    <allowRemote>false</allowRemote>
+  </CatalogServices>
+
+  <!--
+  Configuring the CDM (netcdf-java library)
+  see https://www.unidata.ucar.edu/software/netcdf-java/reference/RuntimeLoading.html
+
+  <nj22Config>
+    <ioServiceProvider class="edu.univ.ny.stuff.FooFiles"/>
+    <coordSysBuilder convention="foo" class="test.Foo"/>
+    <coordTransBuilder name="atmos_ln_sigma_coordinates" type="vertical" class="my.stuff.atmosSigmaLog"/>
+    <typedDatasetFactory datatype="Point" class="gov.noaa.obscure.file.Flabulate"/>
+  </nj22Config>
+  -->
+
+  <!--
+  CDM uses the DiskCache directory to store temporary files, like uncompressed files.
+  <DiskCache>
+    <alwaysUse>false</alwaysUse>
+    <scour>1 hour</scour>
+    <maxSize>1 Gb</maxSize>
+  </DiskCache>
+  -->
+
+  <!--
+  Caching open NetcdfFile objects.
+  default is to allow 50 - 100 open files, cleanup every 11 minutes
+  <NetcdfFileCache>
+    <minFiles>50</minFiles>
+    <maxFiles>100</maxFiles>
+    <scour>11 min</scour>
+  </NetcdfFileCache>
+  -->
+
+  <!--
+  The <HTTPFileCache> element:
+  allow 10 - 20 open datasets, cleanup every 17 minutes
+  used by HTTP Range requests.
+  <HTTPFileCache>
+    <minFiles>10</minFiles>
+    <maxFiles>20</maxFiles>
+    <scour>17 min</scour>
+  </HTTPFileCache>
+  -->
+
+  <!--
+  Writing GRIB indexes.
+  <GribIndex>
+    <alwaysUse>false</alwaysUse>
+    <neverUse>false</neverUse>
+    <dir>/tomcat_home/content/thredds/cache/grib/</dir>
+    <policy>nestedDirectory</policy>
+    <scour>0 hours</scour>
+    <maxAge>90 days</maxAge>
+  </GribIndex>
+  -->
+
+  <!--
+  Persist joinNew aggregations to named directory. scour every 24 hours, delete stuff older than 90 days
+  <AggregationCache>
+    <scour>24 hours</scour>
+    <maxAge>90 days</maxAge>
+    <cachePathPolicy>NestedDirectory</cachePathPolicy>
+  </AggregationCache>
+  -->
+
+  <!--
+  How to choose the template dataset for an aggregation. latest, random, or penultimate
+  <Aggregation>
+    <typicalDataset>penultimate</typicalDataset>
+  </Aggregation>
+  -->
+  
+  <NetcdfSubsetService>
+    <scour>15 min</scour>
+    <maxAge>30 min</maxAge>
+  </NetcdfSubsetService>
+
+  <!--
+  <JupyterNotebookService>
+    <allow>true</allow>
+    <maxAge>60</maxAge>
+    <maxFiles>100</maxFiles>
+  </JupyterNotebookService>
+  -->
+
+  <!--
+  <Opendap>
+    <ascLimit>50</ascLimit>
+    <binLimit>500</binLimit>
+    <serverVersion>opendap/3.7</serverVersion>
+  </Opendap>
+    -->
+  
+  <!--
+  The WCS Service is on by default.
+  Also, off by default (and encouraged) is operating on a remote dataset.
+  <WCS>
+    <allow>true</allow>
+    <allowRemote>false</allowRemote>
+    <scour>15 min</scour>
+    <maxAge>30 min</maxAge>
+  </WCS>
+  -->
+
+  <!--
+  <WMS>
+    <allow>true</allow>
+    <allowRemote>false</allowRemote>
+    <maxImageWidth>2048</maxImageWidth>
+    <maxImageHeight>2048</maxImageHeight>
+  </WMS>
+  -->
+
+  <!--
+  <NCISO>
+    <ncmlAllow>true</ncmlAllow>
+    <uddcAllow>true</uddcAllow>
+    <isoAllow>true</isoAllow>
+  </NCISO>
+  -->
+
+  <!--
+  <NCSOS>
+    <allow>false</allow>
+  </NCSOS>
+  -->
+
+  <!-- CatalogGen service is off by default.
+  <CatalogGen>
+    <allow>false</allow>
+  </CatalogGen>
+   -->
+
+  <!-- DLwriter service is off by default.
+       As is support for operating on remote catalogs.
+  <DLwriter>
+    <allow>false</allow>
+    <allowRemote>false</allowRemote>
+  </DLwriter>
+   -->
+
+  <!-- DqcService is off by default.
+  <DqcService>
+    <allow>false</allow>
+  </DqcService>
+   -->
+
+  <!--
+   Link to a Viewer application on the HTML page:
+   <Viewer>my.package.MyViewer</Viewer>
+   -->
+
+   <!--
+   Add a DataSource - essentially an IOSP with access to Servlet request parameters
+   <datasetSource>my.package.DatsetSourceImpl</datasetSource>
+   -->
+
+  <!--
+    Configure how the NetCDF-4 C library is discovered and used.
+    libraryPath: The directory in which the native library is installed.
+    libraryName: The name of the native library. This will be used to locate the proper .DLL, .SO, or .DYLIB file
+      within the libraryPath directory.
+    useForReading: By default, the native library is only used for writing NetCDF-4 files; a pure-Java layer is
+      responsible for reading them. However, if this property is set to true, then it will be used for reading
+      NetCDF-4 (and HDF5) files as well.
+  -->
+  <!--
+  <Netcdf4Clibrary>
+    <libraryPath>/usr/local/lib</libraryPath>
+    <libraryName>netcdf</libraryName>
+    <useForReading>false</useForReading>
+  </Netcdf4Clibrary>
+  -->
+</threddsConfig>

--- a/docker/thredds/content-root/wmsConfig.xml
+++ b/docker/thredds/content-root/wmsConfig.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE wmsConfig SYSTEM "https://www.unidata.ucar.edu/schemas/thredds/dtd/ncwms/wmsConfig.dtd">
+<!--
+Detailed configuration of the WMS service.  This config file can be used to
+set default styling parameters for each dataset/variable, and to enable or disable
+the GetFeatureInfo operation.
+-->
+<wmsConfig>
+    <global>
+        <!-- These settings apply to all datasets unless overridden below -->
+        <defaults>
+            <!-- The global defaults. All elements are mandatory -->
+            <allowFeatureInfo>true</allowFeatureInfo>
+            <defaultColorScaleRange>-50 50</defaultColorScaleRange>
+            <defaultPaletteName>psu-viridis</defaultPaletteName>
+            <defaultNumColorBands>20</defaultNumColorBands>
+            <logScaling>false</logScaling>
+            <intervalTime>false</intervalTime>
+        </defaults>
+        <standardNames>
+            <!-- Use this section to set defaults per standard name -->
+            <!-- Units must come from the UDUNITS vocabulary -->
+            <standardName name="sea_water_potential_temperature" units="K">
+                <defaultColorScaleRange>268 308</defaultColorScaleRange>
+            </standardName>
+            <standardName name="sea_water_temperature" units="K">
+                <defaultColorScaleRange>268 308</defaultColorScaleRange>
+            </standardName>
+            <standardName name="mass_concentration_of_chlorophyll_in_sea_water" units="kg m-3">
+                <logScaling>true</logScaling>
+            </standardName>
+            <standardName name="air_temperature" units="K">
+                <allowFeatureInfo>true</allowFeatureInfo>
+                <defaultColorScaleRange>265 290</defaultColorScaleRange>
+                <defaultPaletteName>seq-YlOrRd</defaultPaletteName>
+                <defaultNumColorBands>20</defaultNumColorBands>
+                <logScaling>false</logScaling>
+                <intervalTime>true</intervalTime>
+            </standardName>
+            <standardName name="precipitation_flux" units="mm">
+                <allowFeatureInfo>true</allowFeatureInfo>
+                <defaultColorScaleRange>-40 40</defaultColorScaleRange>-->
+                <defaultPaletteName>div-BrBG</defaultPaletteName>
+                <defaultNumColorBands>20</defaultNumColorBands>
+                <logScaling>false</logScaling>
+                <intervalTime>true</intervalTime>
+            </standardName>
+        </standardNames>
+    </global>
+    <overrides>
+        <datasetPath pathSpec="testAll/20040503*_eta_211.nc">
+            <!-- Will apply to all paths that match the path spec above -->
+            <pathDefaults>
+                <!-- These will apply to all variables in this path unless overridden below -->
+                <allowFeatureInfo>false</allowFeatureInfo>
+                <defaultPaletteName>x-Occam</defaultPaletteName>
+            </pathDefaults>
+
+            <variables>
+                <!-- Configure variables individually according to their internal ID.
+                     This is the most specific setting and will override any others -->
+                <variable id="Z_sfc">
+                    <defaultColorScaleRange>0 2920</defaultColorScaleRange>
+                </variable>
+            </variables>
+        </datasetPath>
+        <datasetPath pathSpec="testAll/20040504*_eta_211.nc">
+            <!-- Will apply to all paths that match the path spec above -->
+            <pathDefaults>
+                <!-- These will apply to all variables in this path unless overridden below -->
+                <allowFeatureInfo>true</allowFeatureInfo>
+                <defaultPaletteName>seq-Reds</defaultPaletteName>
+            </pathDefaults>
+            <variables>
+                <!-- Configure variables individually according to their internal ID.
+                     This is the most specific setting and will override any others -->
+                <variable id="Z_sfc">
+                    <defaultColorScaleRange>0 3170</defaultColorScaleRange>
+                </variable>
+            </variables>
+        </datasetPath>
+    </overrides>
+</wmsConfig>

--- a/docker/thredds/content-root/wmsConfig.xml
+++ b/docker/thredds/content-root/wmsConfig.xml
@@ -37,6 +37,22 @@ the GetFeatureInfo operation.
                 <logScaling>false</logScaling>
                 <intervalTime>true</intervalTime>
             </standardName>
+            <standardName name="air_temperature_anomaly" units="K">
+                <allowFeatureInfo>true</allowFeatureInfo>
+                <defaultColorScaleRange>-3 3</defaultColorScaleRange>
+                <defaultPaletteName>seq-YlOrRd</defaultPaletteName>
+                <defaultNumColorBands>20</defaultNumColorBands>
+                <logScaling>false</logScaling>
+                <intervalTime>true</intervalTime>
+            </standardName>
+            <standardName name="air_temperature_anomaly_standard_error" units="K">
+                <allowFeatureInfo>true</allowFeatureInfo>
+                <defaultColorScaleRange>-1 1</defaultColorScaleRange>
+                <defaultPaletteName>seq-YlOrRd</defaultPaletteName>
+                <defaultNumColorBands>20</defaultNumColorBands>
+                <logScaling>false</logScaling>
+                <intervalTime>true</intervalTime>
+            </standardName>
             <standardName name="precipitation_flux" units="mm">
                 <allowFeatureInfo>true</allowFeatureInfo>
                 <defaultColorScaleRange>-40 40</defaultColorScaleRange>-->

--- a/poetry.lock
+++ b/poetry.lock
@@ -19,7 +19,7 @@ vine = ">=1.1.3,<5.0.0a1"
 name = "anyio"
 version = "4.3.0"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
@@ -814,7 +814,7 @@ files = [
 name = "exceptiongroup"
 version = "1.2.0"
 description = "Backport of PEP 654 (exception groups)"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -871,7 +871,7 @@ files = [
 name = "h11"
 version = "0.14.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -883,7 +883,7 @@ files = [
 name = "httpcore"
 version = "1.0.3"
 description = "A minimal low-level HTTP client."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
@@ -903,14 +903,14 @@ trio = ["trio (>=0.22.0,<0.24.0)"]
 
 [[package]]
 name = "httpx"
-version = "0.26.0"
+version = "0.27.0"
 description = "The next generation HTTP client."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "httpx-0.26.0-py3-none-any.whl", hash = "sha256:8915f5a3627c4d47b73e8202457cb28f1266982d1159bd5779d86a80c0eab1cd"},
-    {file = "httpx-0.26.0.tar.gz", hash = "sha256:451b55c30d5185ea6b23c2c793abf9bb237d2a7dfb901ced6ff69ad37ec1dfaf"},
+    {file = "httpx-0.27.0-py3-none-any.whl", hash = "sha256:71d5465162c13681bff01ad59b2cc68dd838ea1f10e51574bac27103f00c91a5"},
+    {file = "httpx-0.27.0.tar.gz", hash = "sha256:a0cb88a46f32dc874e04ee956e4c2764aba2aa228f650b06788ba6bda2962ab5"},
 ]
 
 [package.dependencies]
@@ -1880,7 +1880,7 @@ files = [
 name = "sniffio"
 version = "1.3.0"
 description = "Sniff out which async library your code is running under"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -2283,4 +2283,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "1b996c98d861dfc3c1238b03f10f520d4f4f9d733c05a0dd6600e1a19592dc7a"
+content-hash = "1fad407bb1c0f0d077ed051b1a1641ebfc03d0433c61ffec175bf814c5b1f7f7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ packages = [
     {include = "forecastattributes", from = "backend/padoa"},
     {include = "places", from = "backend/padoa"},
     {include = "thredds", from = "backend/padoa"},
+    {include = "arpav_ppcv"},
 ]
 
 [tool.poetry.dependencies]
@@ -47,6 +48,8 @@ pytest-django = "^4.8.0"
 dagger-io = "^0.9.10"
 ruff = "^0.2.2"
 
+[tool.poetry.scripts]
+arpav-ppcv = "arpav_ppcv.main:app"
 
 [tool.pytest.ini_options]
 addopts = "--verbose --cov --cov-branch --log-level=warning"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ requests = "2.23.0"
 python-dateutil = "2.8.1"
 pytz = "2020.1"
 django-redis-sessions = "0.6.1"
+httpx = "^0.27.0"
+anyio = "^4.3.0"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
This PR adds a set of CLI commands to download data from the production THREDDS server in order to set up a local testing environment. It also adds relevant configuration files for running a local THREDDS server via docker compose and serve the files.

- fixes #33 