### PR TITLE
Added API endpoint for discovering coverage identifiers

### DIFF
--- a/arpav_ppcv/webapp/api_v2/routers/coverages.py
+++ b/arpav_ppcv/webapp/api_v2/routers/coverages.py
@@ -163,6 +163,36 @@ def get_coverage_configuration(
     )
 
 
+@router.get(
+    "/coverage-identifiers",
+    response_model=coverage_schemas.CoverageIdentifierList,
+)
+def list_coverage_identifiers(
+    request: Request,
+    db_session: Annotated[Session, Depends(dependencies.get_db_session)],
+    list_params: Annotated[dependencies.CommonListFilterParameters, Depends()],
+    name_contains: Annotated[list[str], Query()] = None,
+):
+    cov_ids, filtered_total = db.list_coverage_identifiers(
+        db_session,
+        limit=list_params.limit,
+        offset=list_params.offset,
+        include_total=True,
+        name_filter=name_contains,
+    )
+    _, unfiltered_total = db.list_coverage_identifiers(
+        db_session, limit=1, offset=0, include_total=True
+    )
+    return coverage_schemas.CoverageIdentifierList.from_items(
+        cov_ids,
+        request=request,
+        limit=list_params.limit,
+        offset=list_params.offset,
+        filtered_total=filtered_total,
+        unfiltered_total=unfiltered_total,
+    )
+
+
 @router.get("/wms/{coverage_identifier}")
 async def wms_endpoint(
     request: Request,

--- a/arpav_ppcv/webapp/api_v2/schemas/coverages.py
+++ b/arpav_ppcv/webapp/api_v2/schemas/coverages.py
@@ -1,4 +1,5 @@
 import uuid
+import typing
 
 import pydantic
 from fastapi import Request
@@ -108,8 +109,26 @@ class CoverageConfigurationList(WebResourceList):
 
 class CoverageIdentifierList(WebResourceList):
     items: list[str]
-    list_item_type = str
     path_operation_name = "list_coverage_identifiers"
+
+    @classmethod
+    def from_items(
+        cls,
+        items: typing.Sequence[str],
+        request: Request,
+        *,
+        limit: int,
+        offset: int,
+        filtered_total: int,
+        unfiltered_total: int,
+    ):
+        return cls(
+            meta=cls._get_meta(len(items), unfiltered_total, filtered_total),
+            links=cls._get_list_links(
+                request, limit, offset, filtered_total, len(items)
+            ),
+            items=[i for i in items],
+        )
 
 
 class ConfigurationParameterList(WebResourceList):


### PR DESCRIPTION
This PR adds the `/api/v2/coverages/coverage-identifiers` API endpoint which can be used to discover coverage identifiers (which are needed for interacting with the WMS and time series endpoints). It can be called like this:

```
http://localhost:8877/api/v2/coverages/coverage-identifiers?
  name_contains=tas_&
  name_contains=ensemble&
  name_contains=anomaly&
  name_contains=rcp26&
  name_contains=djf&
```

which produces the following response:

```json
{
  "items": [
    "tas_30yr_anomaly_seasonal_agree_model_ensemble-tw1-rcp26-DJF", 
    "tas_30yr_anomaly_seasonal_agree_model_ensemble-tw2-rcp26-DJF", 
    "tas_seasonal_anomaly_model_ensemble-rcp26-DJF", 
    "tas_seasonal_anomaly_model_ensemble_lower_uncertainty-rcp26-DJF", 
    "tas_seasonal_anomaly_model_ensemble_upper_uncertainty-rcp26-DJF"
  ],
  "meta": {
    "returned_records": 5,
    "total_records": 1776,
    "total_filtered_records": 5
  },
  "links":{
    "self": "http://localhost:8877/api/v2/coverages/coverage-identifiers?limit=20&offset=0&name_contains=djf",
    "next":null,"previous":null,"first":"http://localhost:8877/api/v2/coverages/coverage-identifiers?limit=20&offset=0&name_contains=djf",
    "last":"http://localhost:8877/api/v2/coverages/coverage-identifiers?limit=20&offset=0&name_contains=djf"
  }
}
```

#### Note

As can be seen from the example response shown above, the current naming scheme is not ideal in ensuring that the frontend will always be able to get back a single coverage identifier - we may need to come up with a better way to name them


---

- fixes #136