### PR TITLE
fix deployment script's calling of docker pull command

### DIFF
--- a/deployments/staging/hook-scripts/deploy.py
+++ b/deployments/staging/hook-scripts/deploy.py
@@ -139,7 +139,8 @@ class _PullImages:
 
     def handle(self) -> None:
         print("Pulling updated docker images...")
-        run(shlex.split(f"docker pull {' '.join(self.images)}"), check=True)
+        for image in self.images:
+            run(shlex.split(f"docker pull {image}"), check=True)
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
This PR fixes an error with the deployment script that is used to automate deployments to staging env. The error is related to a bad call of the `docker pull` command

---

- fixes #144