### PR TITLE
Added bootstrap cov confs for cdd and r95ptot

### DIFF
--- a/arpav_ppcv/bootstrapper/cliapp.py
+++ b/arpav_ppcv/bootstrapper/cliapp.py
@@ -12,8 +12,10 @@ from ..schemas.coverages import (
     ConfigurationParameterValueCreateEmbeddedInConfigurationParameter,
 )
 
+from .coverage_configurations.cdd import generate_cdd_configurations
 from .coverage_configurations.fd import generate_fd_configurations
 from .coverage_configurations.pr import generate_pr_configurations
+from .coverage_configurations.r95ptot import generate_r95ptot_configurations
 from .coverage_configurations.snwdays import generate_snwdays_configurations
 from .coverage_configurations.su30 import generate_su30_configurations
 from .coverage_configurations.tas import generate_tas_configurations
@@ -164,12 +166,14 @@ def bootstrap_coverage_configurations(
             for pv in all_conf_param_values
         }
     coverage_configurations = []
+    coverage_configurations.extend(generate_cdd_configurations(conf_param_values))
     coverage_configurations.extend(
         generate_fd_configurations(conf_param_values, variables)
     )
     coverage_configurations.extend(
         generate_pr_configurations(conf_param_values, variables)
     )
+    coverage_configurations.extend(generate_r95ptot_configurations(conf_param_values))
     coverage_configurations.extend(generate_snwdays_configurations(conf_param_values))
     coverage_configurations.extend(
         generate_su30_configurations(conf_param_values, variables)

--- a/arpav_ppcv/bootstrapper/coverage_configurations/cdd.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/cdd.py
@@ -1,0 +1,356 @@
+"""
+- [x] cdd_30yr_anomaly_annual_agree_model_ensemble
+- [x] cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17
+- [x] cdd_30yr_anomaly_annual_model_ec_earth_racmo22e
+- [x] cdd_30yr_anomaly_annual_model_ec_earth_rca4
+- [x] cdd_30yr_anomaly_annual_model_hadgem2_es_racmo22e
+- [x] cdd_30yr_anomaly_annual_model_mpi_esm_lr_remo2009
+
+"""
+from ...schemas.coverages import (
+    CoverageConfigurationCreate,
+    ConfigurationParameterPossibleValueCreate,
+)
+
+
+def generate_cdd_configurations(
+    conf_param_values,
+) -> list[CoverageConfigurationCreate]:
+    return [
+        CoverageConfigurationCreate(
+            name="cdd_30yr_anomaly_annual_agree_model_ensemble",
+            netcdf_main_dataset_name="cdd",
+            thredds_url_pattern="ensembletwbc/std/clipped/eca_cdd_an_avgagree_{time_window}_{scenario}_{year_period}_ls_VFVGTAA.nc",
+            unit="gg",
+            palette="uncert-stippled/div-BrBg-inv",
+            color_scale_min=-40,
+            color_scale_max=40,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw1")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw2")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "DJF")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "MAM")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "JJA")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "SON")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
+            netcdf_main_dataset_name="cdd",
+            thredds_url_pattern="indici5rcm/clipped/eca_cdd_an_EC-EARTH_CCLM4-8-17_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc",
+            unit="gg",
+            palette="default/div-BrBg-inv",
+            color_scale_min=-40,
+            color_scale_max=40,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw1")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw2")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "DJF")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "MAM")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "JJA")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "SON")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="cdd_30yr_anomaly_annual_model_ec_earth_racmo22e",
+            netcdf_main_dataset_name="cdd",
+            thredds_url_pattern="indici5rcm/clipped/eca_cdd_an_EC-EARTH_RACMO22E_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc",
+            unit="gg",
+            palette="default/div-BrBg-inv",
+            color_scale_min=-40,
+            color_scale_max=40,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw1")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw2")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "DJF")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "MAM")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "JJA")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "SON")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="cdd_30yr_anomaly_annual_model_ec_earth_rca4",
+            netcdf_main_dataset_name="cdd",
+            thredds_url_pattern="indici5rcm/clipped/eca_cdd_an_EC-EARTH_RCA4_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc",
+            unit="gg",
+            palette="default/div-BrBg-inv",
+            color_scale_min=-40,
+            color_scale_max=40,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw1")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw2")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "DJF")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "MAM")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "JJA")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "SON")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="cdd_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
+            netcdf_main_dataset_name="cdd",
+            thredds_url_pattern="indici5rcm/clipped/eca_cdd_an_HadGEM2-ES_RACMO22E_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc",
+            unit="gg",
+            palette="default/div-BrBg-inv",
+            color_scale_min=-40,
+            color_scale_max=40,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw1")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw2")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "DJF")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "MAM")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "JJA")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "SON")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="cdd_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
+            netcdf_main_dataset_name="cdd",
+            thredds_url_pattern="indici5rcm/clipped/eca_cdd_an_MPI-ESM-LR_REMO2009_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc",
+            unit="gg",
+            palette="default/div-BrBg-inv",
+            color_scale_min=-40,
+            color_scale_max=40,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw1")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw2")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "DJF")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "MAM")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "JJA")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "SON")
+                    ].id
+                ),
+            ],
+        ),
+    ]

--- a/arpav_ppcv/bootstrapper/coverage_configurations/r95ptot.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/r95ptot.py
@@ -1,0 +1,356 @@
+"""
+- [x] r95ptot_30yr_anomaly_annual_agree_model_ensemble
+- [x] r95ptot_30yr_anomaly_annual_model_ec_earth_cclm4_8_17
+- [x] r95ptot_30yr_anomaly_annual_model_ec_earth_racmo22e
+- [x] r95ptot_30yr_anomaly_annual_model_ec_earth_rca4
+- [x] r95ptot_30yr_anomaly_annual_model_hadgem2_es_racmo22e
+- [x] r95ptot_30yr_anomaly_annual_model_mpi_esm_lr_remo2009
+
+"""
+from ...schemas.coverages import (
+    CoverageConfigurationCreate,
+    ConfigurationParameterPossibleValueCreate,
+)
+
+
+def generate_r95ptot_configurations(
+    conf_param_values,
+) -> list[CoverageConfigurationCreate]:
+    return [
+        CoverageConfigurationCreate(
+            name="r95ptot_30yr_anomaly_annual_agree_model_ensemble",
+            netcdf_main_dataset_name="r95ptot",
+            thredds_url_pattern="ensembletwbc/std/clipped/pr_change_cumulative_check_avgagree_{time_window}_{scenario}_{year_period}_VFVGTAA.nc",
+            unit="%",
+            palette="uncert-stippled/div-BrBg",
+            color_scale_min=-160,
+            color_scale_max=160,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw1")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw2")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "DJF")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "MAM")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "JJA")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "SON")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="r95ptot_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
+            netcdf_main_dataset_name="r95ptot",
+            thredds_url_pattern="indici5rcm/clipped/pr_change_cumulative_EC-EARTH_CCLM4-8-17_{year_period}_{scenario}_{time_window}_VFVGTAA.nc",
+            unit="%",
+            palette="default/div-BrBg",
+            color_scale_min=-160,
+            color_scale_max=160,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw1")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw2")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "DJF")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "MAM")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "JJA")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "SON")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="r95ptot_30yr_anomaly_annual_model_ec_earth_racmo22e",
+            netcdf_main_dataset_name="r95ptot",
+            thredds_url_pattern="indici5rcm/clipped/pr_change_cumulative_EC-EARTH_RACMO22E_{year_period}_{scenario}_{time_window}_VFVGTAA.nc",
+            unit="%",
+            palette="default/div-BrBg",
+            color_scale_min=-160,
+            color_scale_max=160,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw1")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw2")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "DJF")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "MAM")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "JJA")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "SON")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="r95ptot_30yr_anomaly_annual_model_ec_earth_rca4",
+            netcdf_main_dataset_name="r95ptot",
+            thredds_url_pattern="indici5rcm/clipped/pr_change_cumulative_EC-EARTH_RCA4_{year_period}_{scenario}_{time_window}_VFVGTAA.nc",
+            unit="%",
+            palette="default/div-BrBg",
+            color_scale_min=-160,
+            color_scale_max=160,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw1")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw2")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "DJF")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "MAM")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "JJA")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "SON")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="r95ptot_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
+            netcdf_main_dataset_name="r95ptot",
+            thredds_url_pattern="indici5rcm/clipped/pr_change_cumulative_HadGEM2-ES_RACMO22E_{year_period}_{scenario}_{time_window}_VFVGTAA.nc",
+            unit="%",
+            palette="default/div-BrBg",
+            color_scale_min=-160,
+            color_scale_max=160,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw1")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw2")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "DJF")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "MAM")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "JJA")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "SON")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="r95ptot_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
+            netcdf_main_dataset_name="r95ptot",
+            thredds_url_pattern="indici5rcm/clipped/pr_change_cumulative_MPI-ESM-LR_REMO2009_{year_period}_{scenario}_{time_window}_VFVGTAA.nc",
+            unit="%",
+            palette="default/div-BrBg",
+            color_scale_min=-160,
+            color_scale_max=160,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw1")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw2")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "DJF")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "MAM")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "JJA")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "SON")
+                    ].id
+                ),
+            ],
+        ),
+    ]


### PR DESCRIPTION
This PR adds bootstrap coverage configurations for the missing `CDD` and `R95pTOT` variables.

---

- fixes #115 
- fixes #116 