### PR TITLE
Fixed incorrect calls to renamed db function

### DIFF
--- a/arpav_ppcv/webapp/api_v2/routers/coverages.py
+++ b/arpav_ppcv/webapp/api_v2/routers/coverages.py
@@ -172,8 +172,8 @@ def get_coverage_configuration(
     db_coverage_configuration = db.get_coverage_configuration(
         db_session, coverage_configuration_id
     )
-    allowed_coverage_identifiers = db.list_allowed_coverage_identifiers(
-        db_session, coverage_configuration_id=db_coverage_configuration.id
+    allowed_coverage_identifiers = db.generate_coverage_identifiers(
+        db_session, coverage_configuration=db_coverage_configuration
     )
     return coverage_schemas.CoverageConfigurationReadDetail.from_db_instance(
         db_coverage_configuration, allowed_coverage_identifiers, request
@@ -407,8 +407,8 @@ def get_climate_barometer_time_series(
             db_session, coverage_identifier
         )
     ) is not None:
-        allowed_cov_ids = db.list_allowed_coverage_identifiers(
-            db_session, coverage_configuration_id=db_cov_conf.id
+        allowed_cov_ids = db.generate_coverage_identifiers(
+            db_session, coverage_configuration=db_cov_conf
         )
         if coverage_identifier in allowed_cov_ids:
             coverage = CoverageInternal(
@@ -480,8 +480,8 @@ def get_time_series(
             db_session, coverage_identifier
         )
     ) is not None:
-        allowed_cov_ids = db.list_allowed_coverage_identifiers(
-            db_session, coverage_configuration_id=db_cov_conf.id
+        allowed_cov_ids = db.generate_coverage_identifiers(
+            db_session, coverage_configuration=db_cov_conf
         )
         if coverage_identifier in allowed_cov_ids:
             coverage = CoverageInternal(

--- a/arpav_ppcv/webapp/api_v2/schemas/coverages.py
+++ b/arpav_ppcv/webapp/api_v2/schemas/coverages.py
@@ -137,10 +137,12 @@ class CoverageConfigurationReadDetail(CoverageConfigurationReadListItem):
                 ConfigurationParameterPossibleValueRead(
                     configuration_parameter_name=pv.configuration_parameter_value.configuration_parameter.name,
                     configuration_parameter_display_name_english=(
-                        pv.configuration_parameter_value.configuration_parameter.display_name_english
+                        pv.configuration_parameter_value.configuration_parameter.display_name_english or
+                        pv.configuration_parameter_value.configuration_parameter.name
                     ),
                     configuration_parameter_display_name_italian=(
-                        pv.configuration_parameter_value.configuration_parameter.display_name_italian
+                        pv.configuration_parameter_value.configuration_parameter.display_name_italian or
+                        pv.configuration_parameter_value.configuration_parameter.name
                     ),
                     configuration_parameter_value=pv.configuration_parameter_value.name,
                 )
@@ -194,10 +196,12 @@ class CoverageIdentifierReadListItem(pydantic.BaseModel):
                 ConfigurationParameterPossibleValueRead(
                     configuration_parameter_name=pv.configuration_parameter_value.configuration_parameter.name,
                     configuration_parameter_display_name_english=(
-                        pv.configuration_parameter_value.configuration_parameter.display_name_english
+                        pv.configuration_parameter_value.configuration_parameter.display_name_english or
+                        pv.configuration_parameter_value.configuration_parameter.name
                     ),
                     configuration_parameter_display_name_italian=(
-                        pv.configuration_parameter_value.configuration_parameter.display_name_italian
+                        pv.configuration_parameter_value.configuration_parameter.display_name_italian or
+                        pv.configuration_parameter_value.configuration_parameter.name
                     ),
                     configuration_parameter_value=pv.configuration_parameter_value.name,
                 )

--- a/tests/test_webapp_v2_routers_coverages.py
+++ b/tests/test_webapp_v2_routers_coverages.py
@@ -1,0 +1,26 @@
+import httpx
+
+from arpav_ppcv.schemas import coverages
+
+
+def test_coverage_configurations_list(
+    test_client_v2_app: httpx.Client,
+    sample_coverage_configurations: list[coverages.CoverageConfiguration]
+):
+    list_response = test_client_v2_app.get(
+        test_client_v2_app.app.url_path_for("list_coverage_configurations"),
+        headers={"accept": "application/json"},
+    )
+    assert list_response.status_code == 200
+    assert len(list_response.json()["items"]) == 10
+
+
+def test_coverage_identifiers_list(
+    test_client_v2_app: httpx.Client,
+    sample_coverage_configurations: list[coverages.CoverageConfiguration]
+):
+    list_response = test_client_v2_app.get(
+        test_client_v2_app.app.url_path_for("list_coverage_identifiers"),
+        headers={"accept": "application/json"},
+    )
+    assert list_response.status_code == 200


### PR DESCRIPTION
This PR fixes the error reported in #174 and adds a couple of basic integration tests to ensure the endpoints that list coverage configurations and identifiers return a status of 200 - these are not very robust but will at least prevent this type of regression to happen in the future.

---

- fixes #174