### PR TITLE
Return GeoJSON FeatureCollection from stations list API endpoint

### DIFF
--- a/arpav_ppcv/schemas/fields.py
+++ b/arpav_ppcv/schemas/fields.py
@@ -1,0 +1,16 @@
+import json
+from typing import Annotated
+
+import geoalchemy2
+import shapely.io
+from pydantic.functional_serializers import PlainSerializer
+
+def serialize_wkbelement(wkbelement: geoalchemy2.WKBElement):
+    geom = shapely.io.from_wkb(bytes(wkbelement.data))
+    return json.loads(shapely.io.to_geojson(geom))
+
+
+WkbElement = Annotated[
+    geoalchemy2.WKBElement,
+    PlainSerializer(serialize_wkbelement, return_type=dict, when_used="json")
+]

--- a/arpav_ppcv/schemas/models.py
+++ b/arpav_ppcv/schemas/models.py
@@ -1,29 +1,14 @@
 import datetime as dt
-import json
 import uuid
-from typing import (
-    Annotated,
-    Optional,
-)
+from typing import Optional
 
 import geojson_pydantic
 import geoalchemy2
 import pydantic
 import sqlalchemy
-import shapely.io
 import sqlmodel
-from pydantic.functional_serializers import PlainSerializer
 
-
-def serialize_wkbelement(wkbelement: geoalchemy2.WKBElement):
-    geom = shapely.io.from_wkb(bytes(wkbelement.data))
-    return json.loads(shapely.io.to_geojson(geom))
-
-
-WkbElement = Annotated[
-    geoalchemy2.WKBElement,
-    PlainSerializer(serialize_wkbelement, return_type=dict, when_used="json")
-]
+from . import fields
 
 
 class StationBase(sqlmodel.SQLModel):
@@ -33,7 +18,7 @@ class StationBase(sqlmodel.SQLModel):
         default_factory=uuid.uuid4,
         primary_key=True
     )
-    geom: WkbElement = sqlmodel.Field(
+    geom: fields.WkbElement = sqlmodel.Field(
         sa_column=sqlalchemy.Column(
             geoalchemy2.Geometry(
                 srid=4326,

--- a/arpav_ppcv/webapp/api_v2/schemas/base.py
+++ b/arpav_ppcv/webapp/api_v2/schemas/base.py
@@ -83,7 +83,7 @@ class WebResourceList(base_schemas.ResourceList):
             del filters["limit"]
         if "offset" in filters.keys():
             del filters["offset"]
-        pagination_urls = _get_pagination_urls(
+        pagination_urls = get_pagination_urls(
             request.url_for(cls.path_operation_name),
             num_returned_records,
             filtered_total,
@@ -104,7 +104,7 @@ class WebResourceList(base_schemas.ResourceList):
         )
 
 
-def _get_pagination_urls(
+def get_pagination_urls(
         base_url: str,
         returned_records: int,
         total_records: int,

--- a/arpav_ppcv/webapp/api_v2/schemas/geojson/base.py
+++ b/arpav_ppcv/webapp/api_v2/schemas/geojson/base.py
@@ -1,0 +1,82 @@
+import typing
+
+import geojson_pydantic
+import pydantic
+from fastapi.requests import Request
+
+from ..base import (
+    ListLinks,
+    get_pagination_urls,
+)
+
+F = typing.TypeVar("F", bound="ApiReadableModelAsFeature")
+
+
+@typing.runtime_checkable
+class ApiReadableModelAsFeature(typing.Protocol):
+    """Protocol to be used by all schema models that represent API resources.
+
+    It includes the `from_db_instance()` class method, which is to be used for
+    constructing instances.
+    """
+
+    @classmethod
+    def from_db_instance(  # noqa: D102
+            cls: typing.Type[F], db_instance: pydantic.BaseModel, request: Request
+    ) -> F:
+        ...
+
+
+class ArpavFeatureCollection(geojson_pydantic.FeatureCollection):
+    list_item_type: typing.ClassVar[typing.Type[ApiReadableModelAsFeature]]
+    path_operation_name: typing.ClassVar[str]
+
+    type: str = "FeatureCollection"
+    links: ListLinks
+
+    @classmethod
+    def from_items(
+            cls,
+            items: typing.Sequence[pydantic.BaseModel],
+            request: Request,
+            *,
+            limit: int,
+            offset: int,
+            filtered_total: int,
+            unfiltered_total: int
+    ) -> "cls":
+        return cls(
+            features=[
+                cls.list_item_type.from_db_instance(i, request)
+                for i in items
+            ],
+            links=cls._get_list_links(
+                request, limit, offset, filtered_total, len(items)),
+            numberMatched=filtered_total,
+            numberTotal=unfiltered_total,
+            numberReturned=len(items),
+        )
+
+    @classmethod
+    def _get_list_links(
+            cls,
+            request: Request,
+            limit: int,
+            offset: int,
+            filtered_total: int,
+            num_returned_records: int
+    ) -> ListLinks:
+        filters = dict(request.query_params)
+        if "limit" in filters.keys():
+            del filters["limit"]
+        if "offset" in filters.keys():
+            del filters["offset"]
+        pagination_urls = get_pagination_urls(
+            request.url_for(cls.path_operation_name),
+            num_returned_records,
+            filtered_total,
+            limit,
+            offset,
+            **filters,
+        )
+        return ListLinks(**pagination_urls)

--- a/arpav_ppcv/webapp/api_v2/schemas/geojson/observations.py
+++ b/arpav_ppcv/webapp/api_v2/schemas/geojson/observations.py
@@ -12,7 +12,8 @@ from .base import ArpavFeatureCollection
 class StationFeatureCollectionItem(geojson_pydantic.Feature):
     model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
 
-    type: str = "Point"
+    type: str = "Feature"
+    id: pydantic.UUID4
     geometry: fields.WkbElement
     links: list[str]
 
@@ -24,8 +25,14 @@ class StationFeatureCollectionItem(geojson_pydantic.Feature):
     ) -> "StationFeatureCollectionItem":
         url = request.url_for("get_station", **{"station_id": instance.id})
         return cls(
+            id=instance.id,
             geometry=instance.geom,
-            properties=instance.model_dump(exclude={"geom"}),
+            properties=instance.model_dump(
+                exclude={
+                    "id",
+                    "geom",
+                }
+            ),
             links=[str(url)]
         )
 

--- a/arpav_ppcv/webapp/api_v2/schemas/geojson/observations.py
+++ b/arpav_ppcv/webapp/api_v2/schemas/geojson/observations.py
@@ -1,0 +1,35 @@
+from fastapi import Request
+import geojson_pydantic
+import pydantic
+
+from .....schemas import (
+    models as app_models,
+    fields,
+)
+from .base import ArpavFeatureCollection
+
+
+class StationFeatureCollectionItem(geojson_pydantic.Feature):
+    model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
+
+    type: str = "Point"
+    geometry: fields.WkbElement
+    links: list[str]
+
+    @classmethod
+    def from_db_instance(
+            cls,
+            instance: app_models.Station,
+            request: Request,
+    ) -> "StationFeatureCollectionItem":
+        url = request.url_for("get_station", **{"station_id": instance.id})
+        return cls(
+            geometry=instance.geom,
+            properties=instance.model_dump(exclude={"geom"}),
+            links=[str(url)]
+        )
+
+
+class StationFeatureCollection(ArpavFeatureCollection):
+    path_operation_name = "list_stations"
+    list_item_type = StationFeatureCollectionItem

--- a/arpav_ppcv/webapp/api_v2/schemas/observations.py
+++ b/arpav_ppcv/webapp/api_v2/schemas/observations.py
@@ -1,4 +1,5 @@
 import logging
+
 import pydantic
 from fastapi import Request
 


### PR DESCRIPTION
This PR changes the default response type of `/api/v2/observations/stations` (AKA the stations list endpoint) to be a GeoJSON feature collection.

The proposed implementation makes the default response media type be `application/geo+json`. It is still possible to get the previous response type by simply passing the accept header `Accept: application/json` - we can decide later if it is worth keeping the plain JSON response or just have the GeoJSON.

Example request using the [httpie](https://httpie.io/) client (the `limit` query parameter is passed just for getting a small response that I can paste here:

```
http localhost:5001/api/v2/observations/stations limit==2
```

and corresponding response

```json
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "geometry": {
        "type": "Point",
        "coordinates": [
          12.28232702,
          45.88132477
        ]
      },
      "properties": {
        "code": "100",
        "name": "Conegliano",
        "type_": "agro",
        "altitude_m": 90
      },
      "id": "4eb8a422-22f1-4bd5-827d-763ba84891f0",
      "links": [
        "http://localhost:5001/api/v2/observations/stations/4eb8a422-22f1-4bd5-827d-763ba84891f0"
      ]
    },
    {
      "type": "Feature",
      "geometry": {
        "type": "Point",
        "coordinates": [
          12.36910037,
          44.9173386
        ]
      },
      "properties": {
        "code": "101",
        "name": "Porto Tolle - Pradon",
        "type_": "agro",
        "altitude_m": -3
      },
      "id": "72d079c3-b071-4e31-87e7-bcebafc0d220",
      "links": [
        "http://localhost:5001/api/v2/observations/stations/72d079c3-b071-4e31-87e7-bcebafc0d220"
      ]
    }
  ],
  "links": {
    "self": "http://localhost:5001/api/v2/observations/stations?limit=2&offset=0",
    "next": "http://localhost:5001/api/v2/observations/stations?limit=2&offset=2",
    "previous": null,
    "first": "http://localhost:5001/api/v2/observations/stations?limit=2&offset=0",
    "last": "http://localhost:5001/api/v2/observations/stations?limit=2&offset=182"
  }
}
```
