### PR TITLE
Add missing cascade parameters to coverage configuration db relationships

### DIFF
--- a/arpav_ppcv/database.py
+++ b/arpav_ppcv/database.py
@@ -1179,6 +1179,20 @@ def update_coverage_configuration(
     return db_coverage_configuration
 
 
+def delete_coverage_configuration(
+    session: sqlmodel.Session, coverage_configuration_id: uuid.UUID
+) -> None:
+    """Delete a coverage configuration."""
+    db_coverage_configuration = get_coverage_configuration(
+        session, coverage_configuration_id
+    )
+    if db_coverage_configuration is not None:
+        session.delete(db_coverage_configuration)
+        session.commit()
+    else:
+        raise RuntimeError("Coverage configuration not found")
+
+
 def generate_coverage_identifiers(
     coverage_configuration: coverages.CoverageConfiguration,
     configuration_parameter_values_filter: Optional[

--- a/arpav_ppcv/schemas/coverages.py
+++ b/arpav_ppcv/schemas/coverages.py
@@ -188,7 +188,8 @@ class CoverageConfiguration(sqlmodel.SQLModel, table=True):
         sa_relationship_kwargs={
             "foreign_keys": (
                 "RelatedCoverageConfiguration.main_coverage_configuration_id"
-            )
+            ),
+            "cascade": "all, delete, delete-orphan",
         },
     )
     primary_coverage_configurations: list[
@@ -198,7 +199,8 @@ class CoverageConfiguration(sqlmodel.SQLModel, table=True):
         sa_relationship_kwargs={
             "foreign_keys": (
                 "RelatedCoverageConfiguration.secondary_coverage_configuration_id"
-            )
+            ),
+            "cascade": "all, delete, delete-orphan",
         },
     )
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -205,6 +205,20 @@ def test_create_coverage_configuration_simple(
         )
 
 
+def test_delete_coverage_configuration_works(
+    arpav_db_session, sample_real_coverage_configurations
+):
+    cov_conf_name = "tas_annual_absolute_model_ensemble"
+    db_cov_conf = database.get_coverage_configuration_by_name(
+        arpav_db_session, cov_conf_name
+    )
+    database.delete_coverage_configuration(arpav_db_session, db_cov_conf.id)
+    assert (
+        database.get_coverage_configuration_by_name(arpav_db_session, cov_conf_name)
+        is None
+    )
+
+
 def test_create_coverage_configuration_with_possible_values(
     arpav_db_session, sample_configuration_parameters
 ):


### PR DESCRIPTION
This PR adds missing `CASCADE` parameters to the relationships governing coverage configurations.

As a result of this PR it is now possible to use the admin UI to delete coverage configurations.

---

- fixes #104