### PR TITLE
Added tests for determination of related and uncertainty datasets

### DIFF
--- a/tests/notebooks/generic.ipynb
+++ b/tests/notebooks/generic.ipynb
@@ -55,7 +55,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "coverage_identifier = \"tas_seasonal_absolute_model_ensemble-annual-model_ensemble-tas-absolute-rcp26-DJF\"\n",
+    "coverage_identifier = \"tas_seasonal_anomaly_model_ensemble-annual-model_ensemble-tas-anomaly-rcp26-MAM\"\n",
     "point_coords = \"POINT(11.5469 44.9524)\"\n",
     "date_range = \"../..\"\n",
     "\n",
@@ -67,60 +67,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "974c6dfa-7d87-4388-9ef5-dd29fb855919",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'tas_seasonal_absolute_model_ensemble_upper_uncertainty-annual-model_ensemble-tas-absolute-rcp26-upper_bound-DJF'"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "operations.get_related_uncertainty_coverage_configurations(session, cov)[1].identifier"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "33991a12-8e81-4de0-8812-057b25a6296f",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "CoverageConfiguration(description_english='Average daily air temperature near the ground', color_scale_max=32.0, description_italian=\"Temperatura media giornaliera dell'aria vicino al suolo\", observation_variable_id=None, netcdf_main_dataset_name='tas_stddown', observation_variable_aggregation_type=None, thredds_url_pattern='ensymbc/std/clipped/tas_stddown_{scenario}_{year_period}_ts19762100_ls_VFVG.nc', uncertainty_lower_bounds_coverage_configuration_id=None, name='tas_seasonal_absolute_model_ensemble_lower_uncertainty', wms_main_layer_name='tas_stddown', uncertainty_upper_bounds_coverage_configuration_id=None, id=UUID('37ec5342-7eba-4d99-831e-b8e027577ec0'), unit='ºC', display_name_english='Mean temperature', palette='default/seq-YlOrRd', display_name_italian='Temperatura media', color_scale_min=-3.0, coverage_id_pattern='{name}-{aggregation_period}-{climatological_model}-{climatological_variable}-{measure}-{scenario}-{uncertainty_type}-{year_period}')"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "cov.configuration.uncertainty_lower_bounds_coverage_configuration"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 4,
-   "id": "e2b7ec11-5168-42dd-8992-cb98f1f4def3",
+   "id": "48b441be-581b-48d6-86a4-11ea7a36b795",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['tas_seasonal_absolute_model_ec_earth_cclm4_8_17-annual-ec_earth_cclm_4_8_17-tas-absolute-rcp26-DJF',\n",
-       " 'tas_seasonal_absolute_model_ec_earth_racmo22e-annual-ec_earth_racmo22e-tas-absolute-rcp26-DJF',\n",
-       " 'tas_seasonal_absolute_model_ec_earth_rca4-annual-ec_earth_rca4-tas-absolute-rcp26-DJF',\n",
-       " 'tas_seasonal_absolute_model_hadgem2_es_racmo22e-annual-hadgem2_racmo22e-tas-absolute-rcp26-DJF',\n",
-       " 'tas_seasonal_absolute_model_mpi_esm_lr_remo2009-annual-mpi_esm_lr_remo2009-tas-absolute-rcp26-DJF']"
+       "['tas_seasonal_anomaly_model_ensemble_lower_uncertainty-annual-model_ensemble-tas-anomaly-rcp26-lower_bound-MAM',\n",
+       " 'tas_seasonal_anomaly_model_ensemble_upper_uncertainty-annual-model_ensemble-tas-anomaly-rcp26-upper_bound-MAM']"
       ]
      },
      "execution_count": 4,
@@ -129,8 +84,145 @@
     }
    ],
    "source": [
-    "[c.identifier for c in operations.get_related_coverages(cov)]"
+    "[c.identifier for c in operations.get_related_uncertainty_coverage_configurations(session, cov)]"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "82b5c65f-afe2-4b83-b3a0-54d14a5ea3e5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "id_parts=['annual', 'model_ensemble', 'tas', 'anomaly', 'rcp26', 'MAM']\n",
+      "about to process the found pattern_parts...\n",
+      "checking configuration_parameter_name='aggregation_period'...\n",
+      "id_part='annual'\n",
+      "checking configuration_parameter_name='climatological_model'...\n",
+      "id_part='model_ensemble'\n",
+      "checking configuration_parameter_name='climatological_variable'...\n",
+      "id_part='tas'\n",
+      "checking configuration_parameter_name='measure'...\n",
+      "id_part='anomaly'\n",
+      "checking configuration_parameter_name='scenario'...\n",
+      "id_part='rcp26'\n",
+      "checking configuration_parameter_name='year_period'...\n",
+      "id_part='MAM'\n",
+      "result={'aggregation_period': 'annual', 'climatological_model': 'model_ensemble', 'climatological_variable': 'tas', 'measure': 'anomaly', 'scenario': 'rcp26', 'year_period': 'MAM'}\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'aggregation_period': 'annual',\n",
+       " 'climatological_model': 'model_ensemble',\n",
+       " 'climatological_variable': 'tas',\n",
+       " 'measure': 'anomaly',\n",
+       " 'scenario': 'rcp26',\n",
+       " 'year_period': 'MAM'}"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cov.configuration.retrieve_configuration_parameters(cov.identifier)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f829643d-7e9c-40f4-b352-ea4d74e4ed2f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'{name}-{aggregation_period}-{climatological_model}-{climatological_variable}-{measure}-{scenario}-{year_period}'"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cov.configuration.coverage_id_pattern"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "5ae32788-669a-4903-8222-c694d4dacf3e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['tas_seasonal_anomaly_model_ensemble-annual-model_ensemble-tas-anomaly-rcp26-DJF',\n",
+       " 'tas_seasonal_anomaly_model_ensemble-annual-model_ensemble-tas-anomaly-rcp26-MAM',\n",
+       " 'tas_seasonal_anomaly_model_ensemble-annual-model_ensemble-tas-anomaly-rcp26-JJA',\n",
+       " 'tas_seasonal_anomaly_model_ensemble-annual-model_ensemble-tas-anomaly-rcp26-SON',\n",
+       " 'tas_seasonal_anomaly_model_ensemble-annual-model_ensemble-tas-anomaly-rcp45-DJF',\n",
+       " 'tas_seasonal_anomaly_model_ensemble-annual-model_ensemble-tas-anomaly-rcp45-MAM',\n",
+       " 'tas_seasonal_anomaly_model_ensemble-annual-model_ensemble-tas-anomaly-rcp45-JJA',\n",
+       " 'tas_seasonal_anomaly_model_ensemble-annual-model_ensemble-tas-anomaly-rcp45-SON',\n",
+       " 'tas_seasonal_anomaly_model_ensemble-annual-model_ensemble-tas-anomaly-rcp85-DJF',\n",
+       " 'tas_seasonal_anomaly_model_ensemble-annual-model_ensemble-tas-anomaly-rcp85-MAM',\n",
+       " 'tas_seasonal_anomaly_model_ensemble-annual-model_ensemble-tas-anomaly-rcp85-JJA',\n",
+       " 'tas_seasonal_anomaly_model_ensemble-annual-model_ensemble-tas-anomaly-rcp85-SON']"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "db.generate_coverage_identifiers(cov.configuration)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "366393b0-cea5-4a2b-bd3a-13316b2c85d0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tas_annual_absolute_model_ensemble-annual-model_ensemble-tas-absolute-rcp26-year tas_annual_absolute_model_ec_earth_cclm4_8_17-annual-ec_earth_cclm_4_8_17-tas-absolute-rcp26-year\n",
+      "----------\n",
+      "tas_annual_absolute_model_ensemble-annual-model_ensemble-tas-absolute-rcp26-year tas_annual_absolute_model_ec_earth_racmo22e-annual-ec_earth_racmo22e-tas-absolute-rcp26-year\n",
+      "----------\n",
+      "tas_annual_absolute_model_ensemble-annual-model_ensemble-tas-absolute-rcp26-year tas_annual_absolute_model_ec_earth_rca4-annual-ec_earth_rca4-tas-absolute-rcp26-year\n",
+      "----------\n",
+      "tas_annual_absolute_model_ensemble-annual-model_ensemble-tas-absolute-rcp26-year tas_annual_absolute_model_hadgem2_es_racmo22e-annual-hadgem2_racmo22e-tas-absolute-rcp26-year\n",
+      "----------\n",
+      "tas_annual_absolute_model_ensemble-annual-model_ensemble-tas-absolute-rcp26-year tas_annual_absolute_model_mpi_esm_lr_remo2009-annual-mpi_esm_lr_remo2009-tas-absolute-rcp26-year\n",
+      "----------\n"
+     ]
+    }
+   ],
+   "source": [
+    "for related_cov in operations.get_related_coverages(cov):\n",
+    "    print(cov.identifier, related_cov.identifier)\n",
+    "    print(\"----------\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b50e512-cff5-4f30-8576-9e2ea92a2948",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -1,11 +1,20 @@
 import datetime as dt
 
 import pytest
-from arpav_ppcv import operations
+from pandas.core.dtypes.common import (
+    is_datetime64_ns_dtype,
+    is_float_dtype,
+)
+
+from arpav_ppcv import (
+    database,
+    operations,
+)
+from arpav_ppcv.schemas import coverages
 
 
 @pytest.mark.parametrize(
-    "range, expected",
+    "temporal_range, expected",
     [
         pytest.param("../..", (None, None)),
         pytest.param(
@@ -22,6 +31,152 @@ from arpav_ppcv import operations
         ),
     ],
 )
-def test_parse_temporal_range(range, expected):
-    result = operations._parse_temporal_range(range)
+def test_parse_temporal_range(temporal_range, expected):
+    result = operations._parse_temporal_range(temporal_range)
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    [
+        "time_start",
+        "time_end",
+        "expected_first_tas_value",
+        "expected_last_tas_value",
+        "expected_first_dt_value",
+        "expected_last_dt_value",
+    ],
+    [
+        pytest.param(
+            None,
+            None,
+            2.640222,
+            3.911859,
+            "1976-02-15T12:00:00+00:00",
+            "2017-02-14T16:00:00+00:00",
+        ),
+        pytest.param(
+            dt.datetime(1980, 1, 1),
+            None,
+            3.5937133,
+            3.911859,
+            "1980-02-15T11:48:17.561000+00:00",
+            "2017-02-14T16:00:00+00:00",
+        ),
+        pytest.param(
+            None,
+            dt.datetime(2000, 1, 1),
+            2.640222,
+            4.3369384,
+            "1976-02-15T12:00:00+00:00",
+            "1999-02-15T04:52:40.976000+00:00",
+        ),
+        pytest.param(
+            dt.datetime(1980, 1, 1),
+            dt.datetime(2000, 1, 1),
+            3.5937133,
+            4.3369384,
+            "1980-02-15T11:48:17.561000+00:00",
+            "1999-02-15T04:52:40.976000+00:00",
+        ),
+    ],
+)
+def test_parse_ncss_dataset(
+    sample_tas_csv_data,
+    time_start,
+    time_end,
+    expected_first_tas_value,
+    expected_last_tas_value,
+    expected_first_dt_value,
+    expected_last_dt_value,
+):
+    result = operations._parse_ncss_dataset(
+        raw_data=sample_tas_csv_data,
+        source_main_ds_name="tas",
+        time_start=time_start,
+        time_end=time_end,
+        target_main_ds_name="tas",
+    )
+    assert result.index.name == "time"
+    assert is_datetime64_ns_dtype(result.index.dtype)
+    assert is_float_dtype(result.tas)
+    assert result.index[0].isoformat() == expected_first_dt_value
+    assert result.index[-1].isoformat() == expected_last_dt_value
+    assert result.tas[0] == pytest.approx(expected_first_tas_value)
+    assert result.tas[-1] == pytest.approx(expected_last_tas_value)
+
+
+@pytest.mark.parametrize(
+    "cov_conf_name, cov_identifier, expected_lower_identifier, expected_upper_identifier",
+    [
+        pytest.param(
+            "tas_seasonal_anomaly_model_ensemble",
+            "tas_seasonal_anomaly_model_ensemble-annual-model_ensemble-tas-anomaly-rcp26-MAM",
+            "tas_seasonal_anomaly_model_ensemble_lower_uncertainty-annual-model_ensemble-tas-anomaly-rcp26-lower_bound-MAM",
+            "tas_seasonal_anomaly_model_ensemble_upper_uncertainty-annual-model_ensemble-tas-anomaly-rcp26-upper_bound-MAM",
+        ),
+        pytest.param(
+            "tas_annual_absolute_model_ensemble",
+            "tas_annual_absolute_model_ensemble-annual-model_ensemble-tas-absolute-rcp26-year",
+            "tas_annual_absolute_model_ensemble_lower_uncertainty-annual-model_ensemble-tas-absolute-rcp26-lower_bound-year",
+            "tas_annual_absolute_model_ensemble_upper_uncertainty-annual-model_ensemble-tas-absolute-rcp26-upper_bound-year",
+        ),
+    ],
+)
+def test_get_related_uncertainty_coverage_configurations(
+    arpav_db_session,
+    sample_real_coverage_configurations: list[coverages.CoverageConfiguration],  # noqa
+    cov_conf_name,
+    cov_identifier,
+    expected_lower_identifier,
+    expected_upper_identifier,
+):
+    cov_conf = database.get_coverage_configuration_by_name(
+        arpav_db_session, cov_conf_name
+    )
+    lower_, upper_ = operations.get_related_uncertainty_coverage_configurations(
+        arpav_db_session,
+        coverage=coverages.CoverageInternal(
+            configuration=cov_conf, identifier=cov_identifier
+        ),
+    )
+    assert lower_.identifier == expected_lower_identifier
+    assert upper_.identifier == expected_upper_identifier
+
+
+@pytest.mark.parametrize(
+    "cov_conf_name, cov_identifier, expected_related_coverage_identifiers",
+    [
+        pytest.param(
+            "tas_seasonal_anomaly_model_ensemble",
+            "tas_seasonal_anomaly_model_ensemble-annual-model_ensemble-tas-anomaly-rcp26-MAM",
+            [
+                "tas_seasonal_anomaly_model_ec_earth_cclm4_8_17-annual-ec_earth_cclm_4_8_17-tas-anomaly-rcp26-MAM",
+                "tas_seasonal_anomaly_model_ec_earth_racmo22e-annual-ec_earth_racmo22e-tas-anomaly-rcp26-MAM",
+                "tas_seasonal_anomaly_model_ec_earth_rca4-annual-ec_earth_rca4-tas-anomaly-rcp26-MAM",
+                "tas_seasonal_anomaly_model_hadgem2_es_racmo22e-annual-hadgem2_racmo22e-tas-anomaly-rcp26-MAM",
+                "tas_seasonal_anomaly_model_mpi_esm_lr_remo2009-annual-mpi_esm_lr_remo2009-tas-anomaly-rcp26-MAM",
+            ],
+        )
+    ],
+)
+def test_get_related_coverage_configurations(
+    arpav_db_session,
+    sample_real_coverage_configurations: list[coverages.CoverageConfiguration],  # noqa
+    cov_conf_name,
+    cov_identifier,
+    expected_related_coverage_identifiers,
+):
+    cov_conf = database.get_coverage_configuration_by_name(
+        arpav_db_session, cov_conf_name
+    )
+    related = operations.get_related_coverages(
+        coverage=coverages.CoverageInternal(
+            configuration=cov_conf, identifier=cov_identifier
+        )
+    )
+    related_cov_identifiers = [c.identifier for c in related]
+    for expected_identifier in expected_related_coverage_identifiers:
+        assert expected_identifier in related_cov_identifiers
+
+    for found_identifier in related_cov_identifiers:
+        assert found_identifier in expected_related_coverage_identifiers


### PR DESCRIPTION
This PR adds some integration tests for the `arpav_ppcv.operations` module, namely for those functions that are responsible for the determination of related coverages and uncertainty ones, which were the root for some of the errors manifested in #174 

---

- fixes #188