### PR TITLE
Added CORS middleware to API v2 app

### DIFF
--- a/arpav_ppcv/config.py
+++ b/arpav_ppcv/config.py
@@ -169,6 +169,9 @@ class ArpavPpcvSettings(BaseSettings):  # noqa
     log_config_file: Path | None = None
     session_secret_key: str = "changeme"
     admin_user: AdminUserSettings = AdminUserSettings()
+    cors_origins: list[str] = ["*"]
+    cors_methods: list[str] = ["GET"]
+    allow_cors_credentials: bool = False
 
     @pydantic.model_validator(mode="after")
     def ensure_test_db_dsn(self):

--- a/arpav_ppcv/webapp/api_v2/app.py
+++ b/arpav_ppcv/webapp/api_v2/app.py
@@ -1,4 +1,5 @@
 import fastapi
+from fastapi.middleware.cors import CORSMiddleware
 
 from ... import config
 from .routers.coverages import router as coverages_router
@@ -20,6 +21,13 @@ def create_app(settings: config.ArpavPpcvSettings) -> fastapi.FastAPI:
             "url": settings.contact.url,
             "email": settings.contact.email,
         },
+    )
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=settings.cors_origins,
+        allow_credentials=settings.allow_cors_credentials,
+        allow_methods=settings.cors_methods,
+        allow_headers=["*"],
     )
     app.include_router(
         base_router,


### PR DESCRIPTION
This PR enables the CORS middleware on the V2 API application. It follows the [docs on the relevant FastAPI section](https://fastapi.tiangolo.com/tutorial/cors/).

CORS origins, methods and auth are hooked up to our settings and can be configured by means of env variables. For security purposes, the default settings disallow all origins, disallow all methods and disable CORS auth.

The dev compose file enables all origins and all methods.


##### NOTE
The staging environment needs to be updated to also enable the relevant settings in order to this to work as expected on staging.

---

- fixes #101