### PR TITLE
Added custom LOESS parameters

### DIFF
--- a/arpav_ppcv/operations.py
+++ b/arpav_ppcv/operations.py
@@ -410,6 +410,8 @@ def _process_coverage_data(
                 _, loess_smoothed, _ = loess_1d(
                     df.index.astype("int64"),
                     df[base_column_name],
+                    degree=0.2,
+                    frac=0.75,
                 )
                 df[column_name] = loess_smoothed
         df = df.drop(columns=[base_column_name])


### PR DESCRIPTION
This PR modifies the generation of the LOESS trendline by adding the values mentioned in #126.

Original LOESS:

![loess_defaults](https://github.com/geobeyond/Arpav-PPCV-backend/assets/732010/4fc68b65-cd37-43e0-9e94-999522c94099)


Updated LOESS:

![loess_deg02_frac075](https://github.com/geobeyond/Arpav-PPCV-backend/assets/732010/4d7c7427-5143-4dc5-a198-afb80bc7cd99)


---

- fixes #126