### PR TITLE
Modify capabilities response to include correct URLs

### DIFF
--- a/arpav_ppcv/webapp/api_v2/routers/coverages.py
+++ b/arpav_ppcv/webapp/api_v2/routers/coverages.py
@@ -2,6 +2,7 @@ import logging
 import math
 import urllib.parse
 import uuid
+from xml.etree import ElementTree as et
 from typing import (
     Annotated,
     Optional,
@@ -209,13 +210,6 @@ async def wms_endpoint(
                         settings.thredds_server.uncertainty_visualization_scale_range
                     ),
                 )
-            elif query_params.get("request") == "GetCapabilities":
-                # TODO: need to tweak the reported URLs
-                # the response to a GetCapabilities request includes URLs for each
-                # operation and some clients (like QGIS) use them for GetMap and
-                # GetLegendGraphic - need to ensure these do not refer to the underlying
-                # THREDDS server
-                ...
             logger.debug(f"{query_params=}")
             wms_url = parsed_url._replace(
                 query=urllib.parse.urlencode(
@@ -242,14 +236,74 @@ async def wms_endpoint(
                     status_code=status.HTTP_502_BAD_GATEWAY,
                 ) from err
             else:
+                if query_params.get("request") == "GetCapabilities":
+                    response_content = _modify_capabilities_response(
+                        wms_response.text, str(request.url).partition("?")[0]
+                    )
+                else:
+                    response_content = wms_response.content
                 response = Response(
-                    content=wms_response.content,
+                    content=response_content,
                     status_code=wms_response.status_code,
                     headers=dict(wms_response.headers),
                 )
             return response
     else:
         raise HTTPException(status_code=400, detail="Invalid coverage_identifier")
+
+
+def _modify_capabilities_response(
+    raw_response_content: str,
+    wms_public_url: str,
+) -> bytes:
+    ns = {
+        "wms": "http://www.opengis.net/wms",
+        "xlink": "http://www.w3.org/1999/xlink",
+        "xsi": "http://www.w3.org/2001/XMLSchema-instance",
+        "edal": "http://reading-escience-centre.github.io/edal-java/wms",
+    }
+    et.register_namespace("", ns["wms"])
+    for prefix, uri in {k: v for k, v in ns.items() if k != "wms"}.items():
+        et.register_namespace(prefix, uri)
+    root = et.fromstring(raw_response_content)
+    service_el = root.findall(f"{{{ns['wms']}}}Service")[0]
+
+    # Remove the OnlineResource element, since we do not expose other
+    # internal THREDDS server URLs
+    for online_resource_el in service_el.findall(f"{{{ns['wms']}}}OnlineResource"):
+        service_el.remove(online_resource_el)
+    request_el = root.findall(f"{{{ns['wms']}}}Capability/{{{ns['wms']}}}Request")[0]
+
+    # modify URLs for GetCapabilities, GetMap and GetFeatureInfo methods
+    get_caps_el = request_el.findall(f"{{{ns['wms']}}}GetCapabilities")[0]
+    get_map_el = request_el.findall(f"{{{ns['wms']}}}GetMap")[0]
+    get_feature_info_el = request_el.findall(f"{{{ns['wms']}}}GetFeatureInfo")[0]
+    for parent_el in (get_caps_el, get_map_el, get_feature_info_el):
+        resource_el = parent_el.findall(
+            f"{{{ns['wms']}}}DCPType/"
+            f"{{{ns['wms']}}}HTTP/"
+            f"{{{ns['wms']}}}Get/"
+            f"{{{ns['wms']}}}OnlineResource"
+        )[0]
+        resource_el.set(f"{{{ns['xlink']}}}href", wms_public_url)
+    # for each relevant layer, modify GetLegendGraphic urls
+    for layer_el in root.findall(f".//{{{ns['wms']}}}Layer"):
+        for legend_online_resource_el in layer_el.findall(
+            f"./"
+            f"{{{ns['wms']}}}Style/"
+            f"{{{ns['wms']}}}LegendURL/"
+            f"{{{ns['wms']}}}OnlineResource"
+        ):
+            attribute_name = f"{{{ns['xlink']}}}href"
+            private_url = legend_online_resource_el.get(attribute_name)
+            url_query = private_url.partition("?")[-1]
+            new_url = "?".join((wms_public_url, url_query))
+            legend_online_resource_el.set(f"{{{ns['xlink']}}}href", new_url)
+    return et.tostring(
+        root,
+        encoding="utf-8",
+    )
+    # return raw_response_content.encode()
 
 
 @router.get("/time-series/{coverage_identifier}", response_model=TimeSeriesList)

--- a/tests/notebooks/generic.ipynb
+++ b/tests/notebooks/generic.ipynb
@@ -2,9 +2,10 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "dbcc00b1-2fc1-43ff-9549-ebca8cf03262",
    "metadata": {},
+   "outputs": [],
    "source": [
     "%matplotlib widget\n",
     "\n",
@@ -37,28 +38,119 @@
     "settings = get_settings()\n",
     "session = sqlmodel.Session(db.get_engine(settings))\n",
     "http_client = httpx.Client()"
-   ],
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "a59ab0ae-00cd-4bb4-88d7-75b5d1f19d49",
-   "metadata": {},
-   "source": [
-    "measurements, _ = db.list_seasonal_measurements(session)"
-   ],
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "d4f70628-8b3f-4060-bf44-3bbd929f8784",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "measurements[0].variable.name"
+    "capabilities_response = httpx.get(\n",
+    "    \"http://webapp:5001/api/v2/coverages/wms/tas_seasonal_absolute_model_ensemble-rcp26-DJF\",\n",
+    "    params={\n",
+    "        \"service\": \"WMS\",\n",
+    "        \"version\": \"1.3.0\",\n",
+    "        \"request\": \"GetCapabilities\"\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "58c874ad-d1fb-4dba-8ced-ec5101bd43d1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "b'<?xml version=\"1.0\" encoding=\"UTF-8\"?>\\n<WMS_Capabilities\\n        version=\"1.3.0\"\\n        updateSequence=\"2024-06-06T15:38:58.994Z\"\\n        xmlns=\"http://www.opengis.net/wms\"\\n        xmlns:xlink=\"http://www.w3.org/1999/xlink\"\\n        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\\n        xmlns:edal=\"http://reading-escience-centre.github.io/edal-java/wms\"\\n        xsi:schemaLocation=\"http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd\">\\n    <Service>\\n        <Name>WMS</Name>\\n        <Title>ARPAV test server</Title>\\n        <Abstract>Regional climate models and data</Abstract>\\n        <KeywordList>\\n            <Keyword>meteorology</Keyword>\\n            <Keyword> atmosphere</Keyword>\\n            <Keyword> climate</Keyword>\\n            <Keyword> ocean</Keyword>\\n            <Keyword> earth science</Keyword>\\n        </KeywordList>\\n        <OnlineResource xlink:type=\"simple\" xlink:href=\"http://thredds:8080/thredds/wms/ensymbc/clipped/tas_avg_rcp26_DJF_ts19762100_ls_VFVG.nc\"/>\\n        <ContactInformation>\\n            <ContactPersonPrimary>\\n                <ContactPerson>Support</ContactPerson>\\n                <ContactOrganization>Geobeyond</ContactOrganization>\\n            </ContactPersonPrimary>\\n            <ContactVoiceTelephone></ContactVoiceTelephone>\\n            <ContactElectronicMailAddress>info@geobeyond.it</ContactElectronicMailAddress>\\n        </ContactInformation>\\n        <Fees>none</Fees>\\n        <AccessConstraints>none</AccessConstraints>\\n        <LayerLimit>1</LayerLimit>\\n        <MaxWidth>2048</MaxWidth>\\n        <MaxHeight>2048</MaxHeight>\\n    </Service>\\n    <Capability>\\n        <Request>\\n            <GetCapabilities>\\n                <Format>text/xml</Format>\\n                <DCPType>\\n                    <HTTP>\\n                        <Get>\\n                            <OnlineResource xlink:type=\"simple\" xlink:href=\"http://thredds:8080/thredds/wms/ensymbc/clipped/tas_avg_rcp26_DJF_ts19762100_ls_VFVG.nc\"/>\\n                        </Get>\\n                    </HTTP>\\n                </DCPType>\\n            </GetCapabilities>\\n            <GetMap>\\n                <Format>image/png</Format>\\n                <Format>image/png;mode=32bit</Format>\\n                <Format>image/gif</Format>\\n                <Format>image/jpeg</Format>\\n                <Format>application/vnd.google-earth.kmz</Format>\\n                <DCPType>\\n                    <HTTP>\\n                        <Get>\\n                            <OnlineResource xlink:type=\"simple\" xlink:href=\"http://thredds:8080/thredds/wms/ensymbc/clipped/tas_avg_rcp26_DJF_ts19762100_ls_VFVG.nc\"/>\\n                        </Get>\\n                    </HTTP>\\n                </DCPType>\\n            </GetMap>\\n            <GetFeatureInfo>\\n                <Format>text/plain</Format>\\n                <Format>text/xml</Format>\\n                <Format>text/html</Format>\\n                <DCPType>\\n                    <HTTP>\\n                        <Get>\\n                            <OnlineResource xlink:type=\"simple\" xlink:href=\"http://thredds:8080/thredds/wms/ensymbc/clipped/tas_avg_rcp26_DJF_ts19762100_ls_VFVG.nc\"/>\\n                        </Get>\\n                    </HTTP>\\n                </DCPType>\\n            </GetFeatureInfo>\\n        </Request>\\n        <Exception>\\n            <Format>XML</Format>\\n        </Exception>\\n        <edal:ExtendedCapabilities>\\n            <edal:CapabilitiesType>ncWMS2</edal:CapabilitiesType>\\n            <edal:ExtendedRequest>\\n                <edal:Request>GetMap</edal:Request>\\n                <edal:UrlParameter>\\n                    <edal:ParameterName>COLORSCALERANGE</edal:ParameterName>\\n                    <edal:ParameterDescription>Of the form min,max this is the scale range used for plotting the data.</edal:ParameterDescription>\\n                </edal:UrlParameter>\\n                <edal:UrlParameter>\\n                    <edal:ParameterName>NUMCOLORBANDS</edal:ParameterName>\\n                    <edal:ParameterDescription>The number of discrete colours to plot the data. Must be between 2 and 250</edal:ParameterDescription>\\n                </edal:UrlParameter>\\n                <edal:UrlParameter>\\n                    <edal:ParameterName>ABOVEMAXCOLOR</edal:ParameterName>\\n                    <edal:ParameterDescription>The colour to plot values which are above the maximum end of the scale range. Colours are as defined above, with the addition of \"extend\", which will use the maximum value of the palette.</edal:ParameterDescription>\\n                </edal:UrlParameter>\\n                <edal:UrlParameter>\\n                    <edal:ParameterName>BELOWMINCOLOR</edal:ParameterName>\\n                    <edal:ParameterDescription>The colour to plot values which are below the minimum end of the scale range. Colours are as defined above, with the addition of \"extend\", which will use the minimum value of the palette.</edal:ParameterDescription>\\n                </edal:UrlParameter>\\n                <edal:UrlParameter>\\n                    <edal:ParameterName>LOGSCALE</edal:ParameterName>\\n                    <edal:ParameterDescription> \"true\" or \"false\" - whether to plot data with a logarithmic scale</edal:ParameterDescription>\\n                </edal:UrlParameter>\\n                <edal:UrlParameter>\\n                    <edal:ParameterName>TARGETTIME</edal:ParameterName>\\n                    <edal:ParameterDescription>For in-situ data, all points which fall within the time range (specified in the TIME parameter) will be plotted. In the case that an in-situ point has multiple time readings within that range, the colour used to plot them will depend on the time value which is closest to this given value</edal:ParameterDescription>\\n                </edal:UrlParameter>\\n                <edal:UrlParameter>\\n                    <edal:ParameterName>TARGETELEVATION</edal:ParameterName>\\n                    <edal:ParameterDescription>For in-situ data, all points which fall within the elevation range (specified in the ELEVATION parameter) will be plotted. In the case that an in-situ point has multiple elevation readings within that range, the colour used to plot them will depend on the elevation value which is closest to this given value</edal:ParameterDescription>\\n                </edal:UrlParameter>\\n                <edal:UrlParameter>\\n                    <edal:ParameterName>OPACITY</edal:ParameterName>\\n                    <edal:ParameterDescription>The percentage opacity of the final output image</edal:ParameterDescription>\\n                </edal:UrlParameter>\\n                <edal:UrlParameter>\\n                    <edal:ParameterName>ANIMATION</edal:ParameterName>\\n                    <edal:ParameterDescription>\"true\" or \"false\" - whether to generate an animation. This also needs the TIME to be of the formstarttime/endtime, and currently is only implemented for features with a discrete time axis.</edal:ParameterDescription>\\n                </edal:UrlParameter>\\n            </edal:ExtendedRequest>\\n            <edal:ExtendedRequest>\\n                <edal:Request>GetTimeseries</edal:Request>\\n                <edal:RequestDescription>This produces either a timeseries graph or, if downloading is enabled, a CSV file containing the data. The URL parameters are identical to those of a GetFeatureInfo request. The TIME parameter should specify a range of times in the form starttime/endtime, and the supported formats are: image/png,image/jpg,image/jpeg,text/csv,text/json,application/prs.coverage+json,application/prs.coverage json</edal:RequestDescription>\\n            </edal:ExtendedRequest>\\n            <edal:ExtendedRequest>\\n                <edal:Request>GetVerticalProfile</edal:Request>\\n                <edal:RequestDescription>This produces either a vertical profile graph or, if downloading is enabled, a CSV file containing the data. The URL parameters are identical to those of a GetFeatureInfo request. The ELEVATION parameter should specify a range of elevations in the form startelevation/endelevation, and the supported formats are: image/png,image/jpg,image/jpeg,text/csv,text/json,application/prs.coverage+json,application/prs.coverage json</edal:RequestDescription>\\n            </edal:ExtendedRequest>\\n            <edal:ExtendedRequest>\\n                <edal:Request>GetTransect</edal:Request>\\n                <edal:RequestDescription>This produces a graph of data values along an arbitrary path. Additionally if there is vertical information present in the dataset, it will produce a vertical section along the same path.  It accepts the same URL parameters as a GetMap requestion, with the additional mandatory parameter LINESTRING</edal:RequestDescription>\\n                <edal:UrlParameter>\\n                    <edal:ParameterName>LINESTRING</edal:ParameterName>\\n                    <edal:ParameterDescription>The points which define the path of the transect to plot.  Of the form x1 y1,x2 y2,x3 y3...</edal:ParameterDescription>\\n                </edal:UrlParameter>\\n            </edal:ExtendedRequest>\\n            <edal:ExtendedRequest>\\n                <edal:Request>GetMetadata</edal:Request>\\n                <edal:RequestDescription>Fetches small pieces of metadata.  Many of these are also present in this capabilities document, but GetMetadata provides a more convenient method of accessing such data. GetMetadata always returns data in the JSON format</edal:RequestDescription>\\n                <edal:UrlParameter>\\n                    <edal:ParameterName>ITEM</edal:ParameterName>\\n                    <edal:ParameterDescription>This specifies the metadata to return.  This can take the values:\\n                        menu: Returns a tree representation of the available WMS layers, with IDs. Takes the optional parameter DATASET to return the same tree for a single dataset\\n                        layerDetails: Returns a set of details needed to plot a given layer. This includes such data as units, layer bounding box, configured scale range, etc. Takes the parameters LAYERNAME and TIME. The TIME parameter is optional, and if it is specified then the nearest available time is returned as part of the layer\\'s details.\\n                        minmax: Calculates the range of values in the given area. Takes the same parameters as a GetMap request.\\n                        timesteps: Returns the available times for a given day. Takes the parameters LAYERNAME and DAY (yyyy-mm-dd)\\n                        animationTimesteps: Returns a list of time strings at different temporal resolutions for a given time range. This is used to present to the user different frequencies for the generation of an animation. Takes the parameters LAYERNAME, START, and END</edal:ParameterDescription>\\n                </edal:UrlParameter>\\n            </edal:ExtendedRequest>\\n            <edal:ExtendedRequest>\\n                <edal:Request>GetLegendGraphic</edal:Request>\\n                <edal:RequestDescription>The GetLegendGraphic request generates an image which can be used as a legend. There are two main options: Generating just a colourbar, and generating a full legend.</edal:RequestDescription>\\n                <edal:UrlParameter>\\n                    <edal:ParameterName>COLORBARONLY</edal:ParameterName>\\n                    <edal:ParameterDescription>\"true\" or \"false\".  Whether to generate a full legend or just the colour bar.  If it\\'s \"true\", the following URL parameters are required:\\n                        PALETTE: The name of the palette to use. If missing, set to \"default\"\\n                        NUMCOLORBANDS: The number of colour bands to use. If missing, set to 250\\n                        VERTICAL: Whether to very colours vertically. If missing, defaults to true\\n                        WIDTH: The width of the image to generate. If missing, defaults to 50\\n                        HEIGHT: The height of the image to generate. If missing, defaults to 200\\n                    \\n                    For a full legend, the additional parameters LAYERS and either STYLES, SLD, or SLD_BODY must be supplied. This is because a single WMS layer may depend on an arbitrary number of sub-layers, depending on the style it is plotted in. In addition to these parameters, the optional parameters controlling the style may be supplied (these are the same as documented in the GetMap request).  Note that for full legends, the supplied width and height are NOT the final height of the image, but rather the width and height of each individual coloured plot area (i.e. the 1d/2d colourbar)</edal:ParameterDescription>\\n                </edal:UrlParameter>\\n            </edal:ExtendedRequest>\\n        </edal:ExtendedCapabilities>\\n        <Layer>\\n            <Title>ARPAV test server</Title>\\n            <CRS>EPSG:4326</CRS>\\n            <CRS>CRS:84</CRS>\\n            <CRS>EPSG:41001</CRS>\\n            <CRS>EPSG:27700</CRS>\\n            <CRS>EPSG:3408</CRS>\\n            <CRS>EPSG:3409</CRS>\\n            <CRS>EPSG:3857</CRS>\\n            <CRS>EPSG:5041</CRS>\\n            <CRS>EPSG:5042</CRS>\\n            <CRS>EPSG:32661</CRS>\\n            <CRS>EPSG:32761</CRS>\\n            <Layer>\\n                <Title>CLMcom-CCLM4-8-17 model output prepared for CORDEX historical</Title>\\n    <Layer queryable=\"1\">\\n        <Name>tas</Name>\\n        <Title>Near-Surface Air Temperature</Title>\\n        <Abstract>Near-Surface Air Temperature</Abstract>\\n        <EX_GeographicBoundingBox>\\n            <westBoundLongitude>10.485284493234719</westBoundLongitude>\\n            <eastBoundLongitude>14.014431253250091</eastBoundLongitude>\\n            <southBoundLatitude>44.76919556898014</southBoundLatitude>\\n            <northBoundLatitude>46.74023778964937</northBoundLatitude>\\n        </EX_GeographicBoundingBox>\\n        <BoundingBox CRS=\"CRS:84\" minx=\"10.485284493234719\" maxx=\"14.014431253250091\" miny=\"44.76919556898014\" maxy=\"46.74023778964937\"/>\\n        <Dimension name=\"time\" units=\"unknown\" multipleValues=\"true\" current=\"true\" default=\"2024-02-15T12:00:00.000Z\">\\n            1976-02-15T12:00:00.000Z,1977-02-15T00:00:00.000Z/1979-02-15T00:00:00.000Z/P365D,1980-02-15T12:00:00.000Z,1981-02-15T00:00:00.000Z/1983-02-15T00:00:00.000Z/P365D,1984-02-15T12:00:00.000Z,1985-02-15T00:00:00.000Z/1987-02-15T00:00:00.000Z/P365D,1988-02-15T12:00:00.000Z,1989-02-15T00:00:00.000Z/1991-02-15T00:00:00.000Z/P365D,1992-02-15T12:00:00.000Z,1993-02-15T00:00:00.000Z/1995-02-15T00:00:00.000Z/P365D,1996-02-15T12:00:00.000Z,1997-02-15T00:00:00.000Z/1999-02-15T00:00:00.000Z/P365D,2000-02-15T12:00:00.000Z,2001-02-15T00:00:00.000Z/2003-02-15T00:00:00.000Z/P365D,2004-02-15T12:00:00.000Z,2005-02-15T00:00:00.000Z/2007-02-15T00:00:00.000Z/P365D,2008-02-15T12:00:00.000Z,2009-02-15T00:00:00.000Z/2011-02-15T00:00:00.000Z/P365D,2012-02-15T12:00:00.000Z,2013-02-15T00:00:00.000Z/2015-02-15T00:00:00.000Z/P365D,2016-02-15T12:00:00.000Z,2017-02-15T00:00:00.000Z/2019-02-15T00:00:00.000Z/P365D,2020-02-15T12:00:00.000Z,2021-02-15T00:00:00.000Z/2023-02-15T00:00:00.000Z/P365D,2024-02-15T12:00:00.000Z,2025-02-15T00:00:00.000Z/2027-02-15T00:00:00.000Z/P365D,2028-02-15T12:00:00.000Z,2029-02-15T00:00:00.000Z/2031-02-15T00:00:00.000Z/P365D,2032-02-15T12:00:00.000Z,2033-02-15T00:00:00.000Z/2035-02-15T00:00:00.000Z/P365D,2036-02-15T12:00:00.000Z,2037-02-15T00:00:00.000Z/2039-02-15T00:00:00.000Z/P365D,2040-02-15T12:00:00.000Z,2041-02-15T00:00:00.000Z/2043-02-15T00:00:00.000Z/P365D,2044-02-15T12:00:00.000Z,2045-02-15T00:00:00.000Z/2047-02-15T00:00:00.000Z/P365D,2048-02-15T12:00:00.000Z,2049-02-15T00:00:00.000Z/2051-02-15T00:00:00.000Z/P365D,2052-02-15T12:00:00.000Z,2053-02-15T00:00:00.000Z/2055-02-15T00:00:00.000Z/P365D,2056-02-15T12:00:00.000Z,2057-02-15T00:00:00.000Z/2059-02-15T00:00:00.000Z/P365D,2060-02-15T12:00:00.000Z,2061-02-15T00:00:00.000Z/2063-02-15T00:00:00.000Z/P365D,2064-02-15T12:00:00.000Z,2065-02-15T00:00:00.000Z/2067-02-15T00:00:00.000Z/P365D,2068-02-15T12:00:00.000Z,2069-02-15T00:00:00.000Z/2071-02-15T00:00:00.000Z/P365D,2072-02-15T12:00:00.000Z,2073-02-15T00:00:00.000Z/2075-02-15T00:00:00.000Z/P365D,2076-02-15T12:00:00.000Z,2077-02-15T00:00:00.000Z/2079-02-15T00:00:00.000Z/P365D,2080-02-15T12:00:00.000Z,2081-02-15T00:00:00.000Z/2083-02-15T00:00:00.000Z/P365D,2084-02-15T12:00:00.000Z,2085-02-15T00:00:00.000Z/2087-02-15T00:00:00.000Z/P365D,2088-02-15T12:00:00.000Z,2089-02-15T00:00:00.000Z/2091-02-15T00:00:00.000Z/P365D,2092-02-15T12:00:00.000Z,2093-02-15T00:00:00.000Z/2095-02-15T00:00:00.000Z/P365D,2096-02-15T12:00:00.000Z,2097-02-15T00:00:00.000Z/2099-02-15T00:00:00.000Z/P365D\\n        </Dimension>\\n        <Dimension name=\"elevation\" units=\"ncwms:height\" unitSymbol=\"m\" default=\"2.0\">\\n            2.0        </Dimension>\\n        <Style>\\n            <Name>default-scalar/default</Name>\\n            <Title>default-scalar/default</Title>\\n            <Abstract>default-scalar style, using the default palette.  Available palettes can be found in the response to http://thredds:8080/thredds/wms/ensymbc/clipped/tas_avg_rcp26_DJF_ts19762100_ls_VFVG.nc?request=GetMetadata&amp;item=layerDetails&amp;layerName=tas\\n            </Abstract>\\n            <LegendURL width=\"110\" height=\"264\">\\n                <Format>image/png</Format>\\n                <OnlineResource xlink:type=\"simple\" xlink:href=\"http://thredds:8080/thredds/wms/ensymbc/clipped/tas_avg_rcp26_DJF_ts19762100_ls_VFVG.nc?REQUEST=GetLegendGraphic&amp;PALETTE=default&amp;LAYERS=tas&amp;STYLES=default-scalar/default\"/>\\n            </LegendURL>\\n        </Style>\\n        <Style>\\n            <Name>colored_contours/default</Name>\\n            <Title>colored_contours/default</Title>\\n            <Abstract>colored_contours style, using the default palette.  Available palettes can be found in the response to http://thredds:8080/thredds/wms/ensymbc/clipped/tas_avg_rcp26_DJF_ts19762100_ls_VFVG.nc?request=GetMetadata&amp;item=layerDetails&amp;layerName=tas\\n            </Abstract>\\n            <LegendURL width=\"110\" height=\"264\">\\n                <Format>image/png</Format>\\n                <OnlineResource xlink:type=\"simple\" xlink:href=\"http://thredds:8080/thredds/wms/ensymbc/clipped/tas_avg_rcp26_DJF_ts19762100_ls_VFVG.nc?REQUEST=GetLegendGraphic&amp;PALETTE=default&amp;LAYERS=tas&amp;STYLES=colored_contours/default\"/>\\n            </LegendURL>\\n        </Style>\\n        <Style>\\n            <Name>contours</Name>\\n            <Title>contours</Title>\\n            <Abstract>contours style</Abstract>\\n        </Style>\\n        <Style>\\n            <Name>raster/default</Name>\\n            <Title>raster/default</Title>\\n            <Abstract>raster style, using the default palette.  Available palettes can be found in the response to http://thredds:8080/thredds/wms/ensymbc/clipped/tas_avg_rcp26_DJF_ts19762100_ls_VFVG.nc?request=GetMetadata&amp;item=layerDetails&amp;layerName=tas\\n            </Abstract>\\n            <LegendURL width=\"110\" height=\"264\">\\n                <Format>image/png</Format>\\n                <OnlineResource xlink:type=\"simple\" xlink:href=\"http://thredds:8080/thredds/wms/ensymbc/clipped/tas_avg_rcp26_DJF_ts19762100_ls_VFVG.nc?REQUEST=GetLegendGraphic&amp;PALETTE=default&amp;LAYERS=tas&amp;STYLES=raster/default\"/>\\n            </LegendURL>\\n        </Style>\\n</Layer>\\n            </Layer>\\n        </Layer>\\n    </Capability>\\n</WMS_Capabilities>\\n'"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
    ],
-   "outputs": []
+   "source": [
+    "capabilities_response.content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "80685c51-a15d-4765-9ed8-03fc7184be4b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from xml.etree import ElementTree as et"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "dc8e904a-641b-4b21-93e9-ad7b6c144f0b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ns = {\n",
+    "    \"wms\": \"http://www.opengis.net/wms\"\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "d3d4f3bb-1497-4800-9808-c7150555bff9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "root = et.fromstring(capabilities_response.content)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "acaca286-40ae-4eb3-afe9-46db4df3a2ef",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Element '{http://www.opengis.net/wms}WMS_Capabilities' at 0x7de7aaf42660>"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "root"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "b2492415-2968-4d2e-b63c-df599da5bb1c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<Element '{http://www.opengis.net/wms}Request' at 0x7de7aaf43510>]"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "root.findall(f\"./{{{ns['wms']}}}Capability/{{{ns['wms']}}}Request\")"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
This PR modifies the capabilities response document that is generated by the THREDDS server as a response to a WMS GetCapabilities request and converts relevant URLs to use the public URL of the system instead of internal THREDDS URLs.

For example, it converts the URLs advertised for the GetMap operation

from this private URL which references the thredds server as it is known inside the docker network:

```
http://thredds:8080/thredds/wms/ensymbc/clipped/tas_avg_rcp26_DJF_ts19762100_ls_VFVG.nc
```

to this URL which uses the system's public URL and our WMS proxy API endpoint:

```
http://localhost:5001/api/v2/coverages/wms/tas_seasonal_absolute_model_ensemble-rcp26-DJF
```

As a result of this PR the system's WMS endpoint is now usable by any generic WMS client, without having to use custom hacks, like ignoring capabilities links.


---

- fixes #119 