### PR TITLE
171 provide bootstrap configuration values to account for translations and possible values

### DIFF
--- a/arpav_ppcv/bootstrapper/configurationparameters.py
+++ b/arpav_ppcv/bootstrapper/configurationparameters.py
@@ -7,6 +7,85 @@ from ..schemas.coverages import (
 def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
     return [
         ConfigurationParameterCreate(
+            name="climatological_variable",
+            display_name_english="Variable",
+            display_name_italian="Variabile",
+            description_english="Climatological variable",
+            description_italian="Variabile climatologica",
+            allowed_values=[
+                ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
+                    name="cdd",
+                    display_name_english="CDD",
+                    display_name_italian="CDD",
+                    description_english="Consecutive Cold Days",
+                    description_italian="Giorni secchi",
+                ),
+                ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
+                    name="fd",
+                    display_name_english="FD",
+                    display_name_italian="FD",
+                    description_english="Frozen Days",
+                    description_italian="Giorni di gelo",
+                ),
+                ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
+                    name="pr",
+                    display_name_english="PR",
+                    display_name_italian="PR",
+                    description_english="Rainfall",
+                    description_italian="Precipitazione",
+                ),
+                ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
+                    name="r95ptot",
+                    display_name_english="R95pTOT",
+                    display_name_italian="R95pTOT",
+                    description_english="Extreme rainfall",
+                    description_italian="Precipitazione estrema",
+                ),
+                ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
+                    name="snwdays",
+                    display_name_english="SNWDAYS",
+                    display_name_italian="SNWDAYS",
+                    description_english="Days with new snow",
+                    description_italian="Giorni con neve nuova",
+                ),
+                ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
+                    name="su30",
+                    display_name_english="SU30",
+                    display_name_italian="SU30",
+                    description_english="Hot days",
+                    description_italian="Giorni caldi",
+                ),
+                ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
+                    name="tas",
+                    display_name_english="TAS",
+                    display_name_italian="TAS",
+                    description_english="Mean temperature",
+                    description_italian="Temperatura media",
+                ),
+                ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
+                    name="tasmax",
+                    display_name_english="TASMAX",
+                    display_name_italian="TASMAX",
+                    description_english="Maximum temperature",
+                    description_italian="Temperatura massima",
+                ),
+                ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
+                    name="tasmin",
+                    display_name_english="TASMIN",
+                    display_name_italian="TASMIN",
+                    description_english="Minimum temperature",
+                    description_italian="Temperatura minima",
+                ),
+                ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
+                    name="tr",
+                    display_name_english="TR",
+                    display_name_italian="TR",
+                    description_english="Tropical nights",
+                    description_italian="Notti tropicali",
+                ),
+            ],
+        ),
+        ConfigurationParameterCreate(
             name="scenario",
             display_name_english="Scenario",
             display_name_italian="Scenario",
@@ -140,6 +219,13 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                         "Stagione climatologica autunnale (settembre, ottobre, novembre)"
                     ),
                 ),
+                ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
+                    name="year",
+                    display_name_english="Year",
+                    display_name_italian="Anno",
+                    description_english="Whole year",
+                    description_italian="L'intero anno",
+                ),
             ],
         ),
         ConfigurationParameterCreate(
@@ -234,6 +320,13 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                     display_name_italian="MPI-ESM-LR-REMO2009",
                     description_english="MPI-ESM-LR-REMO2009 model",
                     description_italian="Modello MPI-ESM-LR-REMO2009",
+                ),
+                ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
+                    name="barometro_climatico",
+                    display_name_english="Climate barometer",
+                    display_name_italian="Barometro climatico",
+                    description_english="Regional overview",
+                    description_italian="Panoramica regionale",
                 ),
             ],
         ),

--- a/arpav_ppcv/bootstrapper/coverage_configurations/cdd.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/cdd.py
@@ -1,15 +1,17 @@
-"""
-- [x] cdd_30yr_anomaly_annual_agree_model_ensemble
-- [x] cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17
-- [x] cdd_30yr_anomaly_annual_model_ec_earth_racmo22e
-- [x] cdd_30yr_anomaly_annual_model_ec_earth_rca4
-- [x] cdd_30yr_anomaly_annual_model_hadgem2_es_racmo22e
-- [x] cdd_30yr_anomaly_annual_model_mpi_esm_lr_remo2009
-
-"""
 from ...schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
+)
+
+_DISPLAY_NAME_ENGLISH = "Consecutive dry days"
+_DISPLAY_NAME_ITALIAN = "Giorni secchi"
+_DESCRIPTION_ENGLISH = (
+    "Number of days with average temperature less than 2 °C and daily precipitation "
+    "greater than 1 mm"
+)
+_DESCRIPTION_ITALIAN = (
+    "Numero di giorni con temperatura media inferiore a 2 °C e precipitazioni "
+    "giornaliere superiori a 1 mm"
 )
 
 
@@ -18,7 +20,11 @@ def generate_configurations(
 ) -> list[CoverageConfigurationCreate]:
     return [
         CoverageConfigurationCreate(
-            name="cdd_30yr_anomaly_annual_agree_model_ensemble",
+            name="cdd_30yr_anomaly_seasonal_agree_model_ensemble",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="cdd",
             wms_main_layer_name="consecutive_dry_days_index_per_time_period-uncertainty_group",
             thredds_url_pattern="ensembletwbc/std/clipped/eca_cdd_an_avgagree_{time_window}_{scenario}_{year_period}_ls_VFVGTAA.nc",
@@ -29,6 +35,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "cdd")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -75,7 +101,11 @@ def generate_configurations(
             ],
         ),
         CoverageConfigurationCreate(
-            name="cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
+            name="cdd_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="cdd",
             wms_main_layer_name="consecutive_dry_days_index_per_time_period",
             thredds_url_pattern="indici5rcm/clipped/eca_cdd_an_EC-EARTH_CCLM4-8-17_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc",
@@ -86,6 +116,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "cdd")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -132,7 +182,11 @@ def generate_configurations(
             ],
         ),
         CoverageConfigurationCreate(
-            name="cdd_30yr_anomaly_annual_model_ec_earth_racmo22e",
+            name="cdd_30yr_anomaly_seasonal_model_ec_earth_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="cdd",
             wms_main_layer_name="consecutive_dry_days_index_per_time_period",
             thredds_url_pattern="indici5rcm/clipped/eca_cdd_an_EC-EARTH_RACMO22E_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc",
@@ -143,6 +197,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "cdd")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_racmo22e")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -189,7 +263,11 @@ def generate_configurations(
             ],
         ),
         CoverageConfigurationCreate(
-            name="cdd_30yr_anomaly_annual_model_ec_earth_rca4",
+            name="cdd_30yr_anomaly_seasonal_model_ec_earth_rca4",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="cdd",
             wms_main_layer_name="consecutive_dry_days_index_per_time_period",
             thredds_url_pattern="indici5rcm/clipped/eca_cdd_an_EC-EARTH_RCA4_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc",
@@ -200,6 +278,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "cdd")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_rca4")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -246,7 +344,11 @@ def generate_configurations(
             ],
         ),
         CoverageConfigurationCreate(
-            name="cdd_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
+            name="cdd_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="cdd",
             wms_main_layer_name="consecutive_dry_days_index_per_time_period",
             thredds_url_pattern="indici5rcm/clipped/eca_cdd_an_HadGEM2-ES_RACMO22E_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc",
@@ -257,6 +359,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "cdd")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "hadgem2_racmo22e")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -303,7 +425,11 @@ def generate_configurations(
             ],
         ),
         CoverageConfigurationCreate(
-            name="cdd_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
+            name="cdd_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="cdd",
             wms_main_layer_name="consecutive_dry_days_index_per_time_period",
             thredds_url_pattern="indici5rcm/clipped/eca_cdd_an_MPI-ESM-LR_REMO2009_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc",
@@ -312,6 +438,26 @@ def generate_configurations(
             color_scale_min=-40,
             color_scale_max=40,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "cdd")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "mpi_esm_lr_remo2009")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
@@ -364,47 +510,47 @@ def generate_configurations(
 
 def get_related_map() -> dict[str, list[str]]:
     return {
-        "cdd_30yr_anomaly_annual_agree_model_ensemble": [
+        "cdd_30yr_anomaly_seasonal_agree_model_ensemble": [
             "cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
             "cdd_30yr_anomaly_annual_model_ec_earth_racmo22e",
             "cdd_30yr_anomaly_annual_model_ec_earth_rca4",
             "cdd_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
             "cdd_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
         ],
-        "cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17": [
-            "cdd_30yr_anomaly_annual_agree_model_ensemble",
-            "cdd_30yr_anomaly_annual_model_ec_earth_racmo22e",
-            "cdd_30yr_anomaly_annual_model_ec_earth_rca4",
-            "cdd_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
-            "cdd_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
+        "cdd_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17": [
+            "cdd_30yr_anomaly_seasonal_agree_model_ensemble",
+            "cdd_30yr_anomaly_seasonal_model_ec_earth_racmo22e",
+            "cdd_30yr_anomaly_seasonal_model_ec_earth_rca4",
+            "cdd_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e",
+            "cdd_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009",
         ],
-        "cdd_30yr_anomaly_annual_model_ec_earth_racmo22e": [
-            "cdd_30yr_anomaly_annual_agree_model_ensemble",
-            "cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
-            "cdd_30yr_anomaly_annual_model_ec_earth_rca4",
-            "cdd_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
-            "cdd_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
+        "cdd_30yr_anomaly_seasonal_model_ec_earth_racmo22e": [
+            "cdd_30yr_anomaly_seasonal_agree_model_ensemble",
+            "cdd_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17",
+            "cdd_30yr_anomaly_seasonal_model_ec_earth_rca4",
+            "cdd_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e",
+            "cdd_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009",
         ],
-        "cdd_30yr_anomaly_annual_model_ec_earth_rca4": [
-            "cdd_30yr_anomaly_annual_agree_model_ensemble",
-            "cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
-            "cdd_30yr_anomaly_annual_model_ec_earth_racmo22e",
-            "cdd_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
-            "cdd_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
+        "cdd_30yr_anomaly_seasonal_model_ec_earth_rca4": [
+            "cdd_30yr_anomaly_seasonal_agree_model_ensemble",
+            "cdd_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17",
+            "cdd_30yr_anomaly_seasonal_model_ec_earth_racmo22e",
+            "cdd_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e",
+            "cdd_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009",
         ],
-        "cdd_30yr_anomaly_annual_model_hadgem2_es_racmo22e": [
-            "cdd_30yr_anomaly_annual_agree_model_ensemble",
-            "cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
-            "cdd_30yr_anomaly_annual_model_ec_earth_racmo22e",
-            "cdd_30yr_anomaly_annual_model_ec_earth_rca4",
-            "cdd_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
+        "cdd_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e": [
+            "cdd_30yr_anomaly_seasonal_agree_model_ensemble",
+            "cdd_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17",
+            "cdd_30yr_anomaly_seasonal_model_ec_earth_racmo22e",
+            "cdd_30yr_anomaly_seasonal_model_ec_earth_rca4",
+            "cdd_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009",
         ],
-        "cdd_30yr_anomaly_annual_model_mpi_esm_lr_remo2009": [
-            "cdd_30yr_anomaly_annual_agree_model_ensemble",
-            "cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
-            "cdd_30yr_anomaly_annual_model_ec_earth_racmo22e",
-            "cdd_30yr_anomaly_annual_model_ec_earth_rca4",
-            "cdd_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
+        "cdd_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009": [
+            "cdd_30yr_anomaly_seasonal_agree_model_ensemble",
+            "cdd_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17",
+            "cdd_30yr_anomaly_seasonal_model_ec_earth_racmo22e",
+            "cdd_30yr_anomaly_seasonal_model_ec_earth_rca4",
+            "cdd_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e",
         ],
     }
 

--- a/arpav_ppcv/bootstrapper/coverage_configurations/fd.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/fd.py
@@ -1,27 +1,13 @@
-"""
-- [x] fd_annual_absolute_model_ensemble
-- [x] fd_annual_absolute_model_ensemble_upper_uncertainty
-- [x] fd_annual_absolute_model_ensemble_lower_uncertainty
-- [x] fd_annual_absolute_model_ec_earth_cclm4_8_17
-- [x] fd_annual_absolute_model_ec_earth_racmo22e
-- [x] fd_annual_absolute_model_ec_earth_rca4
-- [x] fd_annual_absolute_model_hadgem2_es_racmo22e
-- [x] fd_annual_absolute_model_mpi_esm_lr_remo2009
-
-- [x] 30year anomaly
-  - [x] fd_30yr_anomaly_annual_agree_model_ensemble
-  - [x] fd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17
-  - [x] fd_30yr_anomaly_annual_model_ec_earth_racmo22e
-  - [x] fd_30yr_anomaly_annual_model_ec_earth_rca4
-  - [x] fd_30yr_anomaly_annual_model_hadgem2_es_racmo22e
-  - [x] fd_30yr_anomaly_annual_model_mpi_esm_lr_remo2009
-
-"""
 from ...schemas.base import ObservationAggregationType
 from ...schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
 )
+
+_DISPLAY_NAME_ENGLISH = "Frozen days"
+_DISPLAY_NAME_ITALIAN = "Giorni di gelo"
+_DESCRIPTION_ENGLISH = "Number of days with minimum temperature less than 0 °C"
+_DESCRIPTION_ITALIAN = "Numero di giorni con temperatura minima inferiore a 0 °C"
 
 
 def generate_configurations(
@@ -30,6 +16,10 @@ def generate_configurations(
     return [
         CoverageConfigurationCreate(
             name="fd_annual_absolute_model_ensemble",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="fd",
             wms_main_layer_name="fd",
             thredds_url_pattern="ensymbc/clipped/ecafd_0_avg_{scenario}_ts19762100_ls_VFVG.nc",
@@ -40,6 +30,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "fd")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -51,6 +61,11 @@ def generate_configurations(
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
                     ].id
                 ),
             ],
@@ -61,6 +76,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="fd_annual_absolute_model_ec_earth_cclm4_8_17",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="fd",
             wms_main_layer_name="fd",
             thredds_url_pattern="EC-EARTH_CCLM4-8-17ymbc/clipped/ecafd_0_EC-EARTH_CCLM4-8-17_{scenario}_ts19762100_ls_VFVG.nc",
@@ -71,6 +90,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "fd")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -82,6 +121,11 @@ def generate_configurations(
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
                     ].id
                 ),
             ],
@@ -92,6 +136,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="fd_annual_absolute_model_ec_earth_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="fd",
             wms_main_layer_name="fd",
             thredds_url_pattern="EC-EARTH_RACMO22Eymbc/clipped/ecafd_0_EC-EARTH_RACMO22E_{scenario}_ts19762100_ls_VFVG.nc",
@@ -102,6 +150,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "fd")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_racmo22e")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -113,6 +181,11 @@ def generate_configurations(
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
                     ].id
                 ),
             ],
@@ -123,6 +196,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="fd_annual_absolute_model_ec_earth_rca4",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="fd",
             wms_main_layer_name="fd",
             thredds_url_pattern="EC-EARTH_RCA4ymbc/clipped/ecafd_0_EC-EARTH_RCA4_{scenario}_ts19762100_ls_VFVG.nc",
@@ -133,6 +210,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "fd")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_rca4")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -144,6 +241,11 @@ def generate_configurations(
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
                     ].id
                 ),
             ],
@@ -154,6 +256,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="fd_annual_absolute_model_hadgem2_es_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="fd",
             wms_main_layer_name="fd",
             thredds_url_pattern="HadGEM2-ES_RACMO22Eymbc/clipped/ecafd_0_HadGEM2-ES_RACMO22E_{scenario}_ts19762100_ls_VFVG.nc",
@@ -164,6 +270,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "fd")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "hadgem2_racmo22e")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -175,6 +301,11 @@ def generate_configurations(
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
                     ].id
                 ),
             ],
@@ -185,6 +316,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="fd_annual_absolute_model_mpi_esm_lr_remo2009",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="fd",
             wms_main_layer_name="fd",
             thredds_url_pattern="MPI-ESM-LR_REMO2009ymbc/clipped/ecafd_0_MPI-ESM-LR_REMO2009_{scenario}_ts19762100_ls_VFVG.nc",
@@ -195,6 +330,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "fd")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "mpi_esm_lr_remo2009")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -206,6 +361,11 @@ def generate_configurations(
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
                     ].id
                 ),
             ],
@@ -216,6 +376,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="fd_annual_absolute_model_ensemble_upper_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="fd_stdup",
             wms_main_layer_name="fd_stdup",
             thredds_url_pattern="ensymbc/std/clipped/ecafd_0_stdup_{scenario}_ts19762100_ls_VFVG.nc",
@@ -226,6 +390,31 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "fd")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "upper_bound")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -239,10 +428,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="fd_annual_absolute_model_ensemble_lower_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="fd_stddown",
             wms_main_layer_name="fd_stddown",
             thredds_url_pattern="ensymbc/std/clipped/ecafd_0_stddown_{scenario}_ts19762100_ls_VFVG.nc",
@@ -253,6 +451,31 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "fd")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "lower_bound")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -266,10 +489,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="fd_30yr_anomaly_annual_agree_model_ensemble",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="fd",
             wms_main_layer_name="fd_uncertainty_group",
             thredds_url_pattern="ensembletwbc/std/clipped/ecafdan_0_avgagree_{time_window}_{scenario}_ls_VFVG.nc",
@@ -280,6 +512,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "fd")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -303,10 +555,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="fd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="fd",
             wms_main_layer_name="fd",
             thredds_url_pattern="indici5rcm/clipped/ecafdan_0_EC-EARTH_CCLM4-8-17_{scenario}_{time_window}_ls_VFVG.nc",
@@ -317,6 +578,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "fd")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -340,10 +621,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="fd_30yr_anomaly_annual_model_ec_earth_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="fd",
             wms_main_layer_name="fd",
             thredds_url_pattern="indici5rcm/clipped/ecafdan_0_EC-EARTH_RACMO22E_{scenario}_{time_window}_ls_VFVG.nc",
@@ -354,6 +644,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "fd")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_racmo22e")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -377,10 +687,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="fd_30yr_anomaly_annual_model_ec_earth_rca4",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="fd",
             wms_main_layer_name="fd",
             thredds_url_pattern="indici5rcm/clipped/ecafdan_0_EC-EARTH_RCA4_{scenario}_{time_window}_ls_VFVG.nc",
@@ -391,6 +710,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "fd")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_rca4")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -414,10 +753,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="fd_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="fd",
             wms_main_layer_name="fd",
             thredds_url_pattern="indici5rcm/clipped/ecafdan_0_HadGEM2-ES_RACMO22E_{scenario}_{time_window}_ls_VFVG.nc",
@@ -428,6 +776,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "fd")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "hadgem2_racmo22e")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -451,10 +819,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="fd_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="fd",
             wms_main_layer_name="fd",
             thredds_url_pattern="indici5rcm/clipped/ecafdan_0_MPI-ESM-LR_REMO2009_{scenario}_{time_window}_ls_VFVG.nc",
@@ -465,6 +842,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "fd")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "mpi_esm_lr_remo2009")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -486,6 +883,11 @@ def generate_configurations(
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
                     ].id
                 ),
             ],

--- a/arpav_ppcv/bootstrapper/coverage_configurations/pr.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/pr.py
@@ -1,48 +1,13 @@
-"""
-- [x] anomaly
-    - [x] pr_seasonal_anomaly_model_ensemble
-    - [x] pr_seasonal_anomaly_model_ensemble_upper_uncertainty
-    - [x] pr_seasonal_anomaly_model_ensemble_lower_uncertainty
-    - [x] pr_seasonal_anomaly_model_ec_earth_cclm4_8_17
-    - [x] pr_seasonal_anomaly_model_ec_earth_racmo22e
-    - [x] pr_seasonal_anomaly_model_ec_earth_rca4
-    - [x] pr_seasonal_anomaly_model_hadgem2_es_racmo22e
-    - [x] pr_seasonal_anomaly_model_mpi_esm_lr_remo2009
-
-- [x] absolute value
-  - [x] seasonal
-    - [x] pr_seasonal_absolute_model_ensemble
-    - [x] pr_seasonal_absolute_model_ensemble_upper_uncertainty
-    - [x] pr_seasonal_absolute_model_ensemble_lower_uncertainty
-    - [x] pr_seasonal_absolute_model_ec_earth_cclm4_8_17
-    - [x] pr_seasonal_absolute_model_ec_earth_racmo22e
-    - [x] pr_seasonal_absolute_model_ec_earth_rca4
-    - [x] pr_seasonal_absolute_model_hadgem2_es_racmo22e
-    - [x] pr_seasonal_absolute_model_mpi_esm_lr_remo2009
-
-  - [x] annual
-    - [x] pr_annual_absolute_model_ensemble
-    - [x] pr_annual_absolute_model_ensemble_upper_uncertainty
-    - [x] pr_annual_absolute_model_ensemble_lower_uncertainty
-    - [x] pr_annual_absolute_model_ec_earth_cclm4_8_17
-    - [x] pr_annual_absolute_model_ec_earth_racmo22e
-    - [x] pr_annual_absolute_model_ec_earth_rca4
-    - [x] pr_annual_absolute_model_hadgem2_es_racmo22e
-    - [x] pr_annual_absolute_model_mpi_esm_lr_remo2009
-
-- [x] 30year anomaly
-  - [x] pr_30yr_anomaly_seasonal_agree_model_ensemble
-  - [x] pr_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17
-  - [x] pr_30yr_anomaly_seasonal_model_ec_earth_racmo22e
-  - [x] pr_30yr_anomaly_seasonal_model_ec_earth_rca4
-  - [x] pr_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e
-  - [x] pr_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009
-"""
 from ...schemas.base import ObservationAggregationType
 from ...schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
 )
+
+_DISPLAY_NAME_ENGLISH = "Rainfall"
+_DISPLAY_NAME_ITALIAN = "Precipitazione"
+_DESCRIPTION_ENGLISH = "Daily precipitation near the ground"
+_DESCRIPTION_ITALIAN = "Precipitazioni giornaliere in prossimità del suolo"
 
 
 def generate_configurations(
@@ -51,6 +16,10 @@ def generate_configurations(
     return [
         CoverageConfigurationCreate(
             name="pr_seasonal_anomaly_model_ensemble",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="pr",
             wms_main_layer_name="pr",
             thredds_url_pattern="ens5ym/clipped/pr_anom_pp_ts_{scenario}_{year_period}_VFVGTAA.nc",
@@ -59,6 +28,26 @@ def generate_configurations(
             color_scale_min=-40,
             color_scale_max=40,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "pr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -98,6 +87,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="pr_seasonal_anomaly_model_ec_earth_cclm4_8_17",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="pr",
             wms_main_layer_name="pr",
             thredds_url_pattern="EC-EARTH_CCLM4-8-17ym/clipped/pr_EC-EARTH_CCLM4-8-17_{scenario}_{year_period}_anomaly_pp_percentage_VFVGTAA.nc",
@@ -106,6 +99,26 @@ def generate_configurations(
             color_scale_min=-40,
             color_scale_max=40,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "pr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -145,6 +158,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="pr_seasonal_anomaly_model_ec_earth_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="pr",
             wms_main_layer_name="pr",
             thredds_url_pattern="EC-EARTH_RACMO22Eym/clipped/pr_EC-EARTH_RACMO22E_{scenario}_{year_period}_anomaly_pp_percentage_VFVGTAA.nc",
@@ -153,6 +170,26 @@ def generate_configurations(
             color_scale_min=-40,
             color_scale_max=40,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "pr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_racmo22e")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -192,6 +229,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="pr_seasonal_anomaly_model_ec_earth_rca4",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="pr",
             wms_main_layer_name="pr",
             thredds_url_pattern="EC-EARTH_RCA4ym/clipped/pr_EC-EARTH_RCA4_{scenario}_{year_period}_anomaly_pp_percentage_VFVGTAA.nc",
@@ -200,6 +241,26 @@ def generate_configurations(
             color_scale_min=-40,
             color_scale_max=40,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "pr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_rca4")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -239,6 +300,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="pr_seasonal_anomaly_model_hadgem2_es_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="pr",
             wms_main_layer_name="pr",
             thredds_url_pattern="HadGEM2-ES_RACMO22Eym/clipped/pr_HadGEM2-ES_RACMO22E_{scenario}_{year_period}_anomaly_pp_percentage_VFVGTAA.nc",
@@ -247,6 +312,26 @@ def generate_configurations(
             color_scale_min=-40,
             color_scale_max=40,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "pr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "hadgem2_racmo22e")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -286,6 +371,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="pr_seasonal_anomaly_model_mpi_esm_lr_remo2009",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="pr",
             wms_main_layer_name="pr",
             thredds_url_pattern="MPI-ESM-LR_REMO2009ym/clipped/pr_MPI-ESM-LR_REMO2009_{scenario}_{year_period}_anomaly_pp_percentage_VFVGTAA.nc",
@@ -294,6 +383,26 @@ def generate_configurations(
             color_scale_min=-40,
             color_scale_max=40,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "pr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "mpi_esm_lr_remo2009")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -333,6 +442,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="pr_seasonal_anomaly_model_ensemble_upper_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="pr_stdup",
             wms_main_layer_name="pr_stdup",
             thredds_url_pattern="ens5ym/std/clipped/pr_anom_stdup_pp_ts_{scenario}_{year_period}_VFVGTAA.nc",
@@ -341,6 +454,31 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=0,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "pr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "upper_bound")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -380,6 +518,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="pr_seasonal_anomaly_model_ensemble_lower_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="pr_stddown",
             wms_main_layer_name="pr_stddown",
             thredds_url_pattern="ens5ym/std/clipped/pr_anom_stddown_pp_ts_{scenario}_{year_period}_VFVGTAA.nc",
@@ -388,6 +530,31 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=0,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "pr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "lower_bound")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -427,6 +594,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="pr_seasonal_absolute_model_ensemble",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="pr",
             wms_main_layer_name="pr",
             thredds_url_pattern="ensymbc/clipped/pr_avg_{scenario}_{year_period}_ts19762100_ls_VFVGTAA.nc",
@@ -435,6 +606,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=800,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "pr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -478,6 +669,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="pr_annual_absolute_model_ensemble",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="pr",
             wms_main_layer_name="pr",
             thredds_url_pattern="ensymbc/clipped/pr_avg_{scenario}_ts19762100_ls_VFVGTAA.nc",
@@ -486,6 +681,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=3200,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "pr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -501,6 +716,11 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
             observation_variable_id=(
                 v.id if (v := variables.get("PRCPTOT")) is not None else None
@@ -509,6 +729,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="pr_seasonal_absolute_model_ec_earth_cclm4_8_17",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="pr",
             wms_main_layer_name="pr",
             thredds_url_pattern="EC-EARTH_CCLM4-8-17ymbc/clipped/pr_EC-EARTH_CCLM4-8-17_{scenario}_{year_period}_ts_ls_VFVGTAA.nc",
@@ -517,6 +741,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=800,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "pr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -560,6 +804,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="pr_annual_absolute_model_ec_earth_cclm4_8_17",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             wms_main_layer_name="pr",
             netcdf_main_dataset_name="pr",
             thredds_url_pattern="EC-EARTH_CCLM4-8-17ymbc/clipped/pr_EC-EARTH_CCLM4-8-17_{scenario}_ts_ls_VFVGTAA.nc",
@@ -568,6 +816,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=800,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "pr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -583,6 +851,11 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
             observation_variable_id=(
                 v.id if (v := variables.get("PRCPTOT")) is not None else None
@@ -591,6 +864,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="pr_seasonal_absolute_model_ec_earth_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="pr",
             wms_main_layer_name="pr",
             thredds_url_pattern="EC-EARTH_RACMO22Eymbc/clipped/pr_EC-EARTH_RACMO22E_{scenario}_{year_period}_ts_ls_VFVGTAA.nc",
@@ -599,6 +876,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=800,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "pr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_racmo22e")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -642,6 +939,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="pr_annual_absolute_model_ec_earth_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="pr",
             wms_main_layer_name="pr",
             thredds_url_pattern="EC-EARTH_RACMO22Eymbc/clipped/pr_EC-EARTH_RACMO22E_{scenario}_ts_ls_VFVGTAA.nc",
@@ -650,6 +951,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=3200,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "pr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_racmo22e")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -665,6 +986,11 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
             observation_variable_id=(
                 v.id if (v := variables.get("PRCPTOT")) is not None else None
@@ -673,6 +999,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="pr_seasonal_absolute_model_ec_earth_rca4",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="pr",
             wms_main_layer_name="pr",
             thredds_url_pattern="EC-EARTH_RCA4ymbc/clipped/pr_EC-EARTH_RCA4_{scenario}_{year_period}_ts_ls_VFVGTAA.nc",
@@ -681,6 +1011,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=800,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "pr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_rca4")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -724,6 +1074,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="pr_annual_absolute_model_ec_earth_rca4",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="pr",
             wms_main_layer_name="pr",
             thredds_url_pattern="EC-EARTH_RCA4ymbc/clipped/pr_EC-EARTH_RCA4_{scenario}_ts_ls_VFVGTAA.nc",
@@ -732,6 +1086,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=3200,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "pr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_rca4")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -747,6 +1121,11 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
             observation_variable_id=(
                 v.id if (v := variables.get("PRCPTOT")) is not None else None
@@ -755,6 +1134,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="pr_seasonal_absolute_model_hadgem2_es_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="pr",
             wms_main_layer_name="pr",
             thredds_url_pattern="HadGEM2-ES_RACMO22Eymbc/clipped/pr_HadGEM2-ES_RACMO22E_{scenario}_{year_period}_ts_ls_VFVGTAA.nc",
@@ -763,6 +1146,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=800,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "pr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "hadgem2_racmo22e")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -806,6 +1209,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="pr_annual_absolute_model_hadgem2_es_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="pr",
             wms_main_layer_name="pr",
             thredds_url_pattern="HadGEM2-ES_RACMO22Eymbc/clipped/pr_HadGEM2-ES_RACMO22E_{scenario}_ts_ls_VFVGTAA.nc",
@@ -814,6 +1221,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=3200,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "pr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "hadgem2_racmo22e")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -829,6 +1256,11 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
             observation_variable_id=(
                 v.id if (v := variables.get("PRCPTOT")) is not None else None
@@ -837,6 +1269,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="pr_seasonal_absolute_model_mpi_esm_lr_remo2009",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="pr",
             wms_main_layer_name="pr",
             thredds_url_pattern="MPI-ESM-LR_REMO2009ymbc/clipped/pr_MPI-ESM-LR_REMO2009_{scenario}_{year_period}_ts_ls_VFVGTAA.nc",
@@ -845,6 +1281,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=800,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "pr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "mpi_esm_lr_remo2009")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -888,6 +1344,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="pr_annual_absolute_model_mpi_esm_lr_remo2009",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="pr",
             wms_main_layer_name="pr",
             thredds_url_pattern="MPI-ESM-LR_REMO2009ymbc/clipped/pr_MPI-ESM-LR_REMO2009_{scenario}_ts_ls_VFVGTAA.nc",
@@ -896,6 +1356,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=3200,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "pr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "mpi_esm_lr_remo2009")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -911,6 +1391,11 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
             observation_variable_id=(
                 v.id if (v := variables.get("PRCPTOT")) is not None else None
@@ -919,6 +1404,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="pr_seasonal_absolute_model_ensemble_upper_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="pr_stdup",
             wms_main_layer_name="pr_stdup",
             thredds_url_pattern="ensymbc/std/clipped/pr_stdup_{scenario}_{year_period}_ts19762100_ls_VFVGTAA.nc",
@@ -927,6 +1416,31 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=800,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "pr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "upper_bound")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -966,6 +1480,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="pr_seasonal_absolute_model_ensemble_lower_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="pr_stddown",
             wms_main_layer_name="pr_stddown",
             thredds_url_pattern="ensymbc/std/clipped/pr_stddown_{scenario}_{year_period}_ts19762100_ls_VFVGTAA.nc",
@@ -974,6 +1492,31 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=800,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "pr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "lower_bound")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -1013,6 +1556,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="pr_annual_absolute_model_ensemble_upper_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="pr_stdup",
             wms_main_layer_name="pr_stdup",
             thredds_url_pattern="ensymbc/std/clipped/pr_stdup_{scenario}_ts19762100_ls_VFVGTAA.nc",
@@ -1023,6 +1570,31 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "pr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "upper_bound")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -1036,10 +1608,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="pr_annual_absolute_model_ensemble_lower_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="pr_stddown",
             wms_main_layer_name="pr_stddown",
             thredds_url_pattern="ensymbc/std/clipped/pr_stddown_{scenario}_ts19762100_ls_VFVGTAA.nc",
@@ -1050,6 +1631,31 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "pr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "lower_bound")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -1063,10 +1669,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="pr_30yr_anomaly_seasonal_agree_model_ensemble",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="pr",
             wms_main_layer_name="pr-uncertainty_group",
             thredds_url_pattern="ensembletwbc/std/clipped/pr_avgagree_percentage_{time_window}_{scenario}_{year_period}_VFVGTAA.nc",
@@ -1075,6 +1690,26 @@ def generate_configurations(
             color_scale_min=-40,
             color_scale_max=40,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "pr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
@@ -1124,6 +1759,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="pr_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="pr",
             wms_main_layer_name="pr",
             thredds_url_pattern="taspr5rcm/clipped/pr_EC-EARTH_CCLM4-8-17_{scenario}_seas_{time_window}_percentage_{year_period}_VFVGTAA.nc",
@@ -1132,6 +1771,26 @@ def generate_configurations(
             color_scale_min=-40,
             color_scale_max=40,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "pr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
@@ -1181,6 +1840,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="pr_30yr_anomaly_seasonal_model_ec_earth_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="pr",
             wms_main_layer_name="pr",
             thredds_url_pattern="taspr5rcm/clipped/pr_EC-EARTH_RACMO22E_{scenario}_seas_{time_window}_percentage_{year_period}_VFVGTAA.nc",
@@ -1189,6 +1852,26 @@ def generate_configurations(
             color_scale_min=-40,
             color_scale_max=40,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "pr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_racmo22e")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
@@ -1238,6 +1921,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="pr_30yr_anomaly_seasonal_model_ec_earth_rca4",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="pr",
             wms_main_layer_name="pr",
             thredds_url_pattern="taspr5rcm/clipped/pr_EC-EARTH_RCA4_{scenario}_seas_{time_window}_percentage_{year_period}_VFVGTAA.nc",
@@ -1246,6 +1933,26 @@ def generate_configurations(
             color_scale_min=-40,
             color_scale_max=40,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "pr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_rca4")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
@@ -1295,6 +2002,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="pr_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="pr",
             wms_main_layer_name="pr",
             thredds_url_pattern="taspr5rcm/clipped/pr_HadGEM2-ES_RACMO22E_{scenario}_seas_{time_window}_percentage_{year_period}_VFVGTAA.nc",
@@ -1303,6 +2014,26 @@ def generate_configurations(
             color_scale_min=-40,
             color_scale_max=40,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "pr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "hadgem2_racmo22e")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
@@ -1352,6 +2083,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="pr_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="pr",
             wms_main_layer_name="pr",
             thredds_url_pattern="taspr5rcm/clipped/pr_MPI-ESM-LR_REMO2009_{scenario}_seas_{time_window}_percentage_{year_period}_VFVGTAA.nc",
@@ -1360,6 +2095,26 @@ def generate_configurations(
             color_scale_min=-40,
             color_scale_max=40,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "pr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "mpi_esm_lr_remo2009")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")

--- a/arpav_ppcv/bootstrapper/coverage_configurations/r95ptot.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/r95ptot.py
@@ -1,15 +1,16 @@
-"""
-- [x] r95ptot_30yr_anomaly_annual_agree_model_ensemble
-- [x] r95ptot_30yr_anomaly_annual_model_ec_earth_cclm4_8_17
-- [x] r95ptot_30yr_anomaly_annual_model_ec_earth_racmo22e
-- [x] r95ptot_30yr_anomaly_annual_model_ec_earth_rca4
-- [x] r95ptot_30yr_anomaly_annual_model_hadgem2_es_racmo22e
-- [x] r95ptot_30yr_anomaly_annual_model_mpi_esm_lr_remo2009
-
-"""
 from ...schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
+)
+
+_DISPLAY_NAME_ENGLISH = "Extreme rainfall"
+_DISPLAY_NAME_ITALIAN = "Precipitazione estrema"
+_DESCRIPTION_ENGLISH = (
+    "Total cumulative precipitation above the 95th percentile of the reference period"
+)
+_DESCRIPTION_ITALIAN = (
+    "Precipitazioni cumulative totali superiori al 95° percentile del periodo di "
+    "riferimento"
 )
 
 
@@ -18,7 +19,11 @@ def generate_configurations(
 ) -> list[CoverageConfigurationCreate]:
     return [
         CoverageConfigurationCreate(
-            name="r95ptot_30yr_anomaly_annual_agree_model_ensemble",
+            name="r95ptot_30yr_anomaly_seasonal_agree_model_ensemble",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="r95ptot",
             wms_main_layer_name="r95ptot-uncertainty_group",
             thredds_url_pattern="ensembletwbc/std/clipped/pr_change_cumulative_check_avgagree_{time_window}_{scenario}_{year_period}_VFVGTAA.nc",
@@ -29,6 +34,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "r95ptot")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -75,7 +100,11 @@ def generate_configurations(
             ],
         ),
         CoverageConfigurationCreate(
-            name="r95ptot_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
+            name="r95ptot_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="r95ptot",
             wms_main_layer_name="r95ptot",
             thredds_url_pattern="indici5rcm/clipped/pr_change_cumulative_EC-EARTH_CCLM4-8-17_{year_period}_{scenario}_{time_window}_VFVGTAA.nc",
@@ -86,6 +115,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "r95ptot")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -132,7 +181,11 @@ def generate_configurations(
             ],
         ),
         CoverageConfigurationCreate(
-            name="r95ptot_30yr_anomaly_annual_model_ec_earth_racmo22e",
+            name="r95ptot_30yr_anomaly_seasonal_model_ec_earth_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="r95ptot",
             wms_main_layer_name="r95ptot",
             thredds_url_pattern="indici5rcm/clipped/pr_change_cumulative_EC-EARTH_RACMO22E_{year_period}_{scenario}_{time_window}_VFVGTAA.nc",
@@ -143,6 +196,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "r95ptot")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_racmo22e")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -189,7 +262,11 @@ def generate_configurations(
             ],
         ),
         CoverageConfigurationCreate(
-            name="r95ptot_30yr_anomaly_annual_model_ec_earth_rca4",
+            name="r95ptot_30yr_anomaly_seasonal_model_ec_earth_rca4",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="r95ptot",
             wms_main_layer_name="r95ptot",
             thredds_url_pattern="indici5rcm/clipped/pr_change_cumulative_EC-EARTH_RCA4_{year_period}_{scenario}_{time_window}_VFVGTAA.nc",
@@ -200,6 +277,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "r95ptot")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_rca4")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -246,7 +343,11 @@ def generate_configurations(
             ],
         ),
         CoverageConfigurationCreate(
-            name="r95ptot_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
+            name="r95ptot_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="r95ptot",
             wms_main_layer_name="r95ptot",
             thredds_url_pattern="indici5rcm/clipped/pr_change_cumulative_HadGEM2-ES_RACMO22E_{year_period}_{scenario}_{time_window}_VFVGTAA.nc",
@@ -257,6 +358,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "r95ptot")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "hadgem2_racmo22e")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -303,7 +424,11 @@ def generate_configurations(
             ],
         ),
         CoverageConfigurationCreate(
-            name="r95ptot_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
+            name="r95ptot_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="r95ptot",
             wms_main_layer_name="r95ptot",
             thredds_url_pattern="indici5rcm/clipped/pr_change_cumulative_MPI-ESM-LR_REMO2009_{year_period}_{scenario}_{time_window}_VFVGTAA.nc",
@@ -312,6 +437,26 @@ def generate_configurations(
             color_scale_min=-160,
             color_scale_max=160,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "r95ptot")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "mpi_esm_lr_remo2009")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
@@ -364,47 +509,47 @@ def generate_configurations(
 
 def get_related_map() -> dict[str, list[str]]:
     return {
-        "r95ptot_30yr_anomaly_annual_agree_model_ensemble": [
-            "r95ptot_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
-            "r95ptot_30yr_anomaly_annual_model_ec_earth_racmo22e",
-            "r95ptot_30yr_anomaly_annual_model_ec_earth_rca4",
-            "r95ptot_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
-            "r95ptot_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
+        "r95ptot_30yr_anomaly_seasonal_agree_model_ensemble": [
+            "r95ptot_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17",
+            "r95ptot_30yr_anomaly_seasonal_model_ec_earth_racmo22e",
+            "r95ptot_30yr_anomaly_seasonal_model_ec_earth_rca4",
+            "r95ptot_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e",
+            "r95ptot_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009",
         ],
-        "r95ptot_30yr_anomaly_annual_model_ec_earth_cclm4_8_17": [
-            "r95ptot_30yr_anomaly_annual_agree_model_ensemble",
-            "r95ptot_30yr_anomaly_annual_model_ec_earth_racmo22e",
-            "r95ptot_30yr_anomaly_annual_model_ec_earth_rca4",
-            "r95ptot_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
-            "r95ptot_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
+        "r95ptot_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17": [
+            "r95ptot_30yr_anomaly_seasonal_agree_model_ensemble",
+            "r95ptot_30yr_anomaly_seasonal_model_ec_earth_racmo22e",
+            "r95ptot_30yr_anomaly_seasonal_model_ec_earth_rca4",
+            "r95ptot_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e",
+            "r95ptot_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009",
         ],
-        "r95ptot_30yr_anomaly_annual_model_ec_earth_racmo22e": [
-            "r95ptot_30yr_anomaly_annual_agree_model_ensemble",
-            "r95ptot_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
-            "r95ptot_30yr_anomaly_annual_model_ec_earth_rca4",
-            "r95ptot_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
-            "r95ptot_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
+        "r95ptot_30yr_anomaly_seasonal_model_ec_earth_racmo22e": [
+            "r95ptot_30yr_anomaly_seasonal_agree_model_ensemble",
+            "r95ptot_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17",
+            "r95ptot_30yr_anomaly_seasonal_model_ec_earth_rca4",
+            "r95ptot_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e",
+            "r95ptot_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009",
         ],
-        "r95ptot_30yr_anomaly_annual_model_ec_earth_rca4": [
-            "r95ptot_30yr_anomaly_annual_agree_model_ensemble",
-            "r95ptot_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
-            "r95ptot_30yr_anomaly_annual_model_ec_earth_racmo22e",
-            "r95ptot_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
-            "r95ptot_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
+        "r95ptot_30yr_anomaly_seasonal_model_ec_earth_rca4": [
+            "r95ptot_30yr_anomaly_seasonal_agree_model_ensemble",
+            "r95ptot_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17",
+            "r95ptot_30yr_anomaly_seasonal_model_ec_earth_racmo22e",
+            "r95ptot_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e",
+            "r95ptot_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009",
         ],
-        "r95ptot_30yr_anomaly_annual_model_hadgem2_es_racmo22e": [
-            "r95ptot_30yr_anomaly_annual_agree_model_ensemble",
-            "r95ptot_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
-            "r95ptot_30yr_anomaly_annual_model_ec_earth_racmo22e",
-            "r95ptot_30yr_anomaly_annual_model_ec_earth_rca4",
-            "r95ptot_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
+        "r95ptot_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e": [
+            "r95ptot_30yr_anomaly_seasonal_agree_model_ensemble",
+            "r95ptot_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17",
+            "r95ptot_30yr_anomaly_seasonal_model_ec_earth_racmo22e",
+            "r95ptot_30yr_anomaly_seasonal_model_ec_earth_rca4",
+            "r95ptot_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009",
         ],
-        "r95ptot_30yr_anomaly_annual_model_mpi_esm_lr_remo2009": [
-            "r95ptot_30yr_anomaly_annual_agree_model_ensemble",
-            "r95ptot_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
-            "r95ptot_30yr_anomaly_annual_model_ec_earth_racmo22e",
-            "r95ptot_30yr_anomaly_annual_model_ec_earth_rca4",
-            "r95ptot_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
+        "r95ptot_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009": [
+            "r95ptot_30yr_anomaly_seasonal_agree_model_ensemble",
+            "r95ptot_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17",
+            "r95ptot_30yr_anomaly_seasonal_model_ec_earth_racmo22e",
+            "r95ptot_30yr_anomaly_seasonal_model_ec_earth_rca4",
+            "r95ptot_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e",
         ],
     }
 

--- a/arpav_ppcv/bootstrapper/coverage_configurations/snwdays.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/snwdays.py
@@ -1,24 +1,16 @@
-"""
-- [x] snwdays_annual_absolute_model_ensemble
-- [x] snwdays_annual_absolute_model_ensemble_upper_uncertainty
-- [x] snwdays_annual_absolute_model_ensemble_lower_uncertainty
-- [x] snwdays_annual_absolute_model_ec_earth_cclm4_8_17
-- [x] snwdays_annual_absolute_model_ec_earth_racmo22e
-- [x] snwdays_annual_absolute_model_ec_earth_rca4
-- [x] snwdays_annual_absolute_model_hadgem2_es_racmo22e
-- [x] snwdays_annual_absolute_model_mpi_esm_lr_remo2009
-
-- [x] 30year anomaly
-  - [x] snwdays_30yr_anomaly_annual_agree_model_ensemble
-  - [x] snwdays_30yr_anomaly_annual_model_ec_earth_cclm4_8_17
-  - [x] snwdays_30yr_anomaly_annual_model_ec_earth_racmo22e
-  - [x] snwdays_30yr_anomaly_annual_model_ec_earth_rca4
-  - [x] snwdays_30yr_anomaly_annual_model_hadgem2_es_racmo22e
-  - [x] snwdays_30yr_anomaly_annual_model_mpi_esm_lr_remo2009
-"""
 from ...schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
+)
+
+_DISPLAY_NAME_ENGLISH = "Days with new snow"
+_DISPLAY_NAME_ITALIAN = "Giorni di gelo"
+_DESCRIPTION_ENGLISH = (
+    "Maximum number of consecutive dry days (daily precipitation less than 1 mm)"
+)
+_DESCRIPTION_ITALIAN = (
+    "Numero massimo di giorni asciutti consecutivi (precipitazioni giornaliere "
+    "inferiori a 1 mm)"
 )
 
 
@@ -28,6 +20,10 @@ def generate_configurations(
     return [
         CoverageConfigurationCreate(
             name="snwdays_annual_absolute_model_ensemble",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="snwdays",
             wms_main_layer_name="snwdays",
             thredds_url_pattern="ensymbc/clipped/snwdays_1mm_2oc_avg_ts19762100_{scenario}_ls_VFVG.nc",
@@ -38,6 +34,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "snwdays")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -51,10 +67,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="snwdays_annual_absolute_model_ec_earth_cclm4_8_17",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="snwdays",
             wms_main_layer_name="snwdays",
             thredds_url_pattern="EC-EARTH_CCLM4-8-17ymbc/clipped/snwdays_1mm_2oc_EC-EARTH_CCLM4-8-17_{scenario}_ts19762100_ls_VFVG.nc",
@@ -65,6 +90,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "snwdays")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -78,10 +123,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="snwdays_annual_absolute_model_ec_earth_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="snwdays",
             wms_main_layer_name="snwdays",
             thredds_url_pattern="EC-EARTH_RACMO22Eymbc/clipped/snwdays_1mm_2oc_EC-EARTH_RACMO22E_{scenario}_ts19762100_ls_VFVG.nc",
@@ -92,6 +146,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "snwdays")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_racmo22e")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -105,10 +179,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="snwdays_annual_absolute_model_ec_earth_rca4",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="snwdays",
             wms_main_layer_name="snwdays",
             thredds_url_pattern="EC-EARTH_RCA4ymbc/clipped/snwdays_1mm_2oc_EC-EARTH_RCA4_{scenario}_ts19762100_ls_VFVG.nc",
@@ -119,6 +202,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "snwdays")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_rca4")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -132,10 +235,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="snwdays_annual_absolute_model_hadgem2_es_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="snwdays",
             wms_main_layer_name="snwdays",
             thredds_url_pattern="HadGEM2-ES_RACMO22Eymbc/clipped/snwdays_1mm_2oc_HadGEM2-ES_RACMO22E_{scenario}_ts19762100_ls_VFVG.nc",
@@ -146,6 +258,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "snwdays")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "hadgem2_racmo22e")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -159,10 +291,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="snwdays_annual_absolute_model_mpi_esm_lr_remo2009",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="snwdays",
             wms_main_layer_name="snwdays",
             thredds_url_pattern="MPI-ESM-LR_REMO2009ymbc/clipped/snwdays_1mm_2oc_MPI-ESM-LR_REMO2009_{scenario}_ts19762100_ls_VFVG.nc",
@@ -173,6 +314,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "snwdays")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "mpi_esm_lr_remo2009")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -186,10 +347,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="snwdays_annual_absolute_model_ensemble_upper_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="snwdays_stdup",
             wms_main_layer_name="snwdays_stdup",
             thredds_url_pattern="ensymbc/std/clipped/snwdays_1mm_2oc_stdup_ts19762100_{scenario}_ls_VFVG.nc",
@@ -200,6 +370,31 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "snwdays")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "upper_bound")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -213,10 +408,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="snwdays_annual_absolute_model_ensemble_lower_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="snwdays_stddown",
             wms_main_layer_name="snwdays_stddown",
             thredds_url_pattern="ensymbc/std/clipped/snwdays_1mm_2oc_stddown_ts19762100_{scenario}_ls_VFVG.nc",
@@ -227,6 +431,31 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "snwdays")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "lower_bound")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -240,11 +469,20 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         # ---
         CoverageConfigurationCreate(
             name="snwdays_30yr_anomaly_annual_agree_model_ensemble",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="snwdays",
             wms_main_layer_name="snwdays-uncertainty_group",
             thredds_url_pattern="ensembletwbc/std/clipped/snwdays_an_1mm_2oc_avgagree_{time_window}_{scenario}_ls_VFVG.nc",
@@ -255,6 +493,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "snwdays")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -278,10 +536,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="snwdays_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="snwdays",
             wms_main_layer_name="snwdays",
             thredds_url_pattern="indici5rcm/clipped/snwdays_an_1mm_2oc_EC-EARTH_CCLM4-8-17_{scenario}_{time_window}_ls_VFVG.nc",
@@ -292,6 +559,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "snwdays")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -315,10 +602,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="snwdays_30yr_anomaly_annual_model_ec_earth_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="snwdays",
             wms_main_layer_name="snwdays",
             thredds_url_pattern="indici5rcm/clipped/snwdays_an_1mm_2oc_EC-EARTH_RACMO22E_{scenario}_{time_window}_ls_VFVG.nc",
@@ -329,6 +625,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "snwdays")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_racmo22e")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -352,10 +668,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="snwdays_30yr_anomaly_annual_model_ec_earth_rca4",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="snwdays",
             wms_main_layer_name="snwdays",
             thredds_url_pattern="indici5rcm/clipped/snwdays_an_1mm_2oc_EC-EARTH_RCA4_{scenario}_{time_window}_ls_VFVG.nc",
@@ -366,6 +691,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "snwdays")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_rca4")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -389,10 +734,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="snwdays_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="snwdays",
             wms_main_layer_name="snwdays",
             thredds_url_pattern="indici5rcm/clipped/snwdays_an_1mm_2oc_HadGEM2-ES_RACMO22E_{scenario}_{time_window}_ls_VFVG.nc",
@@ -403,6 +757,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "snwdays")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "hadgem2_racmo22e")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -426,10 +800,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="snwdays_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="snwdays",
             wms_main_layer_name="snwdays",
             thredds_url_pattern="indici5rcm/clipped/snwdays_an_1mm_2oc_MPI-ESM-LR_REMO2009_{scenario}_{time_window}_ls_VFVG.nc",
@@ -440,6 +823,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "snwdays")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "mpi_esm_lr_remo2009")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -461,6 +864,11 @@ def generate_configurations(
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
                     ].id
                 ),
             ],

--- a/arpav_ppcv/bootstrapper/coverage_configurations/su30.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/su30.py
@@ -1,26 +1,13 @@
-"""
-- [x] su30_annual_absolute_model_ensemble
-- [x] su30_annual_absolute_model_ensemble_upper_uncertainty
-- [x] su30_annual_absolute_model_ensemble_lower_uncertainty
-- [x] su30_annual_absolute_model_ec_earth_cclm4_8_17
-- [x] su30_annual_absolute_model_ec_earth_racmo22e
-- [x] su30_annual_absolute_model_ec_earth_rca4
-- [x] su30_annual_absolute_model_hadgem2_es_racmo22e
-- [x] su30_annual_absolute_model_mpi_esm_lr_remo2009
-
-- [x] 30year anomaly
-  - [x] su30_30yr_anomaly_annual_agree_model_ensemble
-  - [x] su30_30yr_anomaly_annual_model_ec_earth_cclm4_8_17
-  - [x] su30_30yr_anomaly_annual_model_ec_earth_racmo22e
-  - [x] su30_30yr_anomaly_annual_model_ec_earth_rca4
-  - [x] su30_30yr_anomaly_annual_model_hadgem2_es_racmo22e
-  - [x] su30_30yr_anomaly_annual_model_mpi_esm_lr_remo2009
-"""
 from ...schemas.base import ObservationAggregationType
 from ...schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
 )
+
+_DISPLAY_NAME_ENGLISH = "Hot days"
+_DISPLAY_NAME_ITALIAN = "Giorni caldi"
+_DESCRIPTION_ENGLISH = "Number of days with maximum temperature greater than 30 °C"
+_DESCRIPTION_ITALIAN = "Numero di giorni con temperatura massima superiore a 30 °C"
 
 
 def generate_configurations(
@@ -29,6 +16,10 @@ def generate_configurations(
     return [
         CoverageConfigurationCreate(
             name="su30_annual_absolute_model_ensemble",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="su30",
             wms_main_layer_name="su30",
             thredds_url_pattern="ensymbc/clipped/ecasu_30_avg_{scenario}_ts19762100_ls_VFVG.nc",
@@ -39,6 +30,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "su30")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -50,6 +61,11 @@ def generate_configurations(
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
                     ].id
                 ),
             ],
@@ -60,6 +76,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="su30_annual_absolute_model_ec_earth_cclm4_8_17",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="su30",
             wms_main_layer_name="su30",
             thredds_url_pattern="EC-EARTH_CCLM4-8-17ymbc/clipped/ecasu_30_EC-EARTH_CCLM4-8-17_{scenario}_ts19762100_ls_VFVG.nc",
@@ -70,6 +90,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "su30")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -81,6 +121,11 @@ def generate_configurations(
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
                     ].id
                 ),
             ],
@@ -91,6 +136,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="su30_annual_absolute_model_ec_earth_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="su30",
             wms_main_layer_name="su30",
             thredds_url_pattern="EC-EARTH_RACMO22Eymbc/clipped/ecasu_30_EC-EARTH_RACMO22E_{scenario}_ts19762100_ls_VFVG.nc",
@@ -101,6 +150,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "su30")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_racmo22e")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -112,6 +181,11 @@ def generate_configurations(
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
                     ].id
                 ),
             ],
@@ -122,6 +196,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="su30_annual_absolute_model_ec_earth_rca4",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="su30",
             wms_main_layer_name="su30",
             thredds_url_pattern="EC-EARTH_RCA4ymbc/clipped/ecasu_30_EC-EARTH_RCA4_{scenario}_ts19762100_ls_VFVG.nc",
@@ -132,6 +210,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "su30")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_rca4")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -143,6 +241,11 @@ def generate_configurations(
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
                     ].id
                 ),
             ],
@@ -153,6 +256,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="su30_annual_absolute_model_hadgem2_es_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="su30",
             wms_main_layer_name="su30",
             thredds_url_pattern="HadGEM2-ES_RACMO22Eymbc/clipped/ecasu_30_HadGEM2-ES_RACMO22E_{scenario}_ts19762100_ls_VFVG.nc",
@@ -163,6 +270,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "su30")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "hadgem2_racmo22e")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -174,6 +301,11 @@ def generate_configurations(
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
                     ].id
                 ),
             ],
@@ -184,6 +316,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="su30_annual_absolute_model_mpi_esm_lr_remo2009",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="su30",
             wms_main_layer_name="su30",
             thredds_url_pattern="MPI-ESM-LR_REMO2009ymbc/clipped/ecasu_30_MPI-ESM-LR_REMO2009_{scenario}_ts19762100_ls_VFVG.nc",
@@ -194,6 +330,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "su30")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "mpi_esm_lr_remo2009")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -205,6 +361,11 @@ def generate_configurations(
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
                     ].id
                 ),
             ],
@@ -215,6 +376,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="su30_annual_absolute_model_ensemble_upper_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="su30_stdup",
             wms_main_layer_name="su30_stdup",
             thredds_url_pattern="ensymbc/std/clipped/ecasu_30_stdup_{scenario}_ts19762100_ls_VFVG.nc",
@@ -225,6 +390,31 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "su30")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "upper_bound")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -238,10 +428,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="su30_annual_absolute_model_ensemble_lower_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="su30_stddown",
             wms_main_layer_name="su30_stddown",
             thredds_url_pattern="ensymbc/std/clipped/ecasu_30_stddown_{scenario}_ts19762100_ls_VFVG.nc",
@@ -252,6 +451,31 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "su30")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "lower_bound")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -265,10 +489,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="su30_30yr_anomaly_annual_agree_model_ensemble",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="su30",
             wms_main_layer_name="su30-uncertainty_group",
             thredds_url_pattern="ensembletwbc/std/clipped/ecasuan_30_avgagree_{time_window}_{scenario}_ls_VFVG.nc",
@@ -279,6 +512,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "su30")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -302,10 +555,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="su30_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="su30",
             wms_main_layer_name="su30",
             thredds_url_pattern="indici5rcm/clipped/ecasuan_30_EC-EARTH_CCLM4-8-17_{scenario}_{time_window}_ls_VFVG.nc",
@@ -316,6 +578,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "su30")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -339,10 +621,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="su30_30yr_anomaly_annual_model_ec_earth_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="su30",
             wms_main_layer_name="su30",
             thredds_url_pattern="indici5rcm/clipped/ecasuan_30_EC-EARTH_RACMO22E_{scenario}_{time_window}_ls_VFVG.nc",
@@ -353,6 +644,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "su30")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_racmo22e")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -376,10 +687,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="su30_30yr_anomaly_annual_model_ec_earth_rca4",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="su30",
             wms_main_layer_name="su30",
             thredds_url_pattern="indici5rcm/clipped/ecasuan_30_EC-EARTH_RCA4_{scenario}_{time_window}_ls_VFVG.nc",
@@ -390,6 +710,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "su30")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_rca4")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -413,10 +753,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="su30_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="su30",
             wms_main_layer_name="su30",
             thredds_url_pattern="indici5rcm/clipped/ecasuan_30_HadGEM2-ES_RACMO22E_{scenario}_{time_window}_ls_VFVG.nc",
@@ -427,6 +776,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "su30")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "hadgem2_racmo22e")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -450,10 +819,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="su30_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="su30",
             wms_main_layer_name="su30",
             thredds_url_pattern="indici5rcm/clipped/ecasuan_30_MPI-ESM-LR_REMO2009_{scenario}_{time_window}_ls_VFVG.nc",
@@ -464,6 +842,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "su30")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "mpi_esm_lr_remo2009")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -485,6 +883,11 @@ def generate_configurations(
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
                     ].id
                 ),
             ],

--- a/arpav_ppcv/bootstrapper/coverage_configurations/tas.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/tas.py
@@ -1,54 +1,13 @@
-"""
-- [x] anomaly
-  - [x] tas_seasonal_anomaly_model_ensemble
-  - [x] tas_seasonal_anomaly_model_ec_earth_cclm4_8_17
-  - [x] tas_seasonal_anomaly_model_ec_earth_racmo22e
-  - [x] tas_seasonal_anomaly_model_ec_earth_rca4
-  - [x] tas_seasonal_anomaly_model_hadgem2_es_racmo22e
-  - [x] tas_seasonal_anomaly_model_mpi_esm_lr_remo2009
-  - [x] tas_seasonal_anomaly_model_ensemble_upper_uncertainty
-  - [x] tas_seasonal_anomaly_model_ensemble_lower_uncertainty
-
-- [x] absolute value
-
-  - [x] seasonal
-    - [x] tas_seasonal_absolute_model_ensemble
-    - [x] tas_seasonal_absolute_model_ensemble_upper_uncertainty
-    - [x] tas_seasonal_absolute_model_ensemble_lower_uncertainty
-    - [x] tas_seasonal_absolute_model_ec_earth_cclm4_8_17
-    - [x] tas_seasonal_absolute_model_ec_earth_racmo22e
-    - [x] tas_seasonal_absolute_model_ec_earth_rca4
-    - [x] tas_seasonal_absolute_model_hadgem2_es_racmo22e
-    - [x] tas_seasonal_absolute_model_mpi_esm_lr_remo2009
-
-  - [x] annual
-    - [x] tas_annual_absolute_model_ensemble
-    - [x] tas_annual_absolute_model_ensemble_upper_uncertainty
-    - [x] tas_annual_absolute_model_ensemble_lower_uncertainty
-    - [x] tas_annual_absolute_model_ec_earth_cclm4_8_17
-    - [x] tas_annual_absolute_model_ec_earth_racmo22e
-    - [x] tas_annual_absolute_model_ec_earth_rca4
-    - [x] tas_annual_absolute_model_hadgem2_es_racmo22e
-    - [x] tas_annual_absolute_model_mpi_esm_lr_remo2009
-
-- [x] 30year anomaly
-  - [x] tas_30yr_anomaly_seasonal_agree_model_ensemble
-  - [x] tas_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17
-  - [x] tas_30yr_anomaly_seasonal_model_ec_earth_racmo22e
-  - [x] tas_30yr_anomaly_seasonal_model_ec_earth_rca4
-  - [x] tas_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e
-  - [x] tas_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009
-
-- [x] barometro climatico
-  - [x] tas_barometro_climatico
-  - [x] tas_barometro_climatico_lower_uncertainty
-  - [x] tas_barometro_climatico_upper_uncertainty
-"""
 from ...schemas.base import ObservationAggregationType
 from ...schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
 )
+
+_DISPLAY_NAME_ENGLISH = "Mean temperature"
+_DISPLAY_NAME_ITALIAN = "Temperatura media"
+_DESCRIPTION_ENGLISH = "Average daily air temperature near the ground"
+_DESCRIPTION_ITALIAN = "Temperatura media giornaliera dell'aria vicino al suolo"
 
 
 def generate_configurations(
@@ -57,8 +16,10 @@ def generate_configurations(
     return [
         CoverageConfigurationCreate(
             name="tas_seasonal_anomaly_model_ensemble",
-            display_name_english="TAS seasonal anomaly model ensemble",
-            display_name_italian="TAS anomalie stagionali media ensemble",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas",
             wms_main_layer_name="tas",
             thredds_url_pattern="ens5ym/clipped/tas_anom_pp_ts_{scenario}_{year_period}_VFVGTAA.nc",
@@ -67,6 +28,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=6,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -106,8 +87,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tas_seasonal_anomaly_model_ec_earth_cclm4_8_17",
-            display_name_english="TAS seasonal anomaly EC-EARTH_CCLM4-8-17",
-            display_name_italian="TAS anomalie stagionali EC-EARTH_CCLM4-8-17",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas",
             wms_main_layer_name="tas",
             thredds_url_pattern="EC-EARTH_CCLM4-8-17ym/clipped/tas_EC-EARTH_CCLM4-8-17_{scenario}_{year_period}_anomaly_pp_VFVGTAA.nc",
@@ -116,6 +99,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=6,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -155,8 +158,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tas_seasonal_anomaly_model_ec_earth_racmo22e",
-            display_name_english="TAS seasonal anomaly EC-EARTH_RACM022E",
-            display_name_italian="TAS anomalie stagionali EC-EARTH_RACM022E",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas",
             wms_main_layer_name="tas",
             thredds_url_pattern="EC-EARTH_RACMO22Eym/clipped/tas_EC-EARTH_RACMO22E_{scenario}_{year_period}_anomaly_pp_VFVGTAA.nc",
@@ -165,6 +170,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=6,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_racmo22e")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -204,8 +229,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tas_seasonal_anomaly_model_ec_earth_rca4",
-            display_name_english="TAS seasonal anomaly EC-EARTH_RCA4",
-            display_name_italian="TAS anomalie stagionali EC-EARTH_RCA4",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas",
             wms_main_layer_name="tas",
             thredds_url_pattern="EC-EARTH_RCA4ym/clipped/tas_EC-EARTH_RCA4_{scenario}_{year_period}_anomaly_pp_VFVGTAA.nc",
@@ -214,6 +241,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=6,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_rca4")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -253,8 +300,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tas_seasonal_anomaly_model_hadgem2_es_racmo22e",
-            display_name_english="TAS seasonal anomaly HadGEM2-ES_RACM022E",
-            display_name_italian="TAS anomalie stagionali HadGEM2-ES_RACM022E",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas",
             wms_main_layer_name="tas",
             thredds_url_pattern="HadGEM2-ES_RACMO22Eym/clipped/tas_HadGEM2-ES_RACMO22E_{scenario}_{year_period}_anomaly_pp_VFVGTAA.nc",
@@ -263,6 +312,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=6,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "hadgem2_racmo22e")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -302,8 +371,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tas_seasonal_anomaly_model_mpi_esm_lr_remo2009",
-            display_name_english="TAS seasonal anomaly MPI-ESM-LR_REMO2009",
-            display_name_italian="TAS anomalie stagionali MPI-ESM-LR_REMO2009",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas",
             wms_main_layer_name="tas",
             thredds_url_pattern="MPI-ESM-LR_REMO2009ym/clipped/tas_MPI-ESM-LR_REMO2009_{scenario}_{year_period}_anomaly_pp_VFVGTAA.nc",
@@ -312,6 +383,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=6,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "mpi_esm_lr_remo2009")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -351,8 +442,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tas_seasonal_anomaly_model_ensemble_upper_uncertainty",
-            display_name_english="TAS seasonal anomaly upper uncertainty bounds",
-            display_name_italian="TAS anomalie stagionali limiti superiori di incertezza",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas_stdup",
             wms_main_layer_name="tas_stdup",
             thredds_url_pattern="ens5ym/std/clipped/tas_anom_stdup_pp_ts_{scenario}_{year_period}_VFVGTAA.nc",
@@ -361,6 +454,31 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=0,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "upper_bound")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -400,8 +518,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tas_seasonal_anomaly_model_ensemble_lower_uncertainty",
-            display_name_english="TAS seasonal anomaly lower uncertainty bounds",
-            display_name_italian="TAS anomalie stagionali limiti inferiori di incertezza",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas_stddown",
             wms_main_layer_name="tas_stddown",
             thredds_url_pattern="ens5ym/std/clipped/tas_anom_stddown_pp_ts_{scenario}_{year_period}_VFVGTAA.nc",
@@ -410,6 +530,31 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=0,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "lower_bound")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -449,8 +594,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tas_seasonal_absolute_model_ensemble",
-            display_name_english="TAS seasonal absolute model ensemble",
-            display_name_italian="TAS valore assoluto di stagione media ensemble",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas",
             wms_main_layer_name="tas",
             thredds_url_pattern="ensymbc/clipped/tas_avg_{scenario}_{year_period}_ts19762100_ls_VFVG.nc",
@@ -459,6 +606,26 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -502,8 +669,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tas_annual_absolute_model_ensemble",
-            display_name_english="TAS annual absolute model ensemble",
-            display_name_italian="TAS valore assoluto annuale media ensemble",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas",
             wms_main_layer_name="tas",
             thredds_url_pattern="ensymbc/clipped/tas_avg_{scenario}_ts19762100_ls_VFVG.nc",
@@ -512,6 +681,26 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -527,6 +716,11 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
             observation_variable_id=(
                 v.id if (v := variables.get("TDd")) is not None else None
@@ -535,8 +729,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tas_seasonal_absolute_model_ec_earth_cclm4_8_17",
-            display_name_english="TAS seasonal absolute EC-EARTH_CCLM4-8-17",
-            display_name_italian="TAS valore assoluto di stagione EC-EARTH_CCLM4-8-17",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas",
             wms_main_layer_name="tas",
             thredds_url_pattern="EC-EARTH_CCLM4-8-17ymbc/clipped/tas_EC-EARTH_CCLM4-8-17_{scenario}_{year_period}_ts19762100_ls_VFVG.nc",
@@ -545,6 +741,26 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -588,6 +804,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tas_annual_absolute_model_ec_earth_cclm4_8_17",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas",
             wms_main_layer_name="tas",
             thredds_url_pattern="EC-EARTH_CCLM4-8-17ymbc/clipped/tas_EC-EARTH_CCLM4-8-17_{scenario}_ts19762100_ls_VFVG.nc",
@@ -596,6 +816,26 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -611,6 +851,11 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
             observation_variable_id=(
                 v.id if (v := variables.get("TDd")) is not None else None
@@ -619,8 +864,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tas_seasonal_absolute_model_ec_earth_racmo22e",
-            display_name_english="TAS seasonal absolute EC-EARTH_RACMO22E",
-            display_name_italian="TAS valore assoluto di stagione EC-EARTH_RACMO22E",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas",
             wms_main_layer_name="tas",
             thredds_url_pattern="EC-EARTH_RACMO22Eymbc/clipped/tas_EC-EARTH_RACMO22E_{scenario}_{year_period}_ts19762100_ls_VFVG.nc",
@@ -629,6 +876,26 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_racmo22e")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -672,6 +939,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tas_annual_absolute_model_ec_earth_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas",
             wms_main_layer_name="tas",
             thredds_url_pattern="EC-EARTH_RACMO22Eymbc/clipped/tas_EC-EARTH_RACMO22E_{scenario}_ts19762100_ls_VFVG.nc",
@@ -680,6 +951,26 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_racmo22e")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -695,6 +986,11 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
             observation_variable_id=(
                 v.id if (v := variables.get("TDd")) is not None else None
@@ -703,6 +999,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tas_seasonal_absolute_model_ec_earth_rca4",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas",
             wms_main_layer_name="tas",
             thredds_url_pattern="EC-EARTH_RCA4ymbc/clipped/tas_EC-EARTH_RCA4_{scenario}_{year_period}_ts19762100_ls_VFVG.nc",
@@ -711,6 +1011,26 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_rca4")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -754,6 +1074,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tas_annual_absolute_model_ec_earth_rca4",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas",
             wms_main_layer_name="tas",
             thredds_url_pattern="EC-EARTH_RCA4ymbc/clipped/tas_EC-EARTH_RCA4_{scenario}_ts19762100_ls_VFVG.nc",
@@ -762,6 +1086,26 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_rca4")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -777,6 +1121,11 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
             observation_variable_id=(
                 v.id if (v := variables.get("TDd")) is not None else None
@@ -785,6 +1134,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tas_seasonal_absolute_model_hadgem2_es_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas",
             wms_main_layer_name="tas",
             thredds_url_pattern="HadGEM2-ES_RACMO22Eymbc/clipped/tas_HadGEM2-ES_RACMO22E_{scenario}_{year_period}_ts19762100_ls_VFVG.nc",
@@ -793,6 +1146,26 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "hadgem2_racmo22e")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -836,6 +1209,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tas_annual_absolute_model_hadgem2_es_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas",
             wms_main_layer_name="tas",
             thredds_url_pattern="HadGEM2-ES_RACMO22Eymbc/clipped/tas_HadGEM2-ES_RACMO22E_{scenario}_ts19762100_ls_VFVG.nc",
@@ -844,6 +1221,26 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "hadgem2_racmo22e")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -859,6 +1256,11 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
             observation_variable_id=(
                 v.id if (v := variables.get("TDd")) is not None else None
@@ -867,6 +1269,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tas_seasonal_absolute_model_mpi_esm_lr_remo2009",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas",
             wms_main_layer_name="tas",
             thredds_url_pattern="MPI-ESM-LR_REMO2009ymbc/clipped/tas_MPI-ESM-LR_REMO2009_{scenario}_{year_period}_ts19762100_ls_VFVG.nc",
@@ -875,6 +1281,26 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "mpi_esm_lr_remo2009")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -918,6 +1344,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tas_annual_absolute_model_mpi_esm_lr_remo2009",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas",
             wms_main_layer_name="tas",
             thredds_url_pattern="MPI-ESM-LR_REMO2009ymbc/clipped/tas_MPI-ESM-LR_REMO2009_{scenario}_ts19762100_ls_VFVG.nc",
@@ -926,6 +1356,26 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "mpi_esm_lr_remo2009")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -941,6 +1391,11 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
             observation_variable_id=(
                 v.id if (v := variables.get("TDd")) is not None else None
@@ -949,6 +1404,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tas_seasonal_absolute_model_ensemble_upper_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas_stdup",
             wms_main_layer_name="tas_stdup",
             thredds_url_pattern="ensymbc/std/clipped/tas_stdup_{scenario}_{year_period}_ts19762100_ls_VFVG.nc",
@@ -957,6 +1416,31 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "upper_bound")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -996,6 +1480,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tas_seasonal_absolute_model_ensemble_lower_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas_stddown",
             wms_main_layer_name="tas_stddown",
             thredds_url_pattern="ensymbc/std/clipped/tas_stddown_{scenario}_{year_period}_ts19762100_ls_VFVG.nc",
@@ -1004,6 +1492,31 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "lower_bound")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -1043,6 +1556,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tas_annual_absolute_model_ensemble_upper_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas_stdup",
             wms_main_layer_name="tas_stdup",
             thredds_url_pattern="ensymbc/std/clipped/tas_stdup_{scenario}_ts19762100_ls_VFVG.nc",
@@ -1053,6 +1570,31 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "upper_bound")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -1066,10 +1608,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="tas_annual_absolute_model_ensemble_lower_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas_stddown",
             wms_main_layer_name="tas_stddown",
             thredds_url_pattern="ensymbc/std/clipped/tas_stddown_{scenario}_ts19762100_ls_VFVG.nc",
@@ -1080,6 +1631,31 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "lower_bound")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -1093,10 +1669,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="tas_30yr_anomaly_seasonal_agree_model_ensemble",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas",
             wms_main_layer_name="tas-uncertainty_group",
             thredds_url_pattern="ensembletwbc/std/clipped/tas_avgagree_anom_{time_window}_{scenario}_{year_period}_VFVGTAA.nc",
@@ -1105,6 +1690,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=6,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
@@ -1154,6 +1759,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tas_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas",
             wms_main_layer_name="tas",
             thredds_url_pattern="taspr5rcm/clipped/tas_EC-EARTH_CCLM4-8-17_{scenario}_seas_{time_window}{year_period}_VFVGTAA.nc",
@@ -1162,6 +1771,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=6,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
@@ -1211,6 +1840,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tas_30yr_anomaly_seasonal_model_ec_earth_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas",
             wms_main_layer_name="tas",
             thredds_url_pattern="taspr5rcm/clipped/tas_EC-EARTH_RACMO22E_{scenario}_seas_{time_window}{year_period}_VFVGTAA.nc",
@@ -1219,6 +1852,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=6,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_racmo22e")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
@@ -1268,6 +1921,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tas_30yr_anomaly_seasonal_model_ec_earth_rca4",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas",
             wms_main_layer_name="tas",
             thredds_url_pattern="taspr5rcm/clipped/tas_EC-EARTH_RCA4_{scenario}_seas_{time_window}{year_period}_VFVGTAA.nc",
@@ -1276,6 +1933,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=6,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_rca4")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
@@ -1325,6 +2002,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tas_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas",
             wms_main_layer_name="tas",
             thredds_url_pattern="taspr5rcm/clipped/tas_HadGEM2-ES_RACMO22E_{scenario}_seas_{time_window}{year_period}_VFVGTAA.nc",
@@ -1333,6 +2014,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=6,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "hadgem2_racmo22e")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
@@ -1382,6 +2083,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tas_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas",
             wms_main_layer_name="tas",
             thredds_url_pattern="taspr5rcm/clipped/tas_MPI-ESM-LR_REMO2009_{scenario}_seas_{time_window}{year_period}_VFVGTAA.nc",
@@ -1390,6 +2095,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=6,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "mpi_esm_lr_remo2009")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
@@ -1439,6 +2164,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tas_barometro_climatico",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas",
             wms_main_layer_name="tas",
             thredds_url_pattern="ensymbc/std/clipped/fldmean/tas_avg_{scenario}_ts19762100_ls_VFVG_fldmean.nc",
@@ -1447,6 +2176,16 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "barometro_climatico")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -1466,6 +2205,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tas_barometro_climatico_lower_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas_stddown",
             wms_main_layer_name="tas_stddown",
             thredds_url_pattern="ensymbc/std/clipped/fldmean/tas_stddown_{scenario}_ts19762100_ls_VFVG_fldmean.nc",
@@ -1474,6 +2217,21 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "barometro_climatico")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "lower_bound")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -1493,6 +2251,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tas_barometro_climatico_upper_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tas_stdup",
             wms_main_layer_name="tas_stdup",
             thredds_url_pattern="ensymbc/std/clipped/fldmean/tas_stdup_{scenario}_ts19762100_ls_VFVG_fldmean.nc",
@@ -1501,6 +2263,21 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tas")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "barometro_climatico")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "upper_bound")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")

--- a/arpav_ppcv/bootstrapper/coverage_configurations/tasmax.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/tasmax.py
@@ -1,37 +1,13 @@
-"""
-- [x] seasonal
-  - [x] tasmax_seasonal_absolute_model_ensemble
-  - [x] tasmax_seasonal_absolute_model_ensemble_upper_uncertainty
-  - [x] tasmax_seasonal_absolute_model_ensemble_lower_uncertainty
-  - [x] tasmax_seasonal_absolute_model_ec_earth_cclm4_8_17
-  - [x] tasmax_seasonal_absolute_model_ec_earth_racmo22e
-  - [x] tasmax_seasonal_absolute_model_ec_earth_rca4
-  - [x] tasmax_seasonal_absolute_model_hadgem2_es_racmo22e
-  - [x] tasmax_seasonal_absolute_model_mpi_esm_lr_remo2009
-
-- [x] annual
-  - [x] tasmax_annual_absolute_model_ensemble
-  - [x] tasmax_annual_absolute_model_ensemble_upper_uncertainty
-  - [x] tasmax_annual_absolute_model_ensemble_lower_uncertainty
-  - [x] tasmax_annual_absolute_model_ec_earth_cclm4_8_17
-  - [x] tasmax_annual_absolute_model_ec_earth_racmo22e
-  - [x] tasmax_annual_absolute_model_ec_earth_rca4
-  - [x] tasmax_annual_absolute_model_hadgem2_es_racmo22e
-  - [x] tasmax_annual_absolute_model_mpi_esm_lr_remo2009
-
-- [x] 30year anomaly
-  - [x] tasmax_30yr_anomaly_seasonal_agree_model_ensemble
-  - [x] tasmax_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17
-  - [x] tasmax_30yr_anomaly_seasonal_model_ec_earth_racmo22e
-  - [x] tasmax_30yr_anomaly_seasonal_model_ec_earth_rca4
-  - [x] tasmax_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e
-  - [x] tasmax_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009
-"""
 from ...schemas.base import ObservationAggregationType
 from ...schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
 )
+
+_DISPLAY_NAME_ENGLISH = "Maximum temperature"
+_DISPLAY_NAME_ITALIAN = "Temperatura massima"
+_DESCRIPTION_ENGLISH = "Maximum daily air temperature near the ground"
+_DESCRIPTION_ITALIAN = "Temperatura massima giornaliera dell'aria vicino al suolo"
 
 
 def generate_configurations(
@@ -40,6 +16,10 @@ def generate_configurations(
     return [
         CoverageConfigurationCreate(
             name="tasmax_seasonal_absolute_model_ensemble",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmax",
             wms_main_layer_name="tasmax",
             thredds_url_pattern="ensymbc/clipped/tasmax_avg_{scenario}_{year_period}_ts19762100_ls_VFVG.nc",
@@ -48,6 +28,26 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmax")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -91,6 +91,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmax_annual_absolute_model_ensemble",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmax",
             wms_main_layer_name="tasmax",
             thredds_url_pattern="ensymbc/clipped/tasmax_avg_{scenario}_ts19762100_ls_VFVG.nc",
@@ -99,6 +103,26 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmax")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -114,6 +138,11 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
             observation_variable_id=(
                 v.id if (v := variables.get("TXd")) is not None else None
@@ -122,6 +151,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmax_seasonal_absolute_model_ec_earth_cclm4_8_17",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmax",
             wms_main_layer_name="tasmax",
             thredds_url_pattern="EC-EARTH_CCLM4-8-17ymbc/clipped/tasmax_EC-EARTH_CCLM4-8-17_{scenario}_{year_period}_ts19762100_ls_VFVG.nc",
@@ -130,6 +163,26 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmax")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -173,6 +226,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmax_annual_absolute_model_ec_earth_cclm4_8_17",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmax",
             wms_main_layer_name="tasmax",
             thredds_url_pattern="EC-EARTH_CCLM4-8-17ymbc/clipped/tasmax_EC-EARTH_CCLM4-8-17_{scenario}_ts19762100_ls_VFVG.nc",
@@ -181,6 +238,26 @@ def generate_configurations(
             color_scale_min=7,
             color_scale_max=37,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmax")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -196,6 +273,11 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
             observation_variable_id=(
                 v.id if (v := variables.get("TXd")) is not None else None
@@ -204,6 +286,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmax_seasonal_absolute_model_ec_earth_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmax",
             wms_main_layer_name="tasmax",
             thredds_url_pattern="EC-EARTH_RACMO22Eymbc/clipped/tasmax_EC-EARTH_RACMO22E_{scenario}_{year_period}_ts19762100_ls_VFVG.nc",
@@ -212,6 +298,26 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmax")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_racmo22e")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -255,6 +361,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmax_annual_absolute_model_ec_earth_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmax",
             wms_main_layer_name="tasmax",
             thredds_url_pattern="EC-EARTH_RACMO22Eymbc/clipped/tasmax_EC-EARTH_RACMO22E_{scenario}_ts19762100_ls_VFVG.nc",
@@ -263,6 +373,26 @@ def generate_configurations(
             color_scale_min=7,
             color_scale_max=37,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmax")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_racmo22e")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -278,6 +408,11 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
             observation_variable_id=(
                 v.id if (v := variables.get("TXd")) is not None else None
@@ -286,6 +421,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmax_seasonal_absolute_model_ec_earth_rca4",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmax",
             wms_main_layer_name="tasmax",
             thredds_url_pattern="EC-EARTH_RCA4ymbc/clipped/tasmax_EC-EARTH_RCA4_{scenario}_{year_period}_ts19762100_ls_VFVG.nc",
@@ -294,6 +433,26 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmax")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_rca4")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -337,6 +496,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmax_annual_absolute_model_ec_earth_rca4",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmax",
             wms_main_layer_name="tasmax",
             thredds_url_pattern="EC-EARTH_RCA4ymbc/clipped/tasmax_EC-EARTH_RCA4_{scenario}_ts19762100_ls_VFVG.nc",
@@ -345,6 +508,26 @@ def generate_configurations(
             color_scale_min=7,
             color_scale_max=37,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmax")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_rca4")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -360,6 +543,11 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
             observation_variable_id=(
                 v.id if (v := variables.get("TXd")) is not None else None
@@ -368,6 +556,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmax_seasonal_absolute_model_hadgem2_es_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmax",
             wms_main_layer_name="tasmax",
             thredds_url_pattern="HadGEM2-ES_RACMO22Eymbc/clipped/tasmax_HadGEM2-ES_RACMO22E_{scenario}_{year_period}_ts19762100_ls_VFVG.nc",
@@ -376,6 +568,26 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmax")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "hadgem2_racmo22e")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -419,6 +631,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmax_annual_absolute_model_hadgem2_es_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmax",
             wms_main_layer_name="tasmax",
             thredds_url_pattern="HadGEM2-ES_RACMO22Eymbc/clipped/tasmax_HadGEM2-ES_RACMO22E_{scenario}_ts19762100_ls_VFVG.nc",
@@ -427,6 +643,26 @@ def generate_configurations(
             color_scale_min=7,
             color_scale_max=37,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmax")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "hadgem2_racmo22e")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -442,6 +678,11 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
             observation_variable_id=(
                 v.id if (v := variables.get("TXd")) is not None else None
@@ -450,6 +691,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmax_seasonal_absolute_model_mpi_esm_lr_remo2009",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmax",
             wms_main_layer_name="tasmax",
             thredds_url_pattern="MPI-ESM-LR_REMO2009ymbc/clipped/tasmax_MPI-ESM-LR_REMO2009_{scenario}_{year_period}_ts19762100_ls_VFVG.nc",
@@ -458,6 +703,26 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmax")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "mpi_esm_lr_remo2009")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -501,6 +766,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmax_annual_absolute_model_mpi_esm_lr_remo2009",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmax",
             wms_main_layer_name="tasmax",
             thredds_url_pattern="MPI-ESM-LR_REMO2009ymbc/clipped/tasmax_MPI-ESM-LR_REMO2009_{scenario}_ts19762100_ls_VFVG.nc",
@@ -509,6 +778,26 @@ def generate_configurations(
             color_scale_min=7,
             color_scale_max=37,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmax")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "mpi_esm_lr_remo2009")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -524,6 +813,11 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
             observation_variable_id=(
                 v.id if (v := variables.get("TXd")) is not None else None
@@ -532,6 +826,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmax_seasonal_absolute_model_ensemble_upper_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmax_stdup",
             wms_main_layer_name="tasmax_stdup",
             thredds_url_pattern="ensymbc/std/clipped/tasmax_stdup_{scenario}_{year_period}_ts19762100_ls_VFVG.nc",
@@ -540,6 +838,31 @@ def generate_configurations(
             color_scale_min=7,
             color_scale_max=37,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmax")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "upper_bound")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -579,6 +902,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmax_seasonal_absolute_model_ensemble_lower_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmax_stddown",
             wms_main_layer_name="tasmax_stddown",
             thredds_url_pattern="ensymbc/std/clipped/tasmax_stddown_{scenario}_{year_period}_ts19762100_ls_VFVG.nc",
@@ -587,6 +914,31 @@ def generate_configurations(
             color_scale_min=7,
             color_scale_max=37,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmax")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "lower_bound")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -626,6 +978,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmax_annual_absolute_model_ensemble_upper_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmax_stdup",
             wms_main_layer_name="tasmax_stdup",
             thredds_url_pattern="ensymbc/std/clipped/tasmax_stdup_{scenario}_ts19762100_ls_VFVG.nc",
@@ -636,6 +992,31 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmax")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "upper_bound")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -649,10 +1030,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="tasmax_annual_absolute_model_ensemble_lower_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmax_stddown",
             wms_main_layer_name="tasmax_stddown",
             thredds_url_pattern="ensymbc/std/clipped/tasmax_stddown_{scenario}_ts19762100_ls_VFVG.nc",
@@ -663,6 +1053,31 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmax")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "lower_bound")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -676,10 +1091,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="tasmax_30yr_anomaly_seasonal_agree_model_ensemble",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmax",
             wms_main_layer_name="tasmax-uncertainty_group",
             thredds_url_pattern="ensembletwbc/std/clipped/tasmax_avgagree_anom_{time_window}_{scenario}_{year_period}_VFVGTAA.nc",
@@ -688,6 +1112,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=6,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmax")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
@@ -737,6 +1181,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmax_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmax",
             wms_main_layer_name="tasmax",
             thredds_url_pattern="taspr5rcm/clipped/tasmax_EC-EARTH_CCLM4-8-17_{scenario}_seas_{time_window}{year_period}_VFVGTAA.nc",
@@ -745,6 +1193,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=6,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmax")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
@@ -794,6 +1262,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmax_30yr_anomaly_seasonal_model_ec_earth_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmax",
             wms_main_layer_name="tasmax",
             thredds_url_pattern="taspr5rcm/clipped/tasmax_EC-EARTH_RACMO22E_{scenario}_seas_{time_window}{year_period}_VFVGTAA.nc",
@@ -802,6 +1274,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=6,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmax")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_racmo22e")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
@@ -851,6 +1343,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmax_30yr_anomaly_seasonal_model_ec_earth_rca4",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmax",
             wms_main_layer_name="tasmax",
             thredds_url_pattern="taspr5rcm/clipped/tasmax_EC-EARTH_RCA4_{scenario}_seas_{time_window}{year_period}_VFVGTAA.nc",
@@ -859,6 +1355,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=6,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmax")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_rca4")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
@@ -908,6 +1424,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmax_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmax",
             wms_main_layer_name="tasmax",
             thredds_url_pattern="taspr5rcm/clipped/tasmax_HadGEM2-ES_RACMO22E_{scenario}_seas_{time_window}{year_period}_VFVGTAA.nc",
@@ -916,6 +1436,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=6,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmax")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "hadgem2_racmo22e")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
@@ -965,6 +1505,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmax_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmax",
             wms_main_layer_name="tasmax",
             thredds_url_pattern="taspr5rcm/clipped/tasmax_MPI-ESM-LR_REMO2009_{scenario}_seas_{time_window}{year_period}_VFVGTAA.nc",
@@ -973,6 +1517,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=6,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmax")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "mpi_esm_lr_remo2009")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")

--- a/arpav_ppcv/bootstrapper/coverage_configurations/tasmin.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/tasmin.py
@@ -1,37 +1,13 @@
-"""
-- [x] seasonal
-  - [x] tasmin_seasonal_absolute_model_ensemble
-  - [x] tasmin_seasonal_absolute_model_ensemble_upper_uncertainty
-  - [x] tasmin_seasonal_absolute_model_ensemble_lower_uncertainty
-  - [x] tasmin_seasonal_absolute_model_ec_earth_cclm4_8_17
-  - [x] tasmin_seasonal_absolute_model_ec_earth_racmo22e
-  - [x] tasmin_seasonal_absolute_model_ec_earth_rca4
-  - [x] tasmin_seasonal_absolute_model_hadgem2_es_racmo22e
-  - [x] tasmin_seasonal_absolute_model_mpi_esm_lr_remo2009
-
-- [x] annual
-  - [x] tasmin_annual_absolute_model_ensemble
-  - [x] tasmin_annual_absolute_model_ensemble_upper_uncertainty
-  - [x] tasmin_annual_absolute_model_ensemble_lower_uncertainty
-  - [x] tasmin_annual_absolute_model_ec_earth_cclm4_8_17
-  - [x] tasmin_annual_absolute_model_ec_earth_racmo22e
-  - [x] tasmin_annual_absolute_model_ec_earth_rca4
-  - [x] tasmin_annual_absolute_model_hadgem2_es_racmo22e
-  - [x] tasmin_annual_absolute_model_mpi_esm_lr_remo2009
-
-- [x] 30year anomaly
-  - [x] tasmin_30yr_anomaly_seasonal_agree_model_ensemble
-  - [x] tasmin_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17
-  - [x] tasmin_30yr_anomaly_seasonal_model_ec_earth_racmo22e
-  - [x] tasmin_30yr_anomaly_seasonal_model_ec_earth_rca4
-  - [x] tasmin_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e
-  - [x] tasmin_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009
-"""
 from ...schemas.base import ObservationAggregationType
 from ...schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
 )
+
+_DISPLAY_NAME_ENGLISH = "Minimum temperature"
+_DISPLAY_NAME_ITALIAN = "Temperatura minima"
+_DESCRIPTION_ENGLISH = "Minimum daily air temperature near the ground"
+_DESCRIPTION_ITALIAN = "Temperatura minima giornaliera dell'aria vicino al suolo"
 
 
 def generate_configurations(
@@ -40,6 +16,10 @@ def generate_configurations(
     return [
         CoverageConfigurationCreate(
             name="tasmin_seasonal_absolute_model_ensemble",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmin",
             wms_main_layer_name="tasmin",
             thredds_url_pattern="ensymbc/clipped/tasmin_avg_{scenario}_{year_period}_ts19762100_ls_VFVG.nc",
@@ -48,6 +28,26 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmin")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -91,6 +91,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmin_annual_absolute_model_ensemble",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmin",
             wms_main_layer_name="tasmin",
             thredds_url_pattern="ensymbc/clipped/tasmin_avg_{scenario}_ts19762100_ls_VFVG.nc",
@@ -99,6 +103,26 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmin")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -114,6 +138,11 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
             observation_variable_id=(
                 v.id if (v := variables.get("TNd")) is not None else None
@@ -122,6 +151,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmin_seasonal_absolute_model_ec_earth_cclm4_8_17",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmin",
             wms_main_layer_name="tasmin",
             thredds_url_pattern="EC-EARTH_CCLM4-8-17ymbc/clipped/tasmin_EC-EARTH_CCLM4-8-17_{scenario}_{year_period}_ts19762100_ls_VFVG.nc",
@@ -130,6 +163,26 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmin")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -173,6 +226,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmin_annual_absolute_model_ec_earth_cclm4_8_17",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmin",
             wms_main_layer_name="tasmin",
             thredds_url_pattern="EC-EARTH_CCLM4-8-17ymbc/clipped/tasmin_EC-EARTH_CCLM4-8-17_{scenario}_ts19762100_ls_VFVG.nc",
@@ -181,6 +238,26 @@ def generate_configurations(
             color_scale_min=-13,
             color_scale_max=27,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmin")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -196,6 +273,11 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
             observation_variable_id=(
                 v.id if (v := variables.get("TNd")) is not None else None
@@ -204,6 +286,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmin_seasonal_absolute_model_ec_earth_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmin",
             wms_main_layer_name="tasmin",
             thredds_url_pattern="EC-EARTH_RACMO22Eymbc/clipped/tasmin_EC-EARTH_RACMO22E_{scenario}_{year_period}_ts19762100_ls_VFVG.nc",
@@ -212,6 +298,26 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmin")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_racmo22e")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -255,6 +361,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmin_annual_absolute_model_ec_earth_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmin",
             wms_main_layer_name="tasmin",
             thredds_url_pattern="EC-EARTH_RACMO22Eymbc/clipped/tasmin_EC-EARTH_RACMO22E_{scenario}_ts19762100_ls_VFVG.nc",
@@ -263,6 +373,26 @@ def generate_configurations(
             color_scale_min=-13,
             color_scale_max=27,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmin")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_racmo22e")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -278,6 +408,11 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
             observation_variable_id=(
                 v.id if (v := variables.get("TNd")) is not None else None
@@ -286,6 +421,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmin_seasonal_absolute_model_ec_earth_rca4",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmin",
             wms_main_layer_name="tasmin",
             thredds_url_pattern="EC-EARTH_RCA4ymbc/clipped/tasmin_EC-EARTH_RCA4_{scenario}_{year_period}_ts19762100_ls_VFVG.nc",
@@ -294,6 +433,26 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmin")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_rca4")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -337,6 +496,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmin_annual_absolute_model_ec_earth_rca4",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmin",
             wms_main_layer_name="tasmin",
             thredds_url_pattern="EC-EARTH_RCA4ymbc/clipped/tasmin_EC-EARTH_RCA4_{scenario}_ts19762100_ls_VFVG.nc",
@@ -345,6 +508,26 @@ def generate_configurations(
             color_scale_min=-13,
             color_scale_max=27,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmin")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_rca4")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -360,6 +543,11 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
             observation_variable_id=(
                 v.id if (v := variables.get("TNd")) is not None else None
@@ -368,6 +556,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmin_seasonal_absolute_model_hadgem2_es_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmin",
             wms_main_layer_name="tasmin",
             thredds_url_pattern="HadGEM2-ES_RACMO22Eymbc/clipped/tasmin_HadGEM2-ES_RACMO22E_{scenario}_{year_period}_ts19762100_ls_VFVG.nc",
@@ -376,6 +568,26 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmin")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "hadgem2_racmo22e")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -419,6 +631,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmin_annual_absolute_model_hadgem2_es_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmin",
             wms_main_layer_name="tasmin",
             thredds_url_pattern="HadGEM2-ES_RACMO22Eymbc/clipped/tasmin_HadGEM2-ES_RACMO22E_{scenario}_ts19762100_ls_VFVG.nc",
@@ -427,6 +643,26 @@ def generate_configurations(
             color_scale_min=-13,
             color_scale_max=27,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmin")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "hadgem2_racmo22e")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -442,6 +678,11 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
             observation_variable_id=(
                 v.id if (v := variables.get("TNd")) is not None else None
@@ -450,6 +691,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmin_seasonal_absolute_model_mpi_esm_lr_remo2009",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmin",
             wms_main_layer_name="tasmin",
             thredds_url_pattern="MPI-ESM-LR_REMO2009ymbc/clipped/tasmin_MPI-ESM-LR_REMO2009_{scenario}_{year_period}_ts19762100_ls_VFVG.nc",
@@ -458,6 +703,26 @@ def generate_configurations(
             color_scale_min=-3,
             color_scale_max=32,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmin")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "mpi_esm_lr_remo2009")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -501,6 +766,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmin_annual_absolute_model_mpi_esm_lr_remo2009",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmin",
             wms_main_layer_name="tasmin",
             thredds_url_pattern="MPI-ESM-LR_REMO2009ymbc/clipped/tasmin_MPI-ESM-LR_REMO2009_{scenario}_ts19762100_ls_VFVG.nc",
@@ -509,6 +778,26 @@ def generate_configurations(
             color_scale_min=-13,
             color_scale_max=27,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmin")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "mpi_esm_lr_remo2009")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -524,6 +813,11 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
             observation_variable_id=(
                 v.id if (v := variables.get("TNd")) is not None else None
@@ -532,6 +826,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmin_seasonal_absolute_model_ensemble_upper_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmin_stdup",
             wms_main_layer_name="tasmin_stdup",
             thredds_url_pattern="ensymbc/std/clipped/tasmin_stdup_{scenario}_{year_period}_ts19762100_ls_VFVG.nc",
@@ -540,6 +838,31 @@ def generate_configurations(
             color_scale_min=-13,
             color_scale_max=27,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmin")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "upper_bound")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -579,6 +902,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmin_seasonal_absolute_model_ensemble_lower_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmin_stddown",
             wms_main_layer_name="tasmin_stddown",
             thredds_url_pattern="ensymbc/std/clipped/tasmin_stddown_{scenario}_{year_period}_ts19762100_ls_VFVG.nc",
@@ -587,6 +914,31 @@ def generate_configurations(
             color_scale_min=-13,
             color_scale_max=27,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmin")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "lower_bound")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
@@ -626,6 +978,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmin_annual_absolute_model_ensemble_upper_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmin_stdup",
             wms_main_layer_name="tasmin_stdup",
             thredds_url_pattern="ensymbc/std/clipped/tasmin_stdup_{scenario}_ts19762100_ls_VFVG.nc",
@@ -636,6 +992,31 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmin")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "upper_bound")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -649,10 +1030,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="tasmin_annual_absolute_model_ensemble_lower_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmin_stddown",
             wms_main_layer_name="tasmin_stddown",
             thredds_url_pattern="ensymbc/std/clipped/tasmin_stddown_{scenario}_ts19762100_ls_VFVG.nc",
@@ -663,6 +1053,31 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmin")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "lower_bound")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -676,10 +1091,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="tasmin_30yr_anomaly_seasonal_agree_model_ensemble",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmin",
             wms_main_layer_name="tasmin-uncertainty_group",
             thredds_url_pattern="ensembletwbc/std/clipped/tasmin_avgagree_anom_{time_window}_{scenario}_{year_period}_VFVGTAA.nc",
@@ -688,6 +1112,31 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=6,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmin")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "lower_bound")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
@@ -737,6 +1186,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmin_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmin",
             wms_main_layer_name="tasmin",
             thredds_url_pattern="taspr5rcm/clipped/tasmin_EC-EARTH_CCLM4-8-17_{scenario}_seas_{time_window}{year_period}_VFVGTAA.nc",
@@ -745,6 +1198,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=6,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmin")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
@@ -794,6 +1267,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmin_30yr_anomaly_seasonal_model_ec_earth_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmin",
             wms_main_layer_name="tasmin",
             thredds_url_pattern="taspr5rcm/clipped/tasmin_EC-EARTH_RACMO22E_{scenario}_seas_{time_window}{year_period}_VFVGTAA.nc",
@@ -802,6 +1279,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=6,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmin")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_racmo22e")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
@@ -851,6 +1348,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmin_30yr_anomaly_seasonal_model_ec_earth_rca4",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmin",
             wms_main_layer_name="tasmin",
             thredds_url_pattern="taspr5rcm/clipped/tasmin_EC-EARTH_RCA4_{scenario}_seas_{time_window}{year_period}_VFVGTAA.nc",
@@ -859,6 +1360,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=6,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmin")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_rca4")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
@@ -908,6 +1429,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmin_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmin",
             wms_main_layer_name="tasmin",
             thredds_url_pattern="taspr5rcm/clipped/tasmin_HadGEM2-ES_RACMO22E_{scenario}_seas_{time_window}{year_period}_VFVGTAA.nc",
@@ -916,6 +1441,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=6,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmin")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "hadgem2_racmo22e")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
@@ -965,6 +1510,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tasmin_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tasmin",
             wms_main_layer_name="tasmin",
             thredds_url_pattern="taspr5rcm/clipped/tasmin_MPI-ESM-LR_REMO2009_{scenario}_seas_{time_window}{year_period}_VFVGTAA.nc",
@@ -973,6 +1522,26 @@ def generate_configurations(
             color_scale_min=0,
             color_scale_max=6,
             possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tasmin")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "mpi_esm_lr_remo2009")
+                    ].id
+                ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")

--- a/arpav_ppcv/bootstrapper/coverage_configurations/tr.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/tr.py
@@ -1,26 +1,13 @@
-"""
-- [x] tr_annual_absolute_model_ensemble
-- [x] tr_annual_absolute_model_ensemble_upper_uncertainty
-- [x] tr_annual_absolute_model_ensemble_lower_uncertainty
-- [x] tr_annual_absolute_model_ec_earth_cclm4_8_17
-- [x] tr_annual_absolute_model_ec_earth_racmo22e
-- [x] tr_annual_absolute_model_ec_earth_rca4
-- [x] tr_annual_absolute_model_hadgem2_es_racmo22e
-- [x] tr_annual_absolute_model_mpi_esm_lr_remo2009
-
-- [x] 30year anomaly
-  - [x] tr_30yr_anomaly_annual_agree_model_ensemble
-  - [x] tr_30yr_anomaly_annual_model_ec_earth_cclm4_8_17
-  - [x] tr_30yr_anomaly_annual_model_ec_earth_racmo22e
-  - [x] tr_30yr_anomaly_annual_model_ec_earth_rca4
-  - [x] tr_30yr_anomaly_annual_model_hadgem2_es_racmo22e
-  - [x] tr_30yr_anomaly_annual_model_mpi_esm_lr_remo2009
-"""
 from ...schemas.base import ObservationAggregationType
 from ...schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
 )
+
+_DISPLAY_NAME_ENGLISH = "Tropical nights"
+_DISPLAY_NAME_ITALIAN = "Notti tropicali"
+_DESCRIPTION_ENGLISH = "Number of days with minimum temperature greater than 20 °C"
+_DESCRIPTION_ITALIAN = "Numero di giorni con temperatura minima superiore a 20 °C"
 
 
 def generate_configurations(
@@ -29,6 +16,10 @@ def generate_configurations(
     return [
         CoverageConfigurationCreate(
             name="tr_annual_absolute_model_ensemble",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tr",
             wms_main_layer_name="tr",
             thredds_url_pattern="ensymbc/clipped/ecatr_20_avg_{scenario}_ts19762100_ls_VFVG.nc",
@@ -39,6 +30,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -50,6 +61,11 @@ def generate_configurations(
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
                     ].id
                 ),
             ],
@@ -60,6 +76,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tr_annual_absolute_model_ec_earth_cclm4_8_17",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tr",
             wms_main_layer_name="tr",
             thredds_url_pattern="EC-EARTH_CCLM4-8-17ymbc/clipped/ecatr_20_EC-EARTH_CCLM4-8-17_{scenario}_ts19762100_ls_VFVG.nc",
@@ -70,6 +90,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -81,6 +121,11 @@ def generate_configurations(
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
                     ].id
                 ),
             ],
@@ -91,6 +136,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tr_annual_absolute_model_ec_earth_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tr",
             wms_main_layer_name="tr",
             thredds_url_pattern="EC-EARTH_RACMO22Eymbc/clipped/ecatr_20_EC-EARTH_RACMO22E_{scenario}_ts19762100_ls_VFVG.nc",
@@ -101,6 +150,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_racmo22e")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -112,6 +181,11 @@ def generate_configurations(
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
                     ].id
                 ),
             ],
@@ -122,6 +196,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tr_annual_absolute_model_ec_earth_rca4",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tr",
             wms_main_layer_name="tr",
             thredds_url_pattern="EC-EARTH_RCA4ymbc/clipped/ecatr_20_EC-EARTH_RCA4_{scenario}_ts19762100_ls_VFVG.nc",
@@ -132,6 +210,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_rca4")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -143,6 +241,11 @@ def generate_configurations(
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
                     ].id
                 ),
             ],
@@ -153,6 +256,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tr_annual_absolute_model_hadgem2_es_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tr",
             wms_main_layer_name="tr",
             thredds_url_pattern="HadGEM2-ES_RACMO22Eymbc/clipped/ecatr_20_HadGEM2-ES_RACMO22E_{scenario}_ts19762100_ls_VFVG.nc",
@@ -163,6 +270,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "hadgem2_racmo22e")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -174,6 +301,11 @@ def generate_configurations(
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
                     ].id
                 ),
             ],
@@ -184,6 +316,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tr_annual_absolute_model_mpi_esm_lr_remo2009",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tr",
             wms_main_layer_name="tr",
             thredds_url_pattern="MPI-ESM-LR_REMO2009ymbc/clipped/ecatr_20_MPI-ESM-LR_REMO2009_{scenario}_ts19762100_ls_VFVG.nc",
@@ -194,6 +330,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "mpi_esm_lr_remo2009")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -205,6 +361,11 @@ def generate_configurations(
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
                     ].id
                 ),
             ],
@@ -215,6 +376,10 @@ def generate_configurations(
         ),
         CoverageConfigurationCreate(
             name="tr_annual_absolute_model_ensemble_upper_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tr_stdup",
             wms_main_layer_name="tr_stdup",
             thredds_url_pattern="ensymbc/std/clipped/ecatr_20_stdup_{scenario}_ts19762100_ls_VFVG.nc",
@@ -225,6 +390,31 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "upper_bound")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -238,10 +428,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="tr_annual_absolute_model_ensemble_lower_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tr_stddown",
             wms_main_layer_name="tr_stddown",
             thredds_url_pattern="ensymbc/std/clipped/ecatr_20_stddown_{scenario}_ts19762100_ls_VFVG.nc",
@@ -252,6 +451,31 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "lower_bound")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp26")
                     ].id
                 ),
@@ -265,10 +489,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="tr_30yr_anomaly_annual_agree_model_ensemble",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tr",
             wms_main_layer_name="tr-uncertainty_group",
             thredds_url_pattern="ensembletwbc/std/clipped/ecatran_20_avgagree_{time_window}_{scenario}_ls_VFVG.nc",
@@ -279,6 +512,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -302,10 +555,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="tr_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tr",
             wms_main_layer_name="tr",
             thredds_url_pattern="indici5rcm/clipped/ecatran_20_EC-EARTH_CCLM4-8-17_{scenario}_{time_window}_ls_VFVG.nc",
@@ -316,6 +578,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -339,10 +621,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="tr_30yr_anomaly_annual_model_ec_earth_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tr",
             wms_main_layer_name="tr",
             thredds_url_pattern="indici5rcm/clipped/ecatran_20_EC-EARTH_RACMO22E_{scenario}_{time_window}_ls_VFVG.nc",
@@ -353,6 +644,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_racmo22e")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -376,10 +687,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="tr_30yr_anomaly_annual_model_ec_earth_rca4",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tr",
             wms_main_layer_name="tr",
             thredds_url_pattern="indici5rcm/clipped/ecatran_20_EC-EARTH_RCA4_{scenario}_{time_window}_ls_VFVG.nc",
@@ -390,6 +710,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_rca4")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -413,10 +753,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="tr_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tr",
             wms_main_layer_name="tr",
             thredds_url_pattern="indici5rcm/clipped/ecatran_20_HadGEM2-ES_RACMO22E_{scenario}_{time_window}_ls_VFVG.nc",
@@ -427,6 +776,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "hadgem2_racmo22e")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -450,10 +819,19 @@ def generate_configurations(
                         ("scenario", "rcp85")
                     ].id
                 ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
             ],
         ),
         CoverageConfigurationCreate(
             name="tr_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="tr",
             wms_main_layer_name="tr",
             thredds_url_pattern="indici5rcm/clipped/ecatran_20_MPI-ESM-LR_REMO2009_{scenario}_{time_window}_ls_VFVG.nc",
@@ -464,6 +842,26 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "tr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "mpi_esm_lr_remo2009")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),
@@ -485,6 +883,11 @@ def generate_configurations(
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
                     ].id
                 ),
             ],

--- a/arpav_ppcv/database.py
+++ b/arpav_ppcv/database.py
@@ -120,11 +120,16 @@ def list_variables(
     limit: int = 20,
     offset: int = 0,
     include_total: bool = False,
+    name_filter: Optional[str] = None,
 ) -> tuple[Sequence[observations.Variable], Optional[int]]:
     """List existing variables."""
     statement = sqlmodel.select(observations.Variable).order_by(
         observations.Variable.name
     )
+    if name_filter is not None:
+        statement = _add_substring_filter(
+            statement, name_filter, observations.Variable.name
+        )
     items = session.exec(statement.offset(offset).limit(limit)).all()
     num_items = _get_total_num_records(session, statement) if include_total else None
     return items, num_items
@@ -236,6 +241,7 @@ def list_stations(
     limit: int = 20,
     offset: int = 0,
     include_total: bool = False,
+    name_filter: Optional[str] = None,
     polygon_intersection_filter: shapely.Polygon = None,
     variable_id_filter: Optional[uuid.UUID] = None,
     variable_aggregation_type: Optional[
@@ -250,6 +256,10 @@ def list_stations(
     statement = sqlmodel.select(observations.Station).order_by(
         observations.Station.code
     )
+    if name_filter is not None:
+        statement = _add_substring_filter(
+            statement, name_filter, observations.Station.name
+        )
     if polygon_intersection_filter is not None:
         statement = statement.where(
             func.ST_Intersects(

--- a/arpav_ppcv/webapp/admin/views/coverages.py
+++ b/arpav_ppcv/webapp/admin/views/coverages.py
@@ -245,6 +245,7 @@ class ConfigurationParameterView(ModelView):
             database.list_configuration_parameters,
             limit=limit,
             offset=skip,
+            name_filter=str(where) if where not in (None, "") else None,
             include_total=False,
         )
         db_conf_params, _ = await anyio.to_thread.run_sync(
@@ -439,6 +440,7 @@ class CoverageConfigurationView(ModelView):
             database.list_coverage_configurations,
             limit=limit,
             offset=skip,
+            name_filter=str(where) if where not in (None, "") else None,
             include_total=False,
         )
         db_cov_confs, _ = await anyio.to_thread.run_sync(

--- a/arpav_ppcv/webapp/admin/views/observations.py
+++ b/arpav_ppcv/webapp/admin/views/observations.py
@@ -297,6 +297,7 @@ class VariableView(ModelView):
             db.list_variables,
             limit=limit,
             offset=skip,
+            name_filter=str(where) if where not in (None, "") else None,
             include_total=False,
         )
         db_vars, _ = await anyio.to_thread.run_sync(
@@ -319,7 +320,7 @@ class StationView(ModelView):
         fields.UuidField("id"),
         starlette_admin.StringField("name", required=True),
         starlette_admin.StringField("code", required=True),
-        starlette_admin.StringField("type", required=True),
+        starlette_admin.StringField("type_", required=True),
         starlette_admin.FloatField("longitude", required=True),
         starlette_admin.FloatField("latitude", required=True),
         starlette_admin.DateField("active_since"),
@@ -448,6 +449,7 @@ class StationView(ModelView):
             limit=limit,
             offset=skip,
             include_total=False,
+            name_filter=str(where) if where not in (None, "") else None,
         )
         db_stations, _ = await anyio.to_thread.run_sync(
             list_stations, request.state.session

--- a/arpav_ppcv/webapp/api_v2/routers/coverages.py
+++ b/arpav_ppcv/webapp/api_v2/routers/coverages.py
@@ -158,6 +158,9 @@ def get_coverage_configuration(
     )
 
 
+# PossibleValue: pydantic.StringConstraints(pattern="^[\w-_]+:[\w-_]+$")
+
+
 @router.get(
     "/coverage-identifiers",
     response_model=coverage_schemas.CoverageIdentifierList,
@@ -168,7 +171,17 @@ def list_coverage_identifiers(
     db_session: Annotated[Session, Depends(dependencies.get_db_session)],
     list_params: Annotated[dependencies.CommonListFilterParameters, Depends()],
     name_contains: Annotated[list[str], Query()] = None,
+    possible_value: Annotated[
+        list[
+            Annotated[
+                str,
+                pydantic.StringConstraints(pattern=r"^[0-9a-zA-Z_]+:[0-9a-zA-Z_]+$"),
+            ]
+        ],
+        Query(),
+    ] = None,
 ):
+    logger.debug(f"{possible_value=}")
     cov_internals, filtered_total = db.list_coverage_identifiers(
         db_session,
         limit=list_params.limit,

--- a/arpav_ppcv/webapp/api_v2/routers/coverages.py
+++ b/arpav_ppcv/webapp/api_v2/routers/coverages.py
@@ -52,6 +52,7 @@ async def list_configuration_parameters(
     request: Request,
     db_session: Annotated[Session, Depends(dependencies.get_db_session)],
     list_params: Annotated[dependencies.CommonListFilterParameters, Depends()],
+    name_contains: str | None = None,
 ):
     """List configuration parameters."""
     config_params, filtered_total = db.list_configuration_parameters(
@@ -59,6 +60,7 @@ async def list_configuration_parameters(
         limit=list_params.limit,
         offset=list_params.offset,
         include_total=True,
+        name_filter=name_contains,
     )
     _, unfiltered_total = db.list_configuration_parameters(
         db_session, limit=1, offset=0, include_total=True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -224,7 +224,7 @@ def sample_coverage_configurations(
 ) -> list[coverages.CoverageConfiguration]:
     db_cov_confs = []
     for i in range(10):
-        params_to_use = random.choices(sample_configuration_parameters, k=2)
+        params_to_use = random.sample(sample_configuration_parameters, k=2)
         param_values_to_use = []
         for param in params_to_use:
             possible_value = coverages.ConfigurationParameterPossibleValue(

--- a/tests/notebooks/generic.ipynb
+++ b/tests/notebooks/generic.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 34,
    "id": "dbcc00b1-2fc1-43ff-9549-ebca8cf03262",
    "metadata": {},
    "outputs": [],
@@ -19,7 +19,10 @@
     "import pandas as pd\n",
     "import shapely.io\n",
     "import sqlmodel\n",
-    "from loess.loess_1d import loess_1d\n",
+    "from sqlalchemy import (\n",
+    "    bindparam, \n",
+    "    func\n",
+    ")\n",
     "\n",
     "from arpav_ppcv import (\n",
     "    database as db,\n",
@@ -32,6 +35,7 @@
     "    ObservationAggregationType,\n",
     "    Season,\n",
     ")\n",
+    "from arpav_ppcv.schemas import coverages\n",
     "from arpav_ppcv.schemas.coverages import CoverageInternal\n",
     "\n",
     "logging.basicConfig(level=logging.DEBUG)\n",
@@ -63,251 +67,166 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "6fa57746-a891-449a-b8c0-313de8470cd5",
+   "execution_count": 29,
+   "id": "d15772a0-a1c1-4258-9f2f-4402d074cbee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pv_cte = (\n",
+    "     sqlmodel\n",
+    "            .select(\n",
+    "                coverages.CoverageConfiguration.id,\n",
+    "                func.jsonb_agg(\n",
+    "                    func.json_build_object(\n",
+    "                        coverages.ConfigurationParameter.name,\n",
+    "                        coverages.ConfigurationParameterValue.name,\n",
+    "                    )\n",
+    "                ).label(\"possible_values\")\n",
+    "            )\n",
+    "            .join(\n",
+    "                coverages.ConfigurationParameterPossibleValue,\n",
+    "                coverages.CoverageConfiguration.id ==\n",
+    "                coverages.ConfigurationParameterPossibleValue.coverage_configuration_id\n",
+    "            )\n",
+    "            .join(\n",
+    "                coverages.ConfigurationParameterValue,\n",
+    "                coverages.ConfigurationParameterValue.id ==\n",
+    "                coverages.ConfigurationParameterPossibleValue.configuration_parameter_value_id\n",
+    "            )\n",
+    "            .join(\n",
+    "                coverages.ConfigurationParameter,\n",
+    "                coverages.ConfigurationParameter.id ==\n",
+    "                coverages.ConfigurationParameterValue.configuration_parameter_id\n",
+    "            ).group_by(coverages.CoverageConfiguration.id)\n",
+    ").cte(\"cov_conf_possible_values\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "74f05366-c299-4964-8efe-de36cfe61de4",
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "['tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp26-DJF',\n",
-       " 'tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp26-MAM',\n",
-       " 'tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp26-JJA',\n",
-       " 'tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp26-SON']"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SELECT coverageconfiguration.id, jsonb_agg(json_build_object(configurationparameter.name, configurationparametervalue.name)) AS possible_values \n",
+      "FROM coverageconfiguration JOIN configurationparameterpossiblevalue ON coverageconfiguration.id = configurationparameterpossiblevalue.coverage_configuration_id JOIN configurationparametervalue ON configurationparametervalue.id = configurationparameterpossiblevalue.configuration_parameter_value_id JOIN configurationparameter ON configurationparameter.id = configurationparametervalue.configuration_parameter_id GROUP BY coverageconfiguration.id\n"
+     ]
     }
    ],
    "source": [
-    "db.list_allowed_coverage_identifiers(\n",
-    "    session, \n",
-    "    coverage_configuration_id=cov.configuration.id, \n",
-    "    select_configuration_parameter_values=[\n",
-    "        db.get_configuration_parameter_value_by_names(session, \"scenario\", \"rcp26\"),\n",
-    "        db.get_configuration_parameter_value_by_names(session, \"time_period\", \"MAM\"),\n",
-    "    ]\n",
+    "print(pv_cte)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "f7966b1d-9d38-4b05-a5ae-ab21a5c0f8b9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pvs = {\n",
+    "    \"climatological_model\": \"model_ensemble\",\n",
+    "    \"scenario\": \"rcp26\"\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "8288a6f8-257d-49b6-a7a6-04b429b15615",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "statement = (\n",
+    "    sqlmodel.select(coverages.CoverageConfiguration)\n",
+    "    .join(pv_cte, pv_cte.c.id == coverages.CoverageConfiguration.id)\n",
+    "    .where(func.jsonb_path_exists(pv_cte.c.possible_values, '$[*] ? (@.climatological_model == \"model_ensemble\")'))\n",
+    "    .where(func.jsonb_path_exists(pv_cte.c.possible_values, '$[*] ? (@.scenario == \"rcp26\")'))\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "c90bcb97-aff2-454c-bc88-eaf30676cdd5",
+   "execution_count": 40,
+   "id": "d1446147-b649-4fdf-b0e6-da0c0a23611e",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "([CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='ensembletwbc/std/clipped/eca_cdd_an_avgagree_{time_window}_{scenario}_{year_period}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_agree_model_ensemble', wms_main_layer_name='consecutive_dry_days_index_per_time_period-uncertainty_group', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d50ef8e7-1a84-435e-84e6-294664b0964c'), unit='gg', display_name_english=None, palette='uncert-stippled/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_agree_model_ensemble-rcp26-tw1-DJF'),\n",
-       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='ensembletwbc/std/clipped/eca_cdd_an_avgagree_{time_window}_{scenario}_{year_period}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_agree_model_ensemble', wms_main_layer_name='consecutive_dry_days_index_per_time_period-uncertainty_group', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d50ef8e7-1a84-435e-84e6-294664b0964c'), unit='gg', display_name_english=None, palette='uncert-stippled/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_agree_model_ensemble-rcp26-tw1-MAM'),\n",
-       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='ensembletwbc/std/clipped/eca_cdd_an_avgagree_{time_window}_{scenario}_{year_period}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_agree_model_ensemble', wms_main_layer_name='consecutive_dry_days_index_per_time_period-uncertainty_group', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d50ef8e7-1a84-435e-84e6-294664b0964c'), unit='gg', display_name_english=None, palette='uncert-stippled/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_agree_model_ensemble-rcp26-tw1-JJA'),\n",
-       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='ensembletwbc/std/clipped/eca_cdd_an_avgagree_{time_window}_{scenario}_{year_period}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_agree_model_ensemble', wms_main_layer_name='consecutive_dry_days_index_per_time_period-uncertainty_group', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d50ef8e7-1a84-435e-84e6-294664b0964c'), unit='gg', display_name_english=None, palette='uncert-stippled/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_agree_model_ensemble-rcp26-tw1-SON'),\n",
-       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='ensembletwbc/std/clipped/eca_cdd_an_avgagree_{time_window}_{scenario}_{year_period}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_agree_model_ensemble', wms_main_layer_name='consecutive_dry_days_index_per_time_period-uncertainty_group', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d50ef8e7-1a84-435e-84e6-294664b0964c'), unit='gg', display_name_english=None, palette='uncert-stippled/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_agree_model_ensemble-rcp26-tw2-DJF'),\n",
-       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='ensembletwbc/std/clipped/eca_cdd_an_avgagree_{time_window}_{scenario}_{year_period}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_agree_model_ensemble', wms_main_layer_name='consecutive_dry_days_index_per_time_period-uncertainty_group', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d50ef8e7-1a84-435e-84e6-294664b0964c'), unit='gg', display_name_english=None, palette='uncert-stippled/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_agree_model_ensemble-rcp26-tw2-MAM'),\n",
-       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='ensembletwbc/std/clipped/eca_cdd_an_avgagree_{time_window}_{scenario}_{year_period}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_agree_model_ensemble', wms_main_layer_name='consecutive_dry_days_index_per_time_period-uncertainty_group', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d50ef8e7-1a84-435e-84e6-294664b0964c'), unit='gg', display_name_english=None, palette='uncert-stippled/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_agree_model_ensemble-rcp26-tw2-JJA'),\n",
-       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='ensembletwbc/std/clipped/eca_cdd_an_avgagree_{time_window}_{scenario}_{year_period}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_agree_model_ensemble', wms_main_layer_name='consecutive_dry_days_index_per_time_period-uncertainty_group', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d50ef8e7-1a84-435e-84e6-294664b0964c'), unit='gg', display_name_english=None, palette='uncert-stippled/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_agree_model_ensemble-rcp26-tw2-SON'),\n",
-       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='indici5rcm/clipped/eca_cdd_an_EC-EARTH_CCLM4-8-17_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17', wms_main_layer_name='consecutive_dry_days_index_per_time_period', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d04c8d32-277b-4d50-ba68-02836523c3af'), unit='gg', display_name_english=None, palette='default/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17-rcp26-tw1-DJF'),\n",
-       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='indici5rcm/clipped/eca_cdd_an_EC-EARTH_CCLM4-8-17_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17', wms_main_layer_name='consecutive_dry_days_index_per_time_period', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d04c8d32-277b-4d50-ba68-02836523c3af'), unit='gg', display_name_english=None, palette='default/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17-rcp26-tw1-MAM'),\n",
-       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='indici5rcm/clipped/eca_cdd_an_EC-EARTH_CCLM4-8-17_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17', wms_main_layer_name='consecutive_dry_days_index_per_time_period', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d04c8d32-277b-4d50-ba68-02836523c3af'), unit='gg', display_name_english=None, palette='default/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17-rcp26-tw1-JJA'),\n",
-       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='indici5rcm/clipped/eca_cdd_an_EC-EARTH_CCLM4-8-17_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17', wms_main_layer_name='consecutive_dry_days_index_per_time_period', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d04c8d32-277b-4d50-ba68-02836523c3af'), unit='gg', display_name_english=None, palette='default/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17-rcp26-tw1-SON'),\n",
-       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='indici5rcm/clipped/eca_cdd_an_EC-EARTH_CCLM4-8-17_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17', wms_main_layer_name='consecutive_dry_days_index_per_time_period', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d04c8d32-277b-4d50-ba68-02836523c3af'), unit='gg', display_name_english=None, palette='default/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17-rcp26-tw2-DJF'),\n",
-       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='indici5rcm/clipped/eca_cdd_an_EC-EARTH_CCLM4-8-17_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17', wms_main_layer_name='consecutive_dry_days_index_per_time_period', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d04c8d32-277b-4d50-ba68-02836523c3af'), unit='gg', display_name_english=None, palette='default/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17-rcp26-tw2-MAM'),\n",
-       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='indici5rcm/clipped/eca_cdd_an_EC-EARTH_CCLM4-8-17_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17', wms_main_layer_name='consecutive_dry_days_index_per_time_period', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d04c8d32-277b-4d50-ba68-02836523c3af'), unit='gg', display_name_english=None, palette='default/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17-rcp26-tw2-JJA'),\n",
-       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='indici5rcm/clipped/eca_cdd_an_EC-EARTH_CCLM4-8-17_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17', wms_main_layer_name='consecutive_dry_days_index_per_time_period', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d04c8d32-277b-4d50-ba68-02836523c3af'), unit='gg', display_name_english=None, palette='default/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17-rcp26-tw2-SON'),\n",
-       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='indici5rcm/clipped/eca_cdd_an_EC-EARTH_RACMO22E_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_model_ec_earth_racmo22e', wms_main_layer_name='consecutive_dry_days_index_per_time_period', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('bb1697d1-d3bd-46aa-88be-f912a0c39ab9'), unit='gg', display_name_english=None, palette='default/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_model_ec_earth_racmo22e-rcp26-tw1-DJF'),\n",
-       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='indici5rcm/clipped/eca_cdd_an_EC-EARTH_RACMO22E_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_model_ec_earth_racmo22e', wms_main_layer_name='consecutive_dry_days_index_per_time_period', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('bb1697d1-d3bd-46aa-88be-f912a0c39ab9'), unit='gg', display_name_english=None, palette='default/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_model_ec_earth_racmo22e-rcp26-tw1-MAM'),\n",
-       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='indici5rcm/clipped/eca_cdd_an_EC-EARTH_RACMO22E_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_model_ec_earth_racmo22e', wms_main_layer_name='consecutive_dry_days_index_per_time_period', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('bb1697d1-d3bd-46aa-88be-f912a0c39ab9'), unit='gg', display_name_english=None, palette='default/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_model_ec_earth_racmo22e-rcp26-tw1-JJA'),\n",
-       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='indici5rcm/clipped/eca_cdd_an_EC-EARTH_RACMO22E_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_model_ec_earth_racmo22e', wms_main_layer_name='consecutive_dry_days_index_per_time_period', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('bb1697d1-d3bd-46aa-88be-f912a0c39ab9'), unit='gg', display_name_english=None, palette='default/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_model_ec_earth_racmo22e-rcp26-tw1-SON')],\n",
-       " None)"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "db.list_coverage_identifiers(\n",
-    "    session,\n",
-    "    matching_configuration_parameters=[\n",
-    "        db.get_configuration_parameter_value_by_names(session, \"scenario\", \"rcp26\"),\n",
-    "        db.get_configuration_parameter_value_by_names(session, \"climatological_model\", \"model_ensemble\"),\n",
-    "    ]\n",
+    "statement = (\n",
+    "    sqlmodel.select(coverages.CoverageConfiguration)\n",
+    "    .join(pv_cte, pv_cte.c.id == coverages.CoverageConfiguration.id)\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "4ac51747-ee8e-468a-a791-5f815b80286a",
+   "execution_count": 41,
+   "id": "035e71d5-3729-4f3f-9c5b-b94e18afae82",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'{name}-{climatological_model}-{measure}-{scenario}-{year_period}'"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "cov.configuration.coverage_id_pattern"
+    "for value_name, value in pvs.items():\n",
+    "    statement = (\n",
+    "        statement\n",
+    "        .where(func.jsonb_path_exists(pv_cte.c.possible_values, f'$[*] ? (@.{value_name} == \"{value}\")'))\n",
+    "    )"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "705a7335-18df-474e-912a-8bd6dfca940d",
+   "execution_count": 42,
+   "id": "72889317-a72d-4417-92d1-65694d953fd9",
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "{'climatological_model': 'model_ensemble',\n",
-       " 'measure': 'absolute',\n",
-       " 'scenario': 'rcp26',\n",
-       " 'year_period': 'DJF'}"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WITH cov_conf_possible_values AS \n",
+      "(SELECT coverageconfiguration.id AS id, jsonb_agg(json_build_object(configurationparameter.name, configurationparametervalue.name)) AS possible_values \n",
+      "FROM coverageconfiguration JOIN configurationparameterpossiblevalue ON coverageconfiguration.id = configurationparameterpossiblevalue.coverage_configuration_id JOIN configurationparametervalue ON configurationparametervalue.id = configurationparameterpossiblevalue.configuration_parameter_value_id JOIN configurationparameter ON configurationparameter.id = configurationparametervalue.configuration_parameter_id GROUP BY coverageconfiguration.id)\n",
+      " SELECT coverageconfiguration.id, coverageconfiguration.name, coverageconfiguration.display_name_english, coverageconfiguration.display_name_italian, coverageconfiguration.description_english, coverageconfiguration.description_italian, coverageconfiguration.netcdf_main_dataset_name, coverageconfiguration.thredds_url_pattern, coverageconfiguration.wms_main_layer_name, coverageconfiguration.unit, coverageconfiguration.palette, coverageconfiguration.color_scale_min, coverageconfiguration.color_scale_max, coverageconfiguration.observation_variable_id, coverageconfiguration.observation_variable_aggregation_type, coverageconfiguration.uncertainty_lower_bounds_coverage_configuration_id, coverageconfiguration.uncertainty_upper_bounds_coverage_configuration_id \n",
+      "FROM coverageconfiguration JOIN cov_conf_possible_values ON cov_conf_possible_values.id = coverageconfiguration.id \n",
+      "WHERE jsonb_path_exists(cov_conf_possible_values.possible_values, '$[*] ? (@.climatological_model == \"model_ensemble\")') AND jsonb_path_exists(cov_conf_possible_values.possible_values, '$[*] ? (@.scenario == \"rcp26\")')\n"
+     ]
     }
    ],
    "source": [
-    "cov.configuration.retrieve_configuration_parameters(cov.identifier)"
+    "print(statement.compile(db.get_engine(settings), compile_kwargs={\"literal_binds\": True}))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "db7e48fd-98fb-439e-8291-a9fd005aec21",
+   "execution_count": 43,
+   "id": "867b4a0f-232f-4c93-b7e6-ebccdb36af9d",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[ConfigurationParameterPossibleValue(configuration_parameter_value_id=UUID('c5381cd2-ca57-48a9-a096-71568e812366'), coverage_configuration_id=UUID('06c104d2-a502-400b-9728-b8e2d9ee65d9')),\n",
-       " ConfigurationParameterPossibleValue(configuration_parameter_value_id=UUID('88fa9565-8af6-4ab5-afeb-bfa00cd97955'), coverage_configuration_id=UUID('06c104d2-a502-400b-9728-b8e2d9ee65d9')),\n",
-       " ConfigurationParameterPossibleValue(configuration_parameter_value_id=UUID('70c82437-5e90-4181-96c7-262a097d18ba'), coverage_configuration_id=UUID('06c104d2-a502-400b-9728-b8e2d9ee65d9')),\n",
-       " ConfigurationParameterPossibleValue(configuration_parameter_value_id=UUID('4842fa35-b13a-446d-ad9f-43a45b82bd23'), coverage_configuration_id=UUID('06c104d2-a502-400b-9728-b8e2d9ee65d9'))]"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "cov.configuration.retrieve_used_values(cov.identifier)"
+    "session.rollback()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "5dd3f90c-fc59-4bec-a613-2297537f190f",
+   "execution_count": 44,
+   "id": "878c6ea7-8946-4779-925a-c89db88703f1",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'ensymbc/clipped/tas_avg_rcp26_DJF_ts19762100_ls_VFVG.nc'"
+       "[CoverageConfiguration(description_english='TAS seasonal absolute model ensemble', color_scale_max=32.0, description_italian='TAS valore assoluto di stagione media ensemble', observation_variable_id=UUID('32706ce0-0134-4122-91a0-9d6f237350b3'), netcdf_main_dataset_name='tas', observation_variable_aggregation_type=<ObservationAggregationType.SEASONAL: 'SEASONAL'>, thredds_url_pattern='ensymbc/clipped/tas_avg_{scenario}_{year_period}_ts19762100_ls_VFVG.nc', uncertainty_lower_bounds_coverage_configuration_id=UUID('9c2bfa7a-d108-4d2d-8c99-f26ae9329e79'), name='tas_seasonal_absolute_model_ensemble', wms_main_layer_name='tas', uncertainty_upper_bounds_coverage_configuration_id=UUID('d33d6b43-0379-447a-ad9d-b2f36f7dce3e'), id=UUID('06c104d2-a502-400b-9728-b8e2d9ee65d9'), unit='ºC', display_name_english='TAS seasonal absolute model ensemble', palette='default/seq-YlOrRd', display_name_italian='TAS valore assoluto di stagione media ensemble', color_scale_min=-3.0, coverage_id_pattern='{name}-{climatological_model}-{measure}-{scenario}-{year_period}')]"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "cov.configuration.get_thredds_url_fragment(cov.identifier)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "9f396350-e5ea-455c-a636-87fd763f3d89",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp26-DJF'"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "cov.configuration.build_coverage_identifier(\n",
-    "    parameters=[\n",
-    "        db.get_configuration_parameter_value_by_names(session, \"climatological_model\", \"model_ensemble\"),\n",
-    "        db.get_configuration_parameter_value_by_names(session, \"measure\", \"absolute\"),\n",
-    "        db.get_configuration_parameter_value_by_names(session, \"scenario\", \"rcp26\"),\n",
-    "        db.get_configuration_parameter_value_by_names(session, \"year_period\", \"DJF\"),\n",
-    "    ]\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "ec2c0ead-cd94-46d5-bacc-67ab35a0238f",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Season.WINTER: 'WINTER'>"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "cov.configuration.get_seasonal_aggregation_query_filter(coverage_identifier)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "02edb671-e3da-4834-b3b6-0284428c89d8",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp26-DJF',\n",
-       " 'tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp26-MAM',\n",
-       " 'tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp26-JJA',\n",
-       " 'tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp26-SON',\n",
-       " 'tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp45-DJF',\n",
-       " 'tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp45-MAM',\n",
-       " 'tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp45-JJA',\n",
-       " 'tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp45-SON',\n",
-       " 'tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp85-DJF',\n",
-       " 'tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp85-MAM',\n",
-       " 'tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp85-JJA',\n",
-       " 'tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp85-SON']"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "db.list_allowed_coverage_identifiers(session, coverage_configuration_id=cov.configuration.id)"
+    "session.exec(statement).all()"
    ]
   }
  ],

--- a/tests/notebooks/generic.ipynb
+++ b/tests/notebooks/generic.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 1,
    "id": "dbcc00b1-2fc1-43ff-9549-ebca8cf03262",
    "metadata": {},
    "outputs": [],
@@ -63,6 +63,101 @@
     "    configuration=db.get_coverage_configuration_by_coverage_identifier(session, coverage_identifier), \n",
     "    identifier=coverage_identifier\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d2de401b-4028-45d2-bf01-4c0cbb806d80",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "param_values = [\n",
+    "    db.get_configuration_parameter_value_by_names(session, \"climatological_model\", \"model_ensemble\"),\n",
+    "    db.get_configuration_parameter_value_by_names(session, \"scenario\", \"rcp26\")\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f379b854-b318-475f-95c7-82b0a2e48f6b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cov_conf = db.get_coverage_configuration_by_name(session, \"tas_seasonal_absolute_model_ensemble\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "46f23579-47c7-4123-a5a0-7368dcaee640",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'rcp26'"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cov_conf.possible_values[0].configuration_parameter_value.name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "d505e1b4-14e9-459a-b942-2226c6bfc82e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:arpav_ppcv.database:locals()={'session': <sqlmodel.orm.session.Session object at 0x740d65c40730>, 'coverage_configuration': CoverageConfiguration(netcdf_main_dataset_name='tas', observation_variable_aggregation_type=<ObservationAggregationType.SEASONAL: 'SEASONAL'>, thredds_url_pattern='ensymbc/clipped/tas_avg_{scenario}_{year_period}_ts19762100_ls_VFVG.nc', uncertainty_lower_bounds_coverage_configuration_id=UUID('9c2bfa7a-d108-4d2d-8c99-f26ae9329e79'), name='tas_seasonal_absolute_model_ensemble', wms_main_layer_name='tas', uncertainty_upper_bounds_coverage_configuration_id=UUID('d33d6b43-0379-447a-ad9d-b2f36f7dce3e'), id=UUID('06c104d2-a502-400b-9728-b8e2d9ee65d9'), unit='ºC', display_name_english='TAS seasonal absolute model ensemble', palette='default/seq-YlOrRd', display_name_italian='TAS valore assoluto di stagione media ensemble', color_scale_min=-3.0, description_english='TAS seasonal absolute model ensemble', color_scale_max=32.0, description_italian='TAS valore assoluto di stagione media ensemble', observation_variable_id=UUID('32706ce0-0134-4122-91a0-9d6f237350b3'), coverage_id_pattern='{name}-{climatological_model}-{measure}-{scenario}-{year_period}'), 'configuration_parameter_values_filter': [ConfigurationParameterValue(id=UUID('c5381cd2-ca57-48a9-a096-71568e812366'), display_name_italian='Insieme di 5 modelli', description_italian='Insieme di cinque modelli climatologici: EC-EARTH CCLM4-8-17, EC-EARTH RACMO22E, EC-EARTH RCA4, HadGEM RACMO22E, MPI-ESM-LR-REMO2009', display_name_english='5 Model ensemble', name='model_ensemble', description_english='Ensemble of five climatological models: EC-EARTH CCLM4-8-17, EC-EARTH RACMO22E, EC-EARTH RCA4, HadGEM RACMO22E, MPI-ESM-LR-REMO2009', configuration_parameter_id=UUID('d6cfbf61-7f87-43a9-8e04-2c9d275eacc2')), ConfigurationParameterValue(id=UUID('70c82437-5e90-4181-96c7-262a097d18ba'), display_name_italian='RCP2.6', description_italian='Scenario Representation Concentration Pathway (RCP) che presuppone valori di forzante climatica di 2,6 W/m2', display_name_english='RCP2.6', name='rcp26', description_english='Representation Concentration Pathway (RCP) scenario that assumes climate forcing values of 2.6 W/m2', configuration_parameter_id=UUID('92bbb178-334f-4f30-bf2c-fb7cba7cd7e0'))]}\n",
+      "DEBUG:arpav_ppcv.database:pattern_parts=['climatological_model', 'measure', 'scenario', 'year_period']\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['tas_seasonal_absolute_model_ensemble-model_ensemble-measure-rcp26-year_period']"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "db.generate_coverage_identifiers(session, coverage_configuration=cov_conf, configuration_parameter_values_filter=param_values)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "978549f0-e1d6-415c-833b-3169b7448920",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "([CoverageConfiguration(netcdf_main_dataset_name='tas', observation_variable_aggregation_type=<ObservationAggregationType.SEASONAL: 'SEASONAL'>, thredds_url_pattern='ensymbc/clipped/tas_avg_{scenario}_{year_period}_ts19762100_ls_VFVG.nc', uncertainty_lower_bounds_coverage_configuration_id=UUID('9c2bfa7a-d108-4d2d-8c99-f26ae9329e79'), name='tas_seasonal_absolute_model_ensemble', wms_main_layer_name='tas', uncertainty_upper_bounds_coverage_configuration_id=UUID('d33d6b43-0379-447a-ad9d-b2f36f7dce3e'), id=UUID('06c104d2-a502-400b-9728-b8e2d9ee65d9'), unit='ºC', display_name_english='TAS seasonal absolute model ensemble', palette='default/seq-YlOrRd', display_name_italian='TAS valore assoluto di stagione media ensemble', color_scale_min=-3.0, description_english='TAS seasonal absolute model ensemble', color_scale_max=32.0, description_italian='TAS valore assoluto di stagione media ensemble', observation_variable_id=UUID('32706ce0-0134-4122-91a0-9d6f237350b3'), coverage_id_pattern='{name}-{climatological_model}-{measure}-{scenario}-{year_period}')],\n",
+       " None)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "db.list_coverage_configurations(session, configuration_parameter_value_filter=param_values)"
    ]
   },
   {

--- a/tests/notebooks/generic.ipynb
+++ b/tests/notebooks/generic.ipynb
@@ -51,7 +51,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "coverage_identifier = \"tas_seasonal_absolute_model_ensemble-rcp26-DJF\"\n",
+    "coverage_identifier = \"tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp26-DJF\"\n",
     "point_coords = \"POINT(11.5469 44.9524)\"\n",
     "date_range = \"../..\"\n",
     "\n",
@@ -63,112 +63,140 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "4ac51747-ee8e-468a-a791-5f815b80286a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "settings.debug = False"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "93c28235-3793-4b3b-acd0-c00a56252cdf",
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "DEBUG:asyncio:Using selector: EpollSelector\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "elapsed: 0.49170613288879395\n"
-     ]
-    }
-   ],
-   "source": [
-    "new_time_start = time.time()\n",
-    "coverage_series, observation_series = operations.get_coverage_time_series(\n",
-    "    settings=settings,\n",
-    "    session=session,\n",
-    "    http_client=httpx.AsyncClient(),\n",
-    "    coverage=cov,\n",
-    "    point_geom=shapely.io.from_wkt(point_coords),\n",
-    "    temporal_range=date_range,\n",
-    "    coverage_smoothing_strategies=[\n",
-    "        CoverageDataSmoothingStrategy.NO_SMOOTHING,\n",
-    "        CoverageDataSmoothingStrategy.MOVING_AVERAGE_11_YEARS,\n",
-    "        CoverageDataSmoothingStrategy.LOESS_SMOOTHING\n",
-    "    ],\n",
-    "    observation_smoothing_strategies=[\n",
-    "        ObservationDataSmoothingStrategy.NO_SMOOTHING,\n",
-    "        ObservationDataSmoothingStrategy.MOVING_AVERAGE_5_YEARS\n",
-    "    ],\n",
-    "    include_coverage_data=True,\n",
-    "    include_observation_data=False,\n",
-    "    include_coverage_uncertainty=True,\n",
-    "    include_coverage_related_data=True\n",
-    ")\n",
-    "new_time_end = time.time()\n",
-    "print(f\"elapsed: {new_time_end - new_time_start}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "63fa30a2-13f9-4157-b3f7-dc131541d3b2",
+   "execution_count": 6,
+   "id": "6fa57746-a891-449a-b8c0-313de8470cd5",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[('tas_seasonal_absolute_model_ec_earth_cclm4_8_17-rcp26-DJF', 'NO_SMOOTHING'),\n",
-       " ('tas_seasonal_absolute_model_ec_earth_cclm4_8_17-rcp26-DJF',\n",
-       "  'MOVING_AVERAGE_11_YEARS'),\n",
-       " ('tas_seasonal_absolute_model_ec_earth_cclm4_8_17-rcp26-DJF',\n",
-       "  'LOESS_SMOOTHING'),\n",
-       " ('tas_seasonal_absolute_model_ensemble-rcp26-DJF', 'NO_SMOOTHING'),\n",
-       " ('tas_seasonal_absolute_model_ensemble-rcp26-DJF', 'MOVING_AVERAGE_11_YEARS'),\n",
-       " ('tas_seasonal_absolute_model_ensemble-rcp26-DJF', 'LOESS_SMOOTHING'),\n",
-       " ('tas_seasonal_absolute_model_ec_earth_racmo22e-rcp26-DJF', 'NO_SMOOTHING'),\n",
-       " ('tas_seasonal_absolute_model_ec_earth_racmo22e-rcp26-DJF',\n",
-       "  'MOVING_AVERAGE_11_YEARS'),\n",
-       " ('tas_seasonal_absolute_model_ec_earth_racmo22e-rcp26-DJF',\n",
-       "  'LOESS_SMOOTHING'),\n",
-       " ('tas_seasonal_absolute_model_ec_earth_rca4-rcp26-DJF', 'NO_SMOOTHING'),\n",
-       " ('tas_seasonal_absolute_model_ec_earth_rca4-rcp26-DJF',\n",
-       "  'MOVING_AVERAGE_11_YEARS'),\n",
-       " ('tas_seasonal_absolute_model_ec_earth_rca4-rcp26-DJF', 'LOESS_SMOOTHING'),\n",
-       " ('tas_seasonal_absolute_model_ensemble_upper_uncertainty-rcp26-DJF',\n",
-       "  'NO_SMOOTHING'),\n",
-       " ('tas_seasonal_absolute_model_ensemble_upper_uncertainty-rcp26-DJF',\n",
-       "  'MOVING_AVERAGE_11_YEARS'),\n",
-       " ('tas_seasonal_absolute_model_ensemble_upper_uncertainty-rcp26-DJF',\n",
-       "  'LOESS_SMOOTHING'),\n",
-       " ('tas_seasonal_absolute_model_mpi_esm_lr_remo2009-rcp26-DJF', 'NO_SMOOTHING'),\n",
-       " ('tas_seasonal_absolute_model_mpi_esm_lr_remo2009-rcp26-DJF',\n",
-       "  'MOVING_AVERAGE_11_YEARS'),\n",
-       " ('tas_seasonal_absolute_model_mpi_esm_lr_remo2009-rcp26-DJF',\n",
-       "  'LOESS_SMOOTHING'),\n",
-       " ('tas_seasonal_absolute_model_hadgem2_es_racmo22e-rcp26-DJF', 'NO_SMOOTHING'),\n",
-       " ('tas_seasonal_absolute_model_hadgem2_es_racmo22e-rcp26-DJF',\n",
-       "  'MOVING_AVERAGE_11_YEARS'),\n",
-       " ('tas_seasonal_absolute_model_hadgem2_es_racmo22e-rcp26-DJF',\n",
-       "  'LOESS_SMOOTHING'),\n",
-       " ('tas_seasonal_absolute_model_ensemble_lower_uncertainty-rcp26-DJF',\n",
-       "  'NO_SMOOTHING'),\n",
-       " ('tas_seasonal_absolute_model_ensemble_lower_uncertainty-rcp26-DJF',\n",
-       "  'MOVING_AVERAGE_11_YEARS'),\n",
-       " ('tas_seasonal_absolute_model_ensemble_lower_uncertainty-rcp26-DJF',\n",
-       "  'LOESS_SMOOTHING')]"
+       "['tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp26-DJF',\n",
+       " 'tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp26-MAM',\n",
+       " 'tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp26-JJA',\n",
+       " 'tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp26-SON']"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "db.list_allowed_coverage_identifiers(\n",
+    "    session, \n",
+    "    coverage_configuration_id=cov.configuration.id, \n",
+    "    select_configuration_parameter_values=[\n",
+    "        db.get_configuration_parameter_value_by_names(session, \"scenario\", \"rcp26\"),\n",
+    "        db.get_configuration_parameter_value_by_names(session, \"time_period\", \"MAM\"),\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c90bcb97-aff2-454c-bc88-eaf30676cdd5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "([CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='ensembletwbc/std/clipped/eca_cdd_an_avgagree_{time_window}_{scenario}_{year_period}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_agree_model_ensemble', wms_main_layer_name='consecutive_dry_days_index_per_time_period-uncertainty_group', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d50ef8e7-1a84-435e-84e6-294664b0964c'), unit='gg', display_name_english=None, palette='uncert-stippled/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_agree_model_ensemble-rcp26-tw1-DJF'),\n",
+       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='ensembletwbc/std/clipped/eca_cdd_an_avgagree_{time_window}_{scenario}_{year_period}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_agree_model_ensemble', wms_main_layer_name='consecutive_dry_days_index_per_time_period-uncertainty_group', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d50ef8e7-1a84-435e-84e6-294664b0964c'), unit='gg', display_name_english=None, palette='uncert-stippled/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_agree_model_ensemble-rcp26-tw1-MAM'),\n",
+       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='ensembletwbc/std/clipped/eca_cdd_an_avgagree_{time_window}_{scenario}_{year_period}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_agree_model_ensemble', wms_main_layer_name='consecutive_dry_days_index_per_time_period-uncertainty_group', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d50ef8e7-1a84-435e-84e6-294664b0964c'), unit='gg', display_name_english=None, palette='uncert-stippled/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_agree_model_ensemble-rcp26-tw1-JJA'),\n",
+       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='ensembletwbc/std/clipped/eca_cdd_an_avgagree_{time_window}_{scenario}_{year_period}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_agree_model_ensemble', wms_main_layer_name='consecutive_dry_days_index_per_time_period-uncertainty_group', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d50ef8e7-1a84-435e-84e6-294664b0964c'), unit='gg', display_name_english=None, palette='uncert-stippled/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_agree_model_ensemble-rcp26-tw1-SON'),\n",
+       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='ensembletwbc/std/clipped/eca_cdd_an_avgagree_{time_window}_{scenario}_{year_period}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_agree_model_ensemble', wms_main_layer_name='consecutive_dry_days_index_per_time_period-uncertainty_group', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d50ef8e7-1a84-435e-84e6-294664b0964c'), unit='gg', display_name_english=None, palette='uncert-stippled/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_agree_model_ensemble-rcp26-tw2-DJF'),\n",
+       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='ensembletwbc/std/clipped/eca_cdd_an_avgagree_{time_window}_{scenario}_{year_period}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_agree_model_ensemble', wms_main_layer_name='consecutive_dry_days_index_per_time_period-uncertainty_group', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d50ef8e7-1a84-435e-84e6-294664b0964c'), unit='gg', display_name_english=None, palette='uncert-stippled/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_agree_model_ensemble-rcp26-tw2-MAM'),\n",
+       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='ensembletwbc/std/clipped/eca_cdd_an_avgagree_{time_window}_{scenario}_{year_period}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_agree_model_ensemble', wms_main_layer_name='consecutive_dry_days_index_per_time_period-uncertainty_group', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d50ef8e7-1a84-435e-84e6-294664b0964c'), unit='gg', display_name_english=None, palette='uncert-stippled/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_agree_model_ensemble-rcp26-tw2-JJA'),\n",
+       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='ensembletwbc/std/clipped/eca_cdd_an_avgagree_{time_window}_{scenario}_{year_period}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_agree_model_ensemble', wms_main_layer_name='consecutive_dry_days_index_per_time_period-uncertainty_group', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d50ef8e7-1a84-435e-84e6-294664b0964c'), unit='gg', display_name_english=None, palette='uncert-stippled/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_agree_model_ensemble-rcp26-tw2-SON'),\n",
+       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='indici5rcm/clipped/eca_cdd_an_EC-EARTH_CCLM4-8-17_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17', wms_main_layer_name='consecutive_dry_days_index_per_time_period', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d04c8d32-277b-4d50-ba68-02836523c3af'), unit='gg', display_name_english=None, palette='default/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17-rcp26-tw1-DJF'),\n",
+       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='indici5rcm/clipped/eca_cdd_an_EC-EARTH_CCLM4-8-17_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17', wms_main_layer_name='consecutive_dry_days_index_per_time_period', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d04c8d32-277b-4d50-ba68-02836523c3af'), unit='gg', display_name_english=None, palette='default/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17-rcp26-tw1-MAM'),\n",
+       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='indici5rcm/clipped/eca_cdd_an_EC-EARTH_CCLM4-8-17_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17', wms_main_layer_name='consecutive_dry_days_index_per_time_period', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d04c8d32-277b-4d50-ba68-02836523c3af'), unit='gg', display_name_english=None, palette='default/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17-rcp26-tw1-JJA'),\n",
+       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='indici5rcm/clipped/eca_cdd_an_EC-EARTH_CCLM4-8-17_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17', wms_main_layer_name='consecutive_dry_days_index_per_time_period', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d04c8d32-277b-4d50-ba68-02836523c3af'), unit='gg', display_name_english=None, palette='default/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17-rcp26-tw1-SON'),\n",
+       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='indici5rcm/clipped/eca_cdd_an_EC-EARTH_CCLM4-8-17_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17', wms_main_layer_name='consecutive_dry_days_index_per_time_period', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d04c8d32-277b-4d50-ba68-02836523c3af'), unit='gg', display_name_english=None, palette='default/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17-rcp26-tw2-DJF'),\n",
+       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='indici5rcm/clipped/eca_cdd_an_EC-EARTH_CCLM4-8-17_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17', wms_main_layer_name='consecutive_dry_days_index_per_time_period', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d04c8d32-277b-4d50-ba68-02836523c3af'), unit='gg', display_name_english=None, palette='default/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17-rcp26-tw2-MAM'),\n",
+       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='indici5rcm/clipped/eca_cdd_an_EC-EARTH_CCLM4-8-17_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17', wms_main_layer_name='consecutive_dry_days_index_per_time_period', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d04c8d32-277b-4d50-ba68-02836523c3af'), unit='gg', display_name_english=None, palette='default/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17-rcp26-tw2-JJA'),\n",
+       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='indici5rcm/clipped/eca_cdd_an_EC-EARTH_CCLM4-8-17_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17', wms_main_layer_name='consecutive_dry_days_index_per_time_period', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('d04c8d32-277b-4d50-ba68-02836523c3af'), unit='gg', display_name_english=None, palette='default/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17-rcp26-tw2-SON'),\n",
+       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='indici5rcm/clipped/eca_cdd_an_EC-EARTH_RACMO22E_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_model_ec_earth_racmo22e', wms_main_layer_name='consecutive_dry_days_index_per_time_period', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('bb1697d1-d3bd-46aa-88be-f912a0c39ab9'), unit='gg', display_name_english=None, palette='default/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_model_ec_earth_racmo22e-rcp26-tw1-DJF'),\n",
+       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='indici5rcm/clipped/eca_cdd_an_EC-EARTH_RACMO22E_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_model_ec_earth_racmo22e', wms_main_layer_name='consecutive_dry_days_index_per_time_period', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('bb1697d1-d3bd-46aa-88be-f912a0c39ab9'), unit='gg', display_name_english=None, palette='default/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_model_ec_earth_racmo22e-rcp26-tw1-MAM'),\n",
+       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='indici5rcm/clipped/eca_cdd_an_EC-EARTH_RACMO22E_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_model_ec_earth_racmo22e', wms_main_layer_name='consecutive_dry_days_index_per_time_period', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('bb1697d1-d3bd-46aa-88be-f912a0c39ab9'), unit='gg', display_name_english=None, palette='default/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_model_ec_earth_racmo22e-rcp26-tw1-JJA'),\n",
+       "  CoverageInternal(configuration=CoverageConfiguration(netcdf_main_dataset_name='cdd', observation_variable_aggregation_type=None, thredds_url_pattern='indici5rcm/clipped/eca_cdd_an_EC-EARTH_RACMO22E_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='cdd_30yr_anomaly_annual_model_ec_earth_racmo22e', wms_main_layer_name='consecutive_dry_days_index_per_time_period', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('bb1697d1-d3bd-46aa-88be-f912a0c39ab9'), unit='gg', display_name_english=None, palette='default/div-BrBG-inv', display_name_italian=None, color_scale_min=-40.0, description_english=None, color_scale_max=40.0, description_italian=None, observation_variable_id=None, coverage_id_pattern='{name}-{scenario}-{time_window}-{year_period}'), identifier='cdd_30yr_anomaly_annual_model_ec_earth_racmo22e-rcp26-tw1-SON')],\n",
+       " None)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "db.list_coverage_identifiers(\n",
+    "    session,\n",
+    "    matching_configuration_parameters=[\n",
+    "        db.get_configuration_parameter_value_by_names(session, \"scenario\", \"rcp26\"),\n",
+    "        db.get_configuration_parameter_value_by_names(session, \"climatological_model\", \"model_ensemble\"),\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "4ac51747-ee8e-468a-a791-5f815b80286a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'{name}-{climatological_model}-{measure}-{scenario}-{year_period}'"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cov.configuration.coverage_id_pattern"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "705a7335-18df-474e-912a-8bd6dfca940d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'climatological_model': 'model_ensemble',\n",
+       " 'measure': 'absolute',\n",
+       " 'scenario': 'rcp26',\n",
+       " 'year_period': 'DJF'}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cov.configuration.retrieve_configuration_parameters(cov.identifier)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "db7e48fd-98fb-439e-8291-a9fd005aec21",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[ConfigurationParameterPossibleValue(configuration_parameter_value_id=UUID('c5381cd2-ca57-48a9-a096-71568e812366'), coverage_configuration_id=UUID('06c104d2-a502-400b-9728-b8e2d9ee65d9')),\n",
+       " ConfigurationParameterPossibleValue(configuration_parameter_value_id=UUID('88fa9565-8af6-4ab5-afeb-bfa00cd97955'), coverage_configuration_id=UUID('06c104d2-a502-400b-9728-b8e2d9ee65d9')),\n",
+       " ConfigurationParameterPossibleValue(configuration_parameter_value_id=UUID('70c82437-5e90-4181-96c7-262a097d18ba'), coverage_configuration_id=UUID('06c104d2-a502-400b-9728-b8e2d9ee65d9')),\n",
+       " ConfigurationParameterPossibleValue(configuration_parameter_value_id=UUID('4842fa35-b13a-446d-ad9f-43a45b82bd23'), coverage_configuration_id=UUID('06c104d2-a502-400b-9728-b8e2d9ee65d9'))]"
       ]
      },
      "execution_count": 5,
@@ -177,252 +205,109 @@
     }
    ],
    "source": [
-    "[(c.identifier, s.value) for c, s in coverage_series.keys()]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "b3811df1-eb09-45eb-8bd6-e85286007a66",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "raw_data = await operations.retrieve_multiple_ncss_datasets(\n",
-    "    settings, \n",
-    "    httpx.AsyncClient(), \n",
-    "    [\n",
-    "        CoverageInternal(\n",
-    "            identifier=coverage_identifier, \n",
-    "            configuration=db.get_coverage_configuration_by_coverage_identifier(\n",
-    "                session, coverage_identifier)\n",
-    "        ),\n",
-    "    ],\n",
-    "    shapely.io.from_wkt(point_coords),\n",
-    "    (None, None)\n",
-    ")\n",
-    "    "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "d369153d-c155-4e27-ba7c-7228a56dd0f9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "for cov, data_ in raw_data.items():\n",
-    "    df = operations._parse_ncss_dataset(data_, cov.configuration.netcdf_main_dataset_name, None, None, cov.identifier)"
+    "cov.configuration.retrieve_used_values(cov.identifier)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "ca25cce2-36fb-44fb-a60c-b3f8ede028b8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import pyloess"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "16946c48-0c1e-46bf-9cd2-453ee8f5bc2b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "smoothed = pyloess.loess(df.index.year.astype(\"int\").values, df[coverage_identifier], span=0.75, degree=2)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "60dd97fa-6a8f-4ed8-b25b-d13a38d9d89b",
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[1976.        ,    3.39045092],\n",
-       "       [1977.        ,    3.41520367],\n",
-       "       [1978.        ,    3.43951448],\n",
-       "       [1979.        ,    3.46338917],\n",
-       "       [1980.        ,    3.48683499],\n",
-       "       [1981.        ,    3.50985909],\n",
-       "       [1982.        ,    3.53246727],\n",
-       "       [1983.        ,    3.55466547],\n",
-       "       [1984.        ,    3.57645893],\n",
-       "       [1985.        ,    3.59785423],\n",
-       "       [1986.        ,    3.6188608 ],\n",
-       "       [1987.        ,    3.63948834],\n",
-       "       [1988.        ,    3.65974729],\n",
-       "       [1989.        ,    3.67964993],\n",
-       "       [1990.        ,    3.69921081],\n",
-       "       [1991.        ,    3.71844372],\n",
-       "       [1992.        ,    3.73736291],\n",
-       "       [1993.        ,    3.75598335],\n",
-       "       [1994.        ,    3.77432163],\n",
-       "       [1995.        ,    3.7923959 ],\n",
-       "       [1996.        ,    3.81022421],\n",
-       "       [1997.        ,    3.82782181],\n",
-       "       [1998.        ,    3.8452036 ],\n",
-       "       [1999.        ,    3.86238304],\n",
-       "       [2000.        ,    3.87937367],\n",
-       "       [2001.        ,    3.89618642],\n",
-       "       [2002.        ,    3.91283006],\n",
-       "       [2003.        ,    3.92931283],\n",
-       "       [2004.        ,    3.94564078],\n",
-       "       [2005.        ,    3.96181679],\n",
-       "       [2006.        ,    3.97784126],\n",
-       "       [2007.        ,    3.99370947],\n",
-       "       [2008.        ,    4.00941002],\n",
-       "       [2009.        ,    4.02492491],\n",
-       "       [2010.        ,    4.04022963],\n",
-       "       [2011.        ,    4.05528821],\n",
-       "       [2012.        ,    4.07005002],\n",
-       "       [2013.        ,    4.08445509],\n",
-       "       [2014.        ,    4.09843551],\n",
-       "       [2015.        ,    4.11190995],\n",
-       "       [2016.        ,    4.12477485],\n",
-       "       [2017.        ,    4.13690201],\n",
-       "       [2018.        ,    4.14813488],\n",
-       "       [2019.        ,    4.15831013],\n",
-       "       [2020.        ,    4.16730638],\n",
-       "       [2021.        ,    4.17513242],\n",
-       "       [2022.        ,    4.18196441],\n",
-       "       [2023.        ,    4.19625107],\n",
-       "       [2024.        ,    4.21062102],\n",
-       "       [2025.        ,    4.22493585],\n",
-       "       [2026.        ,    4.23921175],\n",
-       "       [2027.        ,    4.25354211],\n",
-       "       [2028.        ,    4.26806956],\n",
-       "       [2029.        ,    4.28300472],\n",
-       "       [2030.        ,    4.29854456],\n",
-       "       [2031.        ,    4.31481714],\n",
-       "       [2032.        ,    4.33193141],\n",
-       "       [2033.        ,    4.34987622],\n",
-       "       [2034.        ,    4.36855939],\n",
-       "       [2035.        ,    4.38791159],\n",
-       "       [2036.        ,    4.40782196],\n",
-       "       [2037.        ,    4.42815529],\n",
-       "       [2038.        ,    4.44861772],\n",
-       "       [2039.        ,    4.46891522],\n",
-       "       [2040.        ,    4.48884042],\n",
-       "       [2041.        ,    4.50831509],\n",
-       "       [2042.        ,    4.52728011],\n",
-       "       [2043.        ,    4.54563333],\n",
-       "       [2044.        ,    4.56325833],\n",
-       "       [2045.        ,    4.58006323],\n",
-       "       [2046.        ,    4.59600293],\n",
-       "       [2047.        ,    4.61099795],\n",
-       "       [2048.        ,    4.6248397 ],\n",
-       "       [2049.        ,    4.63730183],\n",
-       "       [2050.        ,    4.64824497],\n",
-       "       [2051.        ,    4.65766433],\n",
-       "       [2052.        ,    4.66565783],\n",
-       "       [2053.        ,    4.67241102],\n",
-       "       [2054.        ,    4.67526526],\n",
-       "       [2055.        ,    4.67849819],\n",
-       "       [2056.        ,    4.68235967],\n",
-       "       [2057.        ,    4.68683354],\n",
-       "       [2058.        ,    4.69177381],\n",
-       "       [2059.        ,    4.69701813],\n",
-       "       [2060.        ,    4.70242627],\n",
-       "       [2061.        ,    4.70788883],\n",
-       "       [2062.        ,    4.71332622],\n",
-       "       [2063.        ,    4.71868373],\n",
-       "       [2064.        ,    4.72392387],\n",
-       "       [2065.        ,    4.72901914],\n",
-       "       [2066.        ,    4.73395416],\n",
-       "       [2067.        ,    4.7387202 ],\n",
-       "       [2068.        ,    4.74331141],\n",
-       "       [2069.        ,    4.74772083],\n",
-       "       [2070.        ,    4.75194145],\n",
-       "       [2071.        ,    4.75596588],\n",
-       "       [2072.        ,    4.75978888],\n",
-       "       [2073.        ,    4.76340877],\n",
-       "       [2074.        ,    4.76682503],\n",
-       "       [2075.        ,    4.77004131],\n",
-       "       [2076.        ,    4.77306356],\n",
-       "       [2077.        ,    4.7759003 ],\n",
-       "       [2078.        ,    4.77855902],\n",
-       "       [2079.        ,    4.78104787],\n",
-       "       [2080.        ,    4.78337515],\n",
-       "       [2081.        ,    4.78554851],\n",
-       "       [2082.        ,    4.7875757 ],\n",
-       "       [2083.        ,    4.78946472],\n",
-       "       [2084.        ,    4.791222  ],\n",
-       "       [2085.        ,    4.79285211],\n",
-       "       [2086.        ,    4.79436069],\n",
-       "       [2087.        ,    4.7957522 ],\n",
-       "       [2088.        ,    4.79703161],\n",
-       "       [2089.        ,    4.79820364],\n",
-       "       [2090.        ,    4.79927258],\n",
-       "       [2091.        ,    4.8002431 ],\n",
-       "       [2092.        ,    4.80111915],\n",
-       "       [2093.        ,    4.80190698],\n",
-       "       [2094.        ,    4.80260852],\n",
-       "       [2095.        ,    4.80322256],\n",
-       "       [2096.        ,    4.80374603],\n",
-       "       [2097.        ,    4.80417534],\n",
-       "       [2098.        ,    4.8045086 ],\n",
-       "       [2099.        ,    4.80474447]])"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "smoothed"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "cf2d3db8-41e6-47e1-b93e-efa30e882e0f",
+   "id": "5dd3f90c-fc59-4bec-a613-2297537f190f",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([3.39045092, 3.41520367, 3.43951448, 3.46338917, 3.48683499,\n",
-       "       3.50985909, 3.53246727, 3.55466547, 3.57645893, 3.59785423,\n",
-       "       3.6188608 , 3.63948834, 3.65974729, 3.67964993, 3.69921081,\n",
-       "       3.71844372, 3.73736291, 3.75598335, 3.77432163, 3.7923959 ,\n",
-       "       3.81022421, 3.82782181, 3.8452036 , 3.86238304, 3.87937367,\n",
-       "       3.89618642, 3.91283006, 3.92931283, 3.94564078, 3.96181679,\n",
-       "       3.97784126, 3.99370947, 4.00941002, 4.02492491, 4.04022963,\n",
-       "       4.05528821, 4.07005002, 4.08445509, 4.09843551, 4.11190995,\n",
-       "       4.12477485, 4.13690201, 4.14813488, 4.15831013, 4.16730638,\n",
-       "       4.17513242, 4.18196441, 4.19625107, 4.21062102, 4.22493585,\n",
-       "       4.23921175, 4.25354211, 4.26806956, 4.28300472, 4.29854456,\n",
-       "       4.31481714, 4.33193141, 4.34987622, 4.36855939, 4.38791159,\n",
-       "       4.40782196, 4.42815529, 4.44861772, 4.46891522, 4.48884042,\n",
-       "       4.50831509, 4.52728011, 4.54563333, 4.56325833, 4.58006323,\n",
-       "       4.59600293, 4.61099795, 4.6248397 , 4.63730183, 4.64824497,\n",
-       "       4.65766433, 4.66565783, 4.67241102, 4.67526526, 4.67849819,\n",
-       "       4.68235967, 4.68683354, 4.69177381, 4.69701813, 4.70242627,\n",
-       "       4.70788883, 4.71332622, 4.71868373, 4.72392387, 4.72901914,\n",
-       "       4.73395416, 4.7387202 , 4.74331141, 4.74772083, 4.75194145,\n",
-       "       4.75596588, 4.75978888, 4.76340877, 4.76682503, 4.77004131,\n",
-       "       4.77306356, 4.7759003 , 4.77855902, 4.78104787, 4.78337515,\n",
-       "       4.78554851, 4.7875757 , 4.78946472, 4.791222  , 4.79285211,\n",
-       "       4.79436069, 4.7957522 , 4.79703161, 4.79820364, 4.79927258,\n",
-       "       4.8002431 , 4.80111915, 4.80190698, 4.80260852, 4.80322256,\n",
-       "       4.80374603, 4.80417534, 4.8045086 , 4.80474447])"
+       "'ensymbc/clipped/tas_avg_rcp26_DJF_ts19762100_ls_VFVG.nc'"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "smoothed[:, 1]"
+    "cov.configuration.get_thredds_url_fragment(cov.identifier)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "9f396350-e5ea-455c-a636-87fd763f3d89",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp26-DJF'"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cov.configuration.build_coverage_identifier(\n",
+    "    parameters=[\n",
+    "        db.get_configuration_parameter_value_by_names(session, \"climatological_model\", \"model_ensemble\"),\n",
+    "        db.get_configuration_parameter_value_by_names(session, \"measure\", \"absolute\"),\n",
+    "        db.get_configuration_parameter_value_by_names(session, \"scenario\", \"rcp26\"),\n",
+    "        db.get_configuration_parameter_value_by_names(session, \"year_period\", \"DJF\"),\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "ec2c0ead-cd94-46d5-bacc-67ab35a0238f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Season.WINTER: 'WINTER'>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cov.configuration.get_seasonal_aggregation_query_filter(coverage_identifier)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "02edb671-e3da-4834-b3b6-0284428c89d8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp26-DJF',\n",
+       " 'tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp26-MAM',\n",
+       " 'tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp26-JJA',\n",
+       " 'tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp26-SON',\n",
+       " 'tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp45-DJF',\n",
+       " 'tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp45-MAM',\n",
+       " 'tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp45-JJA',\n",
+       " 'tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp45-SON',\n",
+       " 'tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp85-DJF',\n",
+       " 'tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp85-MAM',\n",
+       " 'tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp85-JJA',\n",
+       " 'tas_seasonal_absolute_model_ensemble-model_ensemble-absolute-rcp85-SON']"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "db.list_allowed_coverage_identifiers(session, coverage_configuration_id=cov.configuration.id)"
    ]
   }
  ],


### PR DESCRIPTION
This PR provides a set of bootstrap configuration values for coverages. The main objectives of this PR are to ensure that:

1. All coverage configurations have localized display names and descriptions
2. All coverage configurations have sufficient meta information by means of `possible values` so that the frontend is able to find them by searching for this meta info.

These bootstrap configs are meant to allow to replicate the configuration of the system very fast, by simply typing the CLI command:

```shell
arpav-ppcv bootstrap coverage-configurations
```

The above command creates the configurations for all coverages.

As an example, the bootstrap config for `tas_seasonal_anomaly_model_ensemble` now includes the following information

- name: `tas_seasonal_anomaly_model_ensemble`
- display_name_english: `Mean temperature`
- display_name_italian: `Temperatura media`
- description_english: `Average daily air temperature near the ground`
- description_italian: `Temperatura media giornaliera dell'aria vicino al suolo`
- netcdf_main_dataset_name: `tas`
- wms_main_layer_name: `tas`
- thredds_url_pattern: `ens5ym/clipped/tas_anom_pp_ts_{scenario}_{year_period}_VFVGTAA.nc`
- unit: `ºC`
- palette: `default/seq-YlOrRd`
- color_scale_min: `0`
- color_scale_max: `6`
- possible_values:
  - climatological_variable: `tas`
  - aggregation_period: `annual`
  - measure: `anomaly`
  - climatological_model: `model_ensemble`
  - scenario: `rcp26`
  - scenario: `rcp45`
  - scenario: `rcp85`
  - year_period: `DJF`
  - year_period: `MAM`
  - year_period: `JJA`
  - year_period: `SON`

In order to get the relevant coverage identifier, which is used to request WMS layers, time series and downloads, the frontend can query the API - for example for retrieving the TAS value for the summer month, scenario RCP26 for the configuration mentioned above, the frontend can perform a request like:

```
GET /api/v2/coverages/coverage-identifiers \
  possible_value==climatological_variable:tas \
  possible_value==aggregation_period:annual \
  possible_value==measure:anomaly \
  possible_value==climatological_model:model_ensemble \
  possible_value==scenario:rcp26 \
  possible_value==year_period:JJA
```

This PR also includes the existing values in the response, so that the frontend may further filter the returned items into the one it wants to use. The reponse to the above request:

```json
{
    "items": [
        {
            "identifier": "tas_seasonal_anomaly_model_ensemble-annual-model_ensemble-tas-anomaly-rcp26-JJA",
            "related_coverage_configuration_url": "http://localhost:8877/api/v2/coverages/coverage-configurations/27049eea-798f-4725-ae23-d76db93d629a",
            "wms_base_url": "http://thredds:8080/thredds/wms/ens5ym/clipped/tas_anom_pp_ts_rcp26_JJA_VFVGTAA.nc",
            "wms_main_layer_name": "tas",
            "possible_values": [
                {
                    "configuration_parameter_name": "aggregation_period",
                    "configuration_parameter_display_name_english": "Temporal aggregation period",
                    "configuration_parameter_display_name_italian": "Periodo di aggregazione temporale",
                    "configuration_parameter_value": "annual"
                },
                {
                    "configuration_parameter_name": "climatological_model",
                    "configuration_parameter_display_name_english": "Forecast model",
                    "configuration_parameter_display_name_italian": "Modello di previsione",
                    "configuration_parameter_value": "model_ensemble"
                },
                {
                    "configuration_parameter_name": "climatological_variable",
                    "configuration_parameter_display_name_english": "Variable",
                    "configuration_parameter_display_name_italian": "Variabile",
                    "configuration_parameter_value": "tas"
                },
                {
                    "configuration_parameter_name": "measure",
                    "configuration_parameter_display_name_english": "Measurement type",
                    "configuration_parameter_display_name_italian": "Tipo di misurazione",
                    "configuration_parameter_value": "anomaly"
                },
                {
                    "configuration_parameter_name": "scenario",
                    "configuration_parameter_display_name_english": "Scenario",
                    "configuration_parameter_display_name_italian": "Scenario",
                    "configuration_parameter_value": "rcp26"
                },
                {
                    "configuration_parameter_name": "year_period",
                    "configuration_parameter_display_name_english": "Year period",
                    "configuration_parameter_display_name_italian": "Periodo dell'anno",
                    "configuration_parameter_value": "JJA"
                }
            ]
        },
        {
            "identifier": "tas_seasonal_anomaly_model_ensemble_lower_uncertainty-annual-model_ensemble-tas-anomaly-rcp26-lower_bound-JJA",
            "related_coverage_configuration_url": "http://localhost:8877/api/v2/coverages/coverage-configurations/7a678761-a198-471e-9280-684f022e0d10",
            "wms_base_url": "http://thredds:8080/thredds/wms/ens5ym/std/clipped/tas_anom_stddown_pp_ts_rcp26_JJA_VFVGTAA.nc",
            "wms_main_layer_name": "tas_stddown",
            "possible_values": [
                {
                    "configuration_parameter_name": "aggregation_period",
                    "configuration_parameter_display_name_english": "Temporal aggregation period",
                    "configuration_parameter_display_name_italian": "Periodo di aggregazione temporale",
                    "configuration_parameter_value": "annual"
                },
                {
                    "configuration_parameter_name": "climatological_model",
                    "configuration_parameter_display_name_english": "Forecast model",
                    "configuration_parameter_display_name_italian": "Modello di previsione",
                    "configuration_parameter_value": "model_ensemble"
                },
                {
                    "configuration_parameter_name": "climatological_variable",
                    "configuration_parameter_display_name_english": "Variable",
                    "configuration_parameter_display_name_italian": "Variabile",
                    "configuration_parameter_value": "tas"
                },
                {
                    "configuration_parameter_name": "measure",
                    "configuration_parameter_display_name_english": "Measurement type",
                    "configuration_parameter_display_name_italian": "Tipo di misurazione",
                    "configuration_parameter_value": "anomaly"
                },
                {
                    "configuration_parameter_name": "scenario",
                    "configuration_parameter_display_name_english": "Scenario",
                    "configuration_parameter_display_name_italian": "Scenario",
                    "configuration_parameter_value": "rcp26"
                },
                {
                    "configuration_parameter_name": "uncertainty_type",
                    "configuration_parameter_display_name_english": "Uncertainty type",
                    "configuration_parameter_display_name_italian": "Tipologia dei limiti di incertezza",
                    "configuration_parameter_value": "lower_bound"
                },
                {
                    "configuration_parameter_name": "year_period",
                    "configuration_parameter_display_name_english": "Year period",
                    "configuration_parameter_display_name_italian": "Periodo dell'anno",
                    "configuration_parameter_value": "JJA"
                }
            ]
        },
        {
            "identifier": "tas_seasonal_anomaly_model_ensemble_upper_uncertainty-annual-model_ensemble-tas-anomaly-rcp26-upper_bound-JJA",
            "related_coverage_configuration_url": "http://localhost:8877/api/v2/coverages/coverage-configurations/a2317832-76b1-4c5e-92a2-9b935d789737",
            "wms_base_url": "http://thredds:8080/thredds/wms/ens5ym/std/clipped/tas_anom_stdup_pp_ts_rcp26_JJA_VFVGTAA.nc",
            "wms_main_layer_name": "tas_stdup",
            "possible_values": [
                {
                    "configuration_parameter_name": "aggregation_period",
                    "configuration_parameter_display_name_english": "Temporal aggregation period",
                    "configuration_parameter_display_name_italian": "Periodo di aggregazione temporale",
                    "configuration_parameter_value": "annual"
                },
                {
                    "configuration_parameter_name": "climatological_model",
                    "configuration_parameter_display_name_english": "Forecast model",
                    "configuration_parameter_display_name_italian": "Modello di previsione",
                    "configuration_parameter_value": "model_ensemble"
                },
                {
                    "configuration_parameter_name": "climatological_variable",
                    "configuration_parameter_display_name_english": "Variable",
                    "configuration_parameter_display_name_italian": "Variabile",
                    "configuration_parameter_value": "tas"
                },
                {
                    "configuration_parameter_name": "measure",
                    "configuration_parameter_display_name_english": "Measurement type",
                    "configuration_parameter_display_name_italian": "Tipo di misurazione",
                    "configuration_parameter_value": "anomaly"
                },
                {
                    "configuration_parameter_name": "scenario",
                    "configuration_parameter_display_name_english": "Scenario",
                    "configuration_parameter_display_name_italian": "Scenario",
                    "configuration_parameter_value": "rcp26"
                },
                {
                    "configuration_parameter_name": "uncertainty_type",
                    "configuration_parameter_display_name_english": "Uncertainty type",
                    "configuration_parameter_display_name_italian": "Tipologia dei limiti di incertezza",
                    "configuration_parameter_value": "upper_bound"
                },
                {
                    "configuration_parameter_name": "year_period",
                    "configuration_parameter_display_name_english": "Year period",
                    "configuration_parameter_display_name_italian": "Periodo dell'anno",
                    "configuration_parameter_value": "JJA"
                }
            ]
        }
    ],
    "meta": {
        "returned_records": 3,
        "total_records": 1785,
        "total_filtered_records": 3
    },
    "links": {
        "self": "http://localhost:8877/api/v2/coverages/coverage-identifiers?limit=20&offset=0&possible_value=year_period:JJA",
        "next": null,
        "previous": null,
        "first": "http://localhost:8877/api/v2/coverages/coverage-identifiers?limit=20&offset=0&possible_value=year_period:JJA",
        "last": "http://localhost:8877/api/v2/coverages/coverage-identifiers?limit=20&offset=0&possible_value=year_period:JJA"
    }
}
```


In the example above, the response include three items:

- the main coverage
- the lower uncertainty coverage
- the upper uncertainty coverage

Upon receiving the response, the frontend is able to distinguish between them by inspecting the properties of each. Those that represent uncertainty will have a `configuration_parameter_name: uncertainty_type` property

---

- fixes #171 