### PR TITLE
Add tolgee to compose stack

### DIFF
--- a/docker/compose.dev.yaml
+++ b/docker/compose.dev.yaml
@@ -41,6 +41,8 @@ services:
     ports:
       - target: 80
         published: 8877
+      - target: 81
+        published: 8899
       - target: 8080
         published: 8878
     command: --configFile /traefik.toml
@@ -51,12 +53,16 @@ services:
 
   frontend:
     image: "ghcr.io/geobeyond/arpav-ppcv/arpav-ppcv:${FRONTEND_GIT_BRANCH:-latest}"
+    labels:
+      - "traefik.http.routers.arpav-frontend-router.entrypoints=web"
     ports:
       - target: 80
         published: 5003
 
   webapp:
     image: *webapp-image
+    labels:
+      - "traefik.http.routers.arpav-backend-router.entrypoints=web"
     environment:
       <<: *common-env
       ARPAV_PPCV__CORS_ORIGINS: '["*"]'
@@ -147,6 +153,8 @@ services:
         target: /additional
 
   martin:
+    labels:
+      - "traefik.http.routers.martin-router.entrypoints=web"
     ports:
       - target: 3000
         published: 3000
@@ -160,6 +168,8 @@ services:
         target: /martin-config.yaml
 
   prefect-server:
+    labels:
+      - "traefik.http.routers.prefect-router.entrypoints=web"
     environment:
       PREFECT_API_DATABASE_CONNECTION_URL: "postgresql+asyncpg://prefect:prefectpassword@prefect-db/prefect"
       PREFECT_API_URL: "http://0.0.0.0:4200/api"
@@ -210,7 +220,8 @@ services:
     command: ["-f", "/mnt/locust/locustfile.py"]
 
   tolgee-app:
-    image: tolgee/tolgee
+    labels:
+      - "traefik.http.routers.tolgee-app-router.entrypoints=webDifferentPort"
     environment:
       SERVER_PORT: "8080"
       SPRING_DATASOURCE_URL: "jdbc:postgresql://tolgee-db:5432/tolgee"
@@ -219,20 +230,16 @@ services:
       TOLGEE_AUTHENTICATION_ENABLED: "false"
       TOLGEE_AUTHENTICATION_JWT_SECRET: "dxpw5w66th5sa53m2hbgazmxaases92nqwifjigi3j9owznoyuq6frbnppc7bo9tjmgm5e"
       TOLGEE_FILE_STORAGE_FS_DATA_PATH: "/data"
-      TOLGEE_FRONTEND_URL: "http://localhost:6003"
+      TOLGEE_FRONTEND_URL: "http://localhost:8899"
       TOLGEE_POSTGRES_AUTOSTART_ENABLED: "false"
       TOLGEE_TELEMETRY_ENABLED: "false"
     volumes:
       - tolgee-app-data:/data
-    depends_on:
-      tolgee-db:
-        condition: service_healthy
-    ports:
-      - target: 8080
-        published: 6003
+#    ports:
+#      - target: 8080
+#        published: 6003
 
   tolgee-db:
-    image: "postgis/postgis:16-3.4"
     environment:
       POSTGRES_USER: "tolgee_user"
       POSTGRES_PASSWORD: "tolgeepass"

--- a/docker/compose.dev.yaml
+++ b/docker/compose.dev.yaml
@@ -209,9 +209,46 @@ services:
         target: /mnt/locust
     command: ["-f", "/mnt/locust/locustfile.py"]
 
+  tolgee-app:
+    image: tolgee/tolgee
+    environment:
+      SERVER_PORT: "8080"
+      SPRING_DATASOURCE_URL: "jdbc:postgresql://tolgee-db:5432/tolgee"
+      SPRING_DATASOURCE_USERNAME: "tolgee_user"
+      SPRING_DATASOURCE_PASSWORD: "tolgeepass"
+      TOLGEE_AUTHENTICATION_ENABLED: "false"
+      TOLGEE_AUTHENTICATION_JWT_SECRET: "dxpw5w66th5sa53m2hbgazmxaases92nqwifjigi3j9owznoyuq6frbnppc7bo9tjmgm5e"
+      TOLGEE_FILE_STORAGE_FS_DATA_PATH: "/data"
+      TOLGEE_FRONTEND_URL: "http://localhost:6003"
+      TOLGEE_POSTGRES_AUTOSTART_ENABLED: "false"
+      TOLGEE_TELEMETRY_ENABLED: "false"
+    volumes:
+      - tolgee-app-data:/data
+    depends_on:
+      tolgee-db:
+        condition: service_healthy
+    ports:
+      - target: 8080
+        published: 6003
+
+  tolgee-db:
+    image: "postgis/postgis:16-3.4"
+    environment:
+      POSTGRES_USER: "tolgee_user"
+      POSTGRES_PASSWORD: "tolgeepass"
+      POSTGRES_DB: "tolgee"
+    ports:
+      - target: 5432
+        published: 55435
+    volumes:
+      - tolgee-db-data:/var/lib/postgresql/data
+
+
 volumes:
   db-data:
   test-db-data:
   prefect-server-home:
   prefect-worker-home:
   prefect-db-data:
+  tolgee-app-data:
+  tolgee-db-data:

--- a/docker/compose.staging.yaml
+++ b/docker/compose.staging.yaml
@@ -22,6 +22,8 @@ x-env-file-frontend: &env-file-frontend ${ARPAV_PPCV_DEPLOYMENT_ENV_FILE_FRONTEN
 x-env-file-prefect-db: &env-file-prefect-db ${ARPAV_PPCV_DEPLOYMENT_ENV_FILE_PREFECT_DB_SERVICE:-/home/arpav/environment-files/prefect-db-service.env}
 x-env-file-prefect-server: &env-file-prefect-server ${ARPAV_PPCV_DEPLOYMENT_ENV_FILE_PREFECT_SERVER_SERVICE:-/home/arpav/environment-files/prefect-server-service.env}
 x-env-file-prefect-static-worker: &env-file-prefect-static-worker ${ARPAV_PPCV_DEPLOYMENT_ENV_FILE_PREFECT_STATIC_WORKER_SERVICE:-/home/arpav/environment-files/prefect-static-worker-service.env}
+x-env-file-tolgee-db: &env-file-tolgee-db ${ARPAV_PPCV_DEPLOYMENT_ENV_FILE_TOLGEE_DB_SERVICE:-/home/arpav/environment-files/tolgee-db-service.env}
+x-env-file-tolgee-app: &env-file-tolgee-app ${ARPAV_PPCV_DEPLOYMENT_ENV_FILE_TOLGEE_APP_SERVICE:-/home/arpav/environment-files/tolgee-app-service.env}
 
 name: arpav-ppcv-staging
 
@@ -42,7 +44,7 @@ services:
       - "traefik.http.routers.outside-router-arpav-backend.entrypoints=webSecure"
       - "traefik.http.routers.outside-router-arpav-backend.tls=true"
       - "traefik.http.routers.outside-router-arpav-backend.tls.certResolver=letsEncryptResolver"
-      - "traefik.http.routers.outside-router-arpav-backend.rule=Host(`arpav.geobeyond.dev`)"
+      - "traefik.http.routers.outside-router-arpav-backend.rule=Host(`arpav.geobeyond.dev`) || Host(`tolgee.arpav.geobeyond.dev`)"
       - "exposed.outside=true"
     networks:
       - front
@@ -137,6 +139,7 @@ services:
       - "exposed.inside=true"
     env_file:
       - *env-file-prefect-server
+    restart: unless-stopped
 
   prefect-static-worker:
     networks:
@@ -154,6 +157,26 @@ services:
       - prefect-db-data:/var/lib/postgresql/data
     restart: unless-stopped
 
+  tolgee-app:
+    labels:
+      - "exposed.inside=true"
+      - "traefik.http.routers.tolgee-app-router.rule=Host(`tolgee.arpav.geobeyond.dev`)"
+    networks:
+      - back
+    env_file:
+      - *env-file-tolgee-app
+    restart: unless-stopped
+
+  tolgee-db:
+    networks:
+      - back
+    env_file:
+      - *env-file-tolgee-db
+    volumes:
+      - tolgee-db-data:/var/lib/postgresql/data
+    restart: unless-stopped
+
 volumes:
   db-data:
   prefect-db-data:
+  tolgee-db-data:

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -138,3 +138,19 @@ services:
     environment:
       PG_DATA: /var/lib/postgresql/data/pgdata
     healthcheck: *postgres-db-healthcheck
+
+  tolgee-app:
+    image: "tolgee/tolgee:v3.71.4"
+    depends_on:
+      tolgee-db:
+        condition: service_healthy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.tolgee-app-router.rule=PathPrefix(`/`)"
+      - "traefik.http.services.tolgee-app-service.loadbalancer.server.port=8080"
+
+  tolgee-db:
+    image: "postgis/postgis:16-3.4"
+    environment:
+      PG_DATA: /var/lib/postgresql/data/pgdata
+    healthcheck: *postgres-db-healthcheck

--- a/docker/traefik/dev-config.toml
+++ b/docker/traefik/dev-config.toml
@@ -15,6 +15,9 @@
 [entryPoints.web]
 address = ":80"
 
+[entryPoints.webDifferentPort]
+address = ":81"
+
 [providers]
 
 [providers.docker]


### PR DESCRIPTION
This PR integrates tolgee into the compose stack.

It adds the tolgee self-hosted version as another service. This tolgee service is included in both the dev and staging stacks. 

### Dev stack

When standing up the stack on dev, tolgee is accessible with the following characteristics:

- available at `localhost:8899/`
- does not use any authentication
- configuration supplied via `environment` params in the docker compose file


### Staging stack

When standing up the stack on staging, tolgee is accessible with the following characteristics:

- available at `tolgee.arpav.geobeyond.dev/`
- Uses the tolgee native authentication
- Configuration supplied via an env file, located in the staging server



---

- fixes #154