### PR TITLE
Improved proxying of WMS requests for uncertainty-related layers

### DIFF
--- a/arpav_ppcv/webapp/v2/routers/thredds.py
+++ b/arpav_ppcv/webapp/v2/routers/thredds.py
@@ -164,12 +164,20 @@ async def wms_endpoint(
         parsed_url = urllib.parse.urlparse(base_wms_url)
         logger.info(f"{base_wms_url=}")
         query_params = {k.lower(): v for k, v in request.query_params.items()}
+        logger.debug(f"original query params: {query_params=}")
         if query_params.get("request") in ("GetMap", "GetLegendGraphic"):
             query_params = thredds_utils.tweak_wms_get_map_request(
                 query_params,
                 ds_config,
                 settings.thredds_server.uncertainty_visualization_scale_range
             )
+        elif query_params.get("request") == "GetCapabilities":
+            # TODO: need to tweak the reported URLs
+            # the response to a GetCapabilities request includes URLs for each
+            # operation and some clients (like QGIS) use them for GetMap and
+            # GetLegendGraphic - need to ensure these do not refer to the underlying
+            # THREDDS server
+            ...
         logger.debug(f"{query_params=}")
         wms_url = parsed_url._replace(
             query=urllib.parse.urlencode(

--- a/docker/compose.dev.yaml
+++ b/docker/compose.dev.yaml
@@ -22,6 +22,50 @@ services:
       ARPAV_PPCV__DJANGO_APP__THREDDS__PORT: 8081
       ARPAV_PPCV__DJANGO_APP__REDIS_DSN: redis://redis:6379
       ARPAV_PPCV__DJANGO_APP__SECRET_KEY: some-dev-key
+      ARPAV_PPCV__THREDDS_SERVER__BASE_URL: http://thredds:8080/thredds
+      ARPAV_PPCV__THREDDS_SERVER__DATASETS: >
+        {
+          "uncertainty_test_giovanni": {
+            "thredds_url_pattern": "tests/giovanni-sample/tas_avgagree_anom_tw2_rcp26_DJF_VFVGTAAn.nc",
+            "palette": "uncert-stippled/seq-YlOrRd",
+            "range": [1, 6]
+          },
+          "uncertainty_test": {
+            "thredds_url_pattern": "tests/test-script-agree.nc",
+            "palette": "uncert-stippled/seq-YlOrRd",
+            "range": [1, 6]
+          },
+          "tas_absolute": {
+            "thredds_url_pattern": "ensymbc/tas_avg_{scenario}_{year_period}_ts19762100_ls.nc",
+            "allowed_values": {
+              "scenario": [
+                "rcp26",
+                "rcp45",
+                "rcp85"
+              ],
+              "year_period": [
+                "winter",
+                "spring",
+                "summer",
+                "autumn"
+              ]
+            },
+            "unit": "ºC",
+            "palette": "default/seq-YlOrRd",
+            "range": [-3, 32]
+          },
+          "tas_anomaly": {
+            "thredds_url_pattern": "ensembletwbc/tas_avg_anom_{time_window}_{scenario}_{year_period}.nc",
+            "allowed_values": {
+              "time_window": ["tw1", "tw2"],
+              "scenario": ["rcp26"],
+              "year_period": ["annual"]
+            },
+            "unit": "ºC",
+            "palette": "seq-YlOrRd",
+            "range": [0, 6]
+          }
+        }
     volumes:
       - type: bind
         source: $PWD


### PR DESCRIPTION
This PR refactors a bit the way that WMS `GetLegendGraphic` and `GetMap` requests are overridden by our code in order to provide suitable query parameters to the THREDDS server - this is used in the context of visualizing the uncertainty and also the actual data for those datasets which are served via THREDDS.