### PR TITLE
Added missing translation strings

### DIFF
--- a/arpav_ppcv/schemas/base.py
+++ b/arpav_ppcv/schemas/base.py
@@ -28,7 +28,7 @@ class Season(enum.Enum):
             self.SPRING.name: _("spring"),
             self.SUMMER.name: _("summer"),
             self.AUTUMN.name: _("autumn"),
-        }[self.name]
+        }[self.name] or self.name
 
 
 class ObservationDataSmoothingStrategy(enum.Enum):
@@ -41,7 +41,7 @@ class ObservationDataSmoothingStrategy(enum.Enum):
         return {
             self.NO_SMOOTHING.name: _("no processing"),
             self.MOVING_AVERAGE_5_YEARS.name: _("centered 5-year moving average"),
-        }[self.name]
+        }[self.name] or self.name
 
 
 UNCERTAINTY_TIME_SERIES_PATTERN = "**UNCERTAINTY**"
@@ -60,7 +60,7 @@ class ObservationAggregationType(str, enum.Enum):
             self.MONTHLY.name: _("monthly"),
             self.SEASONAL.name: _("seasonal"),
             self.YEARLY.name: _("yearly"),
-        }[self.name]
+        }[self.name] or self.name
 
 
 class CoverageDataSmoothingStrategy(enum.Enum):
@@ -75,7 +75,7 @@ class CoverageDataSmoothingStrategy(enum.Enum):
             self.NO_SMOOTHING.name: _("no processing"),
             self.LOESS_SMOOTHING.name: _("LOESS"),
             self.MOVING_AVERAGE_11_YEARS.name: _("centered 11-year moving average"),
-        }[self.name]
+        }[self.name] or self.name
 
 
 class StaticCoverageSeriesParameter(enum.Enum):
@@ -92,7 +92,7 @@ class StaticCoverageSeriesParameter(enum.Enum):
             self.PROCESSING_METHOD.name: _("processing method"),
             self.COVERAGE_IDENTIFIER.name: _("coverage identifier"),
             self.COVERAGE_CONFIGURATION.name: _("coverage configuration"),
-        }[self.name]
+        }[self.name] or self.name
 
 
 class StaticObservationSeriesParameter(enum.Enum):
@@ -111,7 +111,7 @@ class StaticObservationSeriesParameter(enum.Enum):
             self.VARIABLE.name: _("variable"),
             self.SERIES_ELABORATION.name: _("series elaboration"),
             self.DERIVED_SERIES.name: _("derived series"),
-        }[self.name]
+        }[self.name] or self.name
 
 
 class TimeSeriesElaboration(enum.Enum):
@@ -124,7 +124,7 @@ class TimeSeriesElaboration(enum.Enum):
         return {
             self.ORIGINAL.name: _("original"),
             self.DERIVED.name: _("derived"),
-        }[self.name]
+        }[self.name] or self.name
 
 
 class ObservationDerivedSeries(enum.Enum):
@@ -137,7 +137,7 @@ class ObservationDerivedSeries(enum.Enum):
         return {
             self.DECADE_SERIES.name: _("decade series"),
             self.MANN_KENDALL_SERIES.name: _("Mann-Kendall series"),
-        }[self.name]
+        }[self.name] or self.name
 
 
 class MannKendallParameters(pydantic.BaseModel):

--- a/arpav_ppcv/translations/en/LC_MESSAGES/messages.po
+++ b/arpav_ppcv/translations/en/LC_MESSAGES/messages.po
@@ -21,88 +21,88 @@ msgstr ""
 
 #: schemas/base.py:27
 msgid "winter"
-msgstr ""
+msgstr "Winter"
 
 #: schemas/base.py:28
 msgid "spring"
-msgstr ""
+msgstr "Spring"
 
 #: schemas/base.py:29
 msgid "summer"
-msgstr ""
+msgstr "Summer"
 
 #: schemas/base.py:30
 msgid "autumn"
-msgstr ""
+msgstr "Autumn"
 
 #: schemas/base.py:42 schemas/base.py:75
 msgid "no processing"
-msgstr ""
+msgstr "no processing"
 
 #: schemas/base.py:43
 msgid "centered 5-year moving average"
-msgstr ""
+msgstr "Centered 5-year moving average"
 
 #: schemas/base.py:60
 msgid "monthly"
-msgstr ""
+msgstr "monthly"
 
 #: schemas/base.py:61
 msgid "seasonal"
-msgstr ""
+msgstr "seasonal"
 
 #: schemas/base.py:62
 msgid "yearly"
-msgstr ""
+msgstr "yearly"
 
 #: schemas/base.py:76
 msgid "LOESS"
-msgstr ""
+msgstr "LOESS"
 
 #: schemas/base.py:77
 msgid "centered 11-year moving average"
-msgstr ""
+msgstr "Centered 11-year moving average"
 
 #: schemas/base.py:91 schemas/base.py:109
 msgid "series name"
-msgstr ""
+msgstr "Series name"
 
 #: schemas/base.py:92 schemas/base.py:110
 msgid "processing method"
-msgstr ""
+msgstr "Processing method"
 
 #: schemas/base.py:93
 msgid "coverage identifier"
-msgstr ""
+msgstr "Coverage identifier"
 
 #: schemas/base.py:94
 msgid "coverage configuration"
-msgstr ""
+msgstr "Coverage configuration"
 
 #: schemas/base.py:111
 msgid "variable"
-msgstr ""
+msgstr "Variable"
 
 #: schemas/base.py:112
 msgid "series elaboration"
-msgstr ""
+msgstr "Series elaboration"
 
 #: schemas/base.py:113
 msgid "derived series"
-msgstr ""
+msgstr "Derived series"
 
 #: schemas/base.py:125
 msgid "original"
-msgstr ""
+msgstr "Original"
 
 #: schemas/base.py:126
 msgid "derived"
-msgstr ""
+msgstr "Derived"
 
 #: schemas/base.py:138
 msgid "decade series"
-msgstr ""
+msgstr "Decade series"
 
 #: schemas/base.py:139
 msgid "Mann-Kendall series"
-msgstr ""
+msgstr "Mann-Kendall series"


### PR DESCRIPTION
This PR adds some missing translation strings and also makes the static strings, which are translated from code enum values return their code value if not translated yet.

---

- fixes #174