### PR TITLE
Updated compose files for using traefik-related labels in staging

### DIFF
--- a/docker/compose.dev.yaml
+++ b/docker/compose.dev.yaml
@@ -14,6 +14,8 @@ services:
     image: "ghcr.io/geobeyond/arpav-ppcv-backend/arpav-ppcv-backend:${CURRENT_GIT_BRANCH:-latest}"
     environment:
       ARPAV_PPCV__DEBUG: true
+      ARPAV_PPCV__BIND_HOST: 0.0.0.0
+      ARPAV_PPCV__BIND_PORT: 5001
       ARPAV_PPCV__PUBLIC_URL: http://localhost:5001
       ARPAV_PPCV__DB_DSN: postgresql://arpav:arpavpassword@db:5432/arpav_ppcv
       ARPAV_PPCV__TEST_DB_DSN: postgresql://arpavtest:arpavtestpassword@test-db:5432/arpav_ppcv_test
@@ -66,6 +68,9 @@ services:
             "range": [0, 6]
           }
         }
+    ports:
+      - target: 5001
+        published: 5001
     volumes:
       - type: bind
         source: $PWD

--- a/docker/compose.staging.yaml
+++ b/docker/compose.staging.yaml
@@ -26,6 +26,13 @@ services:
   webapp:
     env_file:
       - *env-file-webapp
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.arpav-backend.entrypoints=webSecure"
+      - "traefik.http.routers.arpav-backend.tls=true"
+      - "traefik.http.routers.arpav-backend.tls.certResolver=letsEncryptResolver"
+      - "traefik.http.routers.arpav-backend.rule=Host(`arpav.geobeyond.dev`)"
+      - "traefik.http.services.arpav-backend-service.loadbalancer.server.port=5001"
 
   legacy-db:
     env_file:

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -43,12 +43,6 @@ services:
 
   webapp:
     image: "ghcr.io/geobeyond/arpav-ppcv-backend/arpav-ppcv-backend:latest"
-    environment:
-      ARPAV_PPCV__BIND_HOST: 0.0.0.0
-      ARPAV_PPCV__BIND_PORT: 5001
-    ports:
-      - target: 5001
-        published: 5001
     depends_on:
       legacy-db:
         condition: service_healthy


### PR DESCRIPTION
This PR makes some tweaks to existing compose files in order to make use of traefik as the reverse proxy in the staging environment.

- fixes #39