### PR TITLE
Added bootstrap configs for new forecast variables

### DIFF
--- a/arpav_ppcv/bootstrapper/cliapp.py
+++ b/arpav_ppcv/bootstrapper/cliapp.py
@@ -19,7 +19,10 @@ from ..schemas.coverages import (
 
 from .coverage_configurations import (
     cdd,
+    cdds,
     fd,
+    hdds,
+    hwdi,
     pr,
     r95ptot,
     snwdays,
@@ -188,9 +191,12 @@ def bootstrap_coverage_configurations(
         }
     coverage_configurations = []
     coverage_configurations.extend(cdd.generate_configurations(conf_param_values))
+    coverage_configurations.extend(cdds.generate_configurations(conf_param_values))
     coverage_configurations.extend(
         fd.generate_configurations(conf_param_values, variables)
     )
+    coverage_configurations.extend(hdds.generate_configurations(conf_param_values))
+    coverage_configurations.extend(hwdi.generate_configurations(conf_param_values))
     coverage_configurations.extend(
         pr.generate_configurations(conf_param_values, variables)
     )
@@ -233,7 +239,10 @@ def bootstrap_coverage_configurations(
     to_update = {}
     for name, related_names in {
         **cdd.get_related_map(),
+        **cdds.get_related_map(),
         **fd.get_related_map(),
+        **hdds.get_related_map(),
+        **hwdi.get_related_map(),
         **pr.get_related_map(),
         **r95ptot.get_related_map(),
         **snwdays.get_related_map(),
@@ -249,7 +258,10 @@ def bootstrap_coverage_configurations(
 
     for name, uncertainties in {
         **cdd.get_uncertainty_map(),
+        **cdds.get_uncertainty_map(),
         **fd.get_uncertainty_map(),
+        **hdds.get_uncertainty_map(),
+        **hwdi.get_uncertainty_map(),
         **pr.get_uncertainty_map(),
         **r95ptot.get_uncertainty_map(),
         **snwdays.get_uncertainty_map(),

--- a/arpav_ppcv/bootstrapper/configurationparameters.py
+++ b/arpav_ppcv/bootstrapper/configurationparameters.py
@@ -17,8 +17,15 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                     name="cdd",
                     display_name_english="CDD",
                     display_name_italian="CDD",
-                    description_english="Consecutive Cold Days",
+                    description_english="Consecutive Dry Days",
                     description_italian="Giorni secchi",
+                ),
+                ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
+                    name="cdds",
+                    display_name_english="CDDs",
+                    display_name_italian="CDDs",
+                    description_english="Cooling degree days",
+                    description_italian="Gradi giorno di raffrescamento",
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     name="fd",
@@ -26,6 +33,20 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                     display_name_italian="FD",
                     description_english="Frozen Days",
                     description_italian="Giorni di gelo",
+                ),
+                ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
+                    name="hdds",
+                    display_name_english="HDDs",
+                    display_name_italian="HDDs",
+                    description_english="Heating degree days",
+                    description_italian="Gradi giorno di riscaldamento",
+                ),
+                ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
+                    name="hwdi",
+                    display_name_english="HWDI",
+                    display_name_italian="HWDI",
+                    description_english="Duration of heat waves",
+                    description_italian="Durata delle ondate di calore",
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     name="pr",

--- a/arpav_ppcv/bootstrapper/coverage_configurations/cdds.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/cdds.py
@@ -1,0 +1,976 @@
+from ...schemas.coverages import (
+    CoverageConfigurationCreate,
+    ConfigurationParameterPossibleValueCreate,
+)
+
+_DISPLAY_NAME_ENGLISH = "Cooling degree days"
+_DISPLAY_NAME_ITALIAN = "Gradi giorno di raffrescamento"
+_DESCRIPTION_ENGLISH = (
+    "Sum of the average daily temperature minus 21°C if the average daily temperature "
+    "is greater than 24°C"
+)
+_DESCRIPTION_ITALIAN = (
+    "Somma della temperatura media giornaliera meno 21°C se la temperatura media "
+    "giornaliera è maggiore di 24°C"
+)
+
+
+def generate_configurations(
+    conf_param_values,
+) -> list[CoverageConfigurationCreate]:
+    return [
+        CoverageConfigurationCreate(
+            name="cdds_annual_absolute_model_ensemble",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
+            netcdf_main_dataset_name="cdds",
+            wms_main_layer_name="cdds",
+            thredds_url_pattern="ensymbc/clipped_noppcne/cdds_21oc24oc_avg_ts19762100_{scenario}_ls_VFVG.nc",
+            unit="ºC",
+            palette="default/seq-YlOrRd",
+            color_scale_min=0,
+            color_scale_max=1000,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "cdds")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="cdds_annual_absolute_model_ec_earth_cclm4_8_17",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
+            netcdf_main_dataset_name="cdds",
+            wms_main_layer_name="cdds",
+            thredds_url_pattern="EC-EARTH_CCLM4-8-17ymbc/clipped_noppcne/cdds_21oc24oc_EC-EARTH_CCLM4-8-17_{scenario}_ts19762100_ls_VFVG.nc",
+            unit="ºC",
+            palette="default/seq-YlOrRd",
+            color_scale_min=0,
+            color_scale_max=1000,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "cdds")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="cdds_annual_absolute_model_ec_earth_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
+            netcdf_main_dataset_name="cdds",
+            wms_main_layer_name="cdds",
+            thredds_url_pattern="EC-EARTH_RACMO22Eymbc/clipped_noppcne/cdds_21oc24oc_EC-EARTH_RACMO22E_{scenario}_ts19762100_ls_VFVG.nc",
+            unit="ºC",
+            palette="default/seq-YlOrRd",
+            color_scale_min=0,
+            color_scale_max=1000,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "cdds")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_racmo22e")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="cdds_annual_absolute_model_ec_earth_rca4",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
+            netcdf_main_dataset_name="cdds",
+            wms_main_layer_name="cdds",
+            thredds_url_pattern="EC-EARTH_RCA4ymbc/clipped_noppcne/cdds_21oc24oc_EC-EARTH_RCA4_{scenario}_ts19762100_ls_VFVG.nc",
+            unit="ºC",
+            palette="default/seq-YlOrRd",
+            color_scale_min=0,
+            color_scale_max=1000,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "cdds")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_rca4")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="cdds_annual_absolute_model_hadgem2_es_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
+            netcdf_main_dataset_name="cdds",
+            wms_main_layer_name="cdds",
+            thredds_url_pattern="HadGEM2-ES_RACMO22Eymbc/clipped_noppcne/cdds_21oc24oc_HadGEM2-ES_RACMO22E_{scenario}_ts19762100_ls_VFVG.nc",
+            unit="ºC",
+            palette="default/seq-YlOrRd",
+            color_scale_min=0,
+            color_scale_max=1000,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "cdds")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "hadgem2_racmo22e")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="cdds_annual_absolute_model_mpi_esm_lr_remo2009",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
+            netcdf_main_dataset_name="cdds",
+            wms_main_layer_name="cdds",
+            thredds_url_pattern="MPI-ESM-LR_REMO2009ymbc/clipped_noppcne/cdds_21oc24oc_MPI-ESM-LR_REMO2009_{scenario}_ts19762100_ls_VFVG.nc",
+            unit="ºC",
+            palette="default/seq-YlOrRd",
+            color_scale_min=0,
+            color_scale_max=1000,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "cdds")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "mpi_esm_lr_remo2009")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="cdds_annual_absolute_model_ensemble_upper_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
+            netcdf_main_dataset_name="cdds_stdup",
+            wms_main_layer_name="cdds_stdup",
+            thredds_url_pattern="ensymbc/std/clipped/cdds_21oc24oc_stdup_ts19762100_{scenario}_ls_VFVG.nc",
+            unit="ºC",
+            palette="default/seq-YlOrRd",
+            color_scale_min=0,
+            color_scale_max=1000,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "cdds")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "upper_bound")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="cdds_annual_absolute_model_ensemble_lower_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
+            netcdf_main_dataset_name="cdds_stddown",
+            wms_main_layer_name="cdds_stddown",
+            thredds_url_pattern="ensymbc/std/clipped/cdds_21oc24oc_stddown_ts19762100_{scenario}_ls_VFVG.nc",
+            unit="ºC",
+            palette="default/seq-YlOrRd",
+            color_scale_min=0,
+            color_scale_max=1000,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "cdds")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "lower_bound")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
+            ],
+        ),
+        # ---
+        CoverageConfigurationCreate(
+            name="cdds_30yr_anomaly_annual_agree_model_ensemble",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
+            netcdf_main_dataset_name="cdds",
+            wms_main_layer_name="cdds-uncertainty_group",
+            wms_secondary_layer_name="cdds",
+            thredds_url_pattern="ensembletwbc/std/clipped/cdds_an_21oc24oc_avgagree_{time_window}_{scenario}_ls_VFVG.nc",
+            unit="ºC",
+            palette="uncert-stippled/seq-YlOrRd",
+            color_scale_min=0,
+            color_scale_max=1000,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "cdds")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw1")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw2")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="cdds_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
+            netcdf_main_dataset_name="cdds",
+            wms_main_layer_name="cdds",
+            thredds_url_pattern="indici5rcm/clipped_noppcne/cdds_an_21oc24oc_EC-EARTH_CCLM4-8-17_{scenario}_{time_window}_ls_VFVG.nc",
+            unit="ºC",
+            palette="default/seq-YlOrRd",
+            color_scale_min=0,
+            color_scale_max=1000,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "cdds")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw1")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw2")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="cdds_30yr_anomaly_annual_model_ec_earth_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
+            netcdf_main_dataset_name="cdds",
+            wms_main_layer_name="cdds",
+            thredds_url_pattern="indici5rcm/clipped_noppcne/cdds_an_21oc24oc_EC-EARTH_RACMO22E_{scenario}_{time_window}_ls_VFVG.nc",
+            unit="ºC",
+            palette="default/seq-YlOrRd",
+            color_scale_min=0,
+            color_scale_max=1000,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "cdds")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_racmo22e")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw1")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw2")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="cdds_30yr_anomaly_annual_model_ec_earth_rca4",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
+            netcdf_main_dataset_name="cdds",
+            wms_main_layer_name="cdds",
+            thredds_url_pattern="indici5rcm/clipped_noppcne/cdds_an_21oc24oc_EC-EARTH_RCA4_{scenario}_{time_window}_ls_VFVG.nc",
+            unit="ºC",
+            palette="default/seq-YlOrRd",
+            color_scale_min=0,
+            color_scale_max=1000,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "cdds")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_rca4")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw1")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw2")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="cdds_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
+            netcdf_main_dataset_name="cdds",
+            wms_main_layer_name="cdds",
+            thredds_url_pattern="indici5rcm/clipped_noppcne/cdds_an_21oc24oc_HadGEM2-ES_RACMO22E_{scenario}_{time_window}_ls_VFVG.nc",
+            unit="ºC",
+            palette="default/seq-YlOrRd",
+            color_scale_min=0,
+            color_scale_max=1000,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "cdds")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "hadgem2_racmo22e")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw1")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw2")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="cdds_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
+            netcdf_main_dataset_name="cdds",
+            wms_main_layer_name="cdds",
+            thredds_url_pattern="indici5rcm/clipped_noppcne/cdds_an_21oc24oc_MPI-ESM-LR_REMO2009_{scenario}_{time_window}_ls_VFVG.nc",
+            unit="ºC",
+            palette="default/seq-YlOrRd",
+            color_scale_min=0,
+            color_scale_max=1000,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "cdds")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "mpi_esm_lr_remo2009")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw1")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw2")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
+            ],
+        ),
+    ]
+
+
+def get_related_map() -> dict[str, list[str]]:
+    return {
+        "cdds_annual_absolute_model_ensemble": [
+            "cdds_annual_absolute_model_ec_earth_cclm4_8_17",
+            "cdds_annual_absolute_model_ec_earth_racmo22e",
+            "cdds_annual_absolute_model_ec_earth_rca4",
+            "cdds_annual_absolute_model_hadgem2_es_racmo22e",
+            "cdds_annual_absolute_model_mpi_esm_lr_remo2009",
+        ],
+        "cdds_annual_absolute_model_ec_earth_cclm4_8_17": [
+            "cdds_annual_absolute_model_ensemble",
+            "cdds_annual_absolute_model_ec_earth_racmo22e",
+            "cdds_annual_absolute_model_ec_earth_rca4",
+            "cdds_annual_absolute_model_hadgem2_es_racmo22e",
+            "cdds_annual_absolute_model_mpi_esm_lr_remo2009",
+        ],
+        "cdds_annual_absolute_model_ec_earth_racmo22e": [
+            "cdds_annual_absolute_model_ensemble",
+            "cdds_annual_absolute_model_ec_earth_cclm4_8_17",
+            "cdds_annual_absolute_model_ec_earth_rca4",
+            "cdds_annual_absolute_model_hadgem2_es_racmo22e",
+            "cdds_annual_absolute_model_mpi_esm_lr_remo2009",
+        ],
+        "cdds_annual_absolute_model_ec_earth_rca4": [
+            "cdds_annual_absolute_model_ensemble",
+            "cdds_annual_absolute_model_ec_earth_cclm4_8_17",
+            "cdds_annual_absolute_model_ec_earth_racmo22e",
+            "cdds_annual_absolute_model_hadgem2_es_racmo22e",
+            "cdds_annual_absolute_model_mpi_esm_lr_remo2009",
+        ],
+        "cdds_annual_absolute_model_hadgem2_es_racmo22e": [
+            "cdds_annual_absolute_model_ensemble",
+            "cdds_annual_absolute_model_ec_earth_cclm4_8_17",
+            "cdds_annual_absolute_model_ec_earth_racmo22e",
+            "cdds_annual_absolute_model_ec_earth_rca4",
+            "cdds_annual_absolute_model_mpi_esm_lr_remo2009",
+        ],
+        "cdds_annual_absolute_model_mpi_esm_lr_remo2009": [
+            "cdds_annual_absolute_model_ensemble",
+            "cdds_annual_absolute_model_ec_earth_cclm4_8_17",
+            "cdds_annual_absolute_model_ec_earth_racmo22e",
+            "cdds_annual_absolute_model_ec_earth_rca4",
+            "cdds_annual_absolute_model_hadgem2_es_racmo22e",
+        ],
+        "cdds_30yr_anomaly_annual_agree_model_ensemble": [
+            "cdds_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
+            "cdds_30yr_anomaly_annual_model_ec_earth_racmo22e",
+            "cdds_30yr_anomaly_annual_model_ec_earth_rca4",
+            "cdds_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
+            "cdds_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
+        ],
+        "cdds_30yr_anomaly_annual_model_ec_earth_cclm4_8_17": [
+            "cdds_30yr_anomaly_annual_agree_model_ensemble",
+            "cdds_30yr_anomaly_annual_model_ec_earth_racmo22e",
+            "cdds_30yr_anomaly_annual_model_ec_earth_rca4",
+            "cdds_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
+            "cdds_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
+        ],
+        "cdds_30yr_anomaly_annual_model_ec_earth_racmo22e": [
+            "cdds_30yr_anomaly_annual_agree_model_ensemble",
+            "cdds_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
+            "cdds_30yr_anomaly_annual_model_ec_earth_rca4",
+            "cdds_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
+            "cdds_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
+        ],
+        "cdds_30yr_anomaly_annual_model_ec_earth_rca4": [
+            "cdds_30yr_anomaly_annual_agree_model_ensemble",
+            "cdds_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
+            "cdds_30yr_anomaly_annual_model_ec_earth_racmo22e",
+            "cdds_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
+            "cdds_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
+        ],
+        "cdds_30yr_anomaly_annual_model_hadgem2_es_racmo22e": [
+            "cdds_30yr_anomaly_annual_agree_model_ensemble",
+            "cdds_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
+            "cdds_30yr_anomaly_annual_model_ec_earth_racmo22e",
+            "cdds_30yr_anomaly_annual_model_ec_earth_rca4",
+            "cdds_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
+        ],
+        "cdds_30yr_anomaly_annual_model_mpi_esm_lr_remo2009": [
+            "cdds_30yr_anomaly_annual_agree_model_ensemble",
+            "cdds_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
+            "cdds_30yr_anomaly_annual_model_ec_earth_racmo22e",
+            "cdds_30yr_anomaly_annual_model_ec_earth_rca4",
+            "cdds_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
+        ],
+    }
+
+
+def get_uncertainty_map() -> dict[str, tuple[str, str]]:
+    return {
+        "cdds_annual_absolute_model_ensemble": (
+            "cdds_annual_absolute_model_ensemble_upper_uncertainty",
+            "cdds_annual_absolute_model_ensemble_lower_uncertainty",
+        ),
+    }

--- a/arpav_ppcv/bootstrapper/coverage_configurations/hdds.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/hdds.py
@@ -1,0 +1,976 @@
+from ...schemas.coverages import (
+    CoverageConfigurationCreate,
+    ConfigurationParameterPossibleValueCreate,
+)
+
+_DISPLAY_NAME_ENGLISH = "Heating degree days"
+_DISPLAY_NAME_ITALIAN = "Gradi giorno di riscaldamento"
+_DESCRIPTION_ENGLISH = (
+    "Sum of 20°C minus the average daily temperature if the average daily temperature "
+    "is less than 20°C"
+)
+_DESCRIPTION_ITALIAN = (
+    "Somma di 20°C meno la temperatura media giornaliera se la temperatura media "
+    "giornaliera è minore di 20°C"
+)
+
+
+def generate_configurations(
+    conf_param_values,
+) -> list[CoverageConfigurationCreate]:
+    return [
+        CoverageConfigurationCreate(
+            name="hdds_annual_absolute_model_ensemble",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
+            netcdf_main_dataset_name="hdds",
+            wms_main_layer_name="hdds",
+            thredds_url_pattern="ensymbc/clipped_noppcne/hdds_20oc_avg_ts19762100_{scenario}_ls_VFVG.nc",
+            unit="ºC",
+            palette="default/seq-Blues-inv",
+            color_scale_min=0,
+            color_scale_max=7000,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "hdds")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="hdds_annual_absolute_model_ec_earth_cclm4_8_17",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
+            netcdf_main_dataset_name="hdds",
+            wms_main_layer_name="hdds",
+            thredds_url_pattern="EC-EARTH_CCLM4-8-17ymbc/clipped_noppcne/hdds_20oc_EC-EARTH_CCLM4-8-17_{scenario}_ts19762100_ls_VFVG.nc",
+            unit="ºC",
+            palette="default/seq-Blues-inv",
+            color_scale_min=0,
+            color_scale_max=7000,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "hdds")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="hdds_annual_absolute_model_ec_earth_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
+            netcdf_main_dataset_name="hdds",
+            wms_main_layer_name="hdds",
+            thredds_url_pattern="EC-EARTH_RACMO22Eymbc/clipped_noppcne/hdds_20oc_EC-EARTH_RACMO22E_{scenario}_ts19762100_ls_VFVG.nc",
+            unit="ºC",
+            palette="default/seq-Blues-inv",
+            color_scale_min=0,
+            color_scale_max=7000,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "hdds")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_racmo22e")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="hdds_annual_absolute_model_ec_earth_rca4",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
+            netcdf_main_dataset_name="hdds",
+            wms_main_layer_name="hdds",
+            thredds_url_pattern="EC-EARTH_RCA4ymbc/clipped_noppcne/hdds_20oc_EC-EARTH_RCA4_{scenario}_ts19762100_ls_VFVG.nc",
+            unit="ºC",
+            palette="default/seq-Blues-inv",
+            color_scale_min=0,
+            color_scale_max=7000,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "hdds")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_rca4")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="hdds_annual_absolute_model_hadgem2_es_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
+            netcdf_main_dataset_name="hdds",
+            wms_main_layer_name="hdds",
+            thredds_url_pattern="HadGEM2-ES_RACMO22Eymbc/clipped_noppcne/hdds_20oc_HadGEM2-ES_RACMO22E_{scenario}_ts19762100_ls_VFVG.nc",
+            unit="ºC",
+            palette="default/seq-Blues-inv",
+            color_scale_min=0,
+            color_scale_max=7000,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "hdds")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "hadgem2_racmo22e")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="hdds_annual_absolute_model_mpi_esm_lr_remo2009",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
+            netcdf_main_dataset_name="hdds",
+            wms_main_layer_name="hdds",
+            thredds_url_pattern="MPI-ESM-LR_REMO2009ymbc/clipped_noppcne/hdds_20oc_MPI-ESM-LR_REMO2009_{scenario}_ts19762100_ls_VFVG.nc",
+            unit="ºC",
+            palette="default/seq-Blues-inv",
+            color_scale_min=0,
+            color_scale_max=7000,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "hdds")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "mpi_esm_lr_remo2009")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="hdds_annual_absolute_model_ensemble_upper_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
+            netcdf_main_dataset_name="hdds_stdup",
+            wms_main_layer_name="hdds_stdup",
+            thredds_url_pattern="ensymbc/std/clipped/hdds_20oc_stdup_ts19762100_{scenario}_ls_VFVG.nc",
+            unit="ºC",
+            palette="default/seq-Blues-inv",
+            color_scale_min=0,
+            color_scale_max=7000,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "hdds")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "upper_bound")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="hdds_annual_absolute_model_ensemble_lower_uncertainty",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
+            netcdf_main_dataset_name="hdds_stddown",
+            wms_main_layer_name="hdds_stddown",
+            thredds_url_pattern="ensymbc/std/clipped/hdds_20oc_stddown_ts19762100_{scenario}_ls_VFVG.nc",
+            unit="ºC",
+            palette="default/seq-Blues-inv",
+            color_scale_min=0,
+            color_scale_max=7000,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "hdds")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "annual")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "absolute")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("uncertainty_type", "lower_bound")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
+            ],
+        ),
+        # ---
+        CoverageConfigurationCreate(
+            name="hdds_30yr_anomaly_annual_agree_model_ensemble",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
+            netcdf_main_dataset_name="hdds",
+            wms_main_layer_name="hdds-uncertainty_group",
+            wms_secondary_layer_name="hdds",
+            thredds_url_pattern="ensembletwbc/std/clipped/hdds_an_20oc_avgagree_{time_window}_{scenario}_ls_VFVG.nc",
+            unit="ºC",
+            palette="uncert-stippled/seq-YlOrRd-inv",
+            color_scale_min=-2000,
+            color_scale_max=0,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "hdds")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "model_ensemble")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw1")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw2")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="hdds_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
+            netcdf_main_dataset_name="hdds",
+            wms_main_layer_name="hdds",
+            thredds_url_pattern="indici5rcm/clipped_noppcne/hdds_an_20oc_EC-EARTH_CCLM4-8-17_{scenario}_{time_window}_ls_VFVG.nc",
+            unit="ºC",
+            palette="default/seq-YlOrRd-inv",
+            color_scale_min=-2000,
+            color_scale_max=0,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "hdds")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw1")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw2")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="hdds_30yr_anomaly_annual_model_ec_earth_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
+            netcdf_main_dataset_name="hdds",
+            wms_main_layer_name="hdds",
+            thredds_url_pattern="indici5rcm/clipped_noppcne/hdds_an_20oc_EC-EARTH_RACMO22E_{scenario}_{time_window}_ls_VFVG.nc",
+            unit="ºC",
+            palette="default/seq-YlOrRd-inv",
+            color_scale_min=-2000,
+            color_scale_max=0,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "hdds")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_racmo22e")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw1")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw2")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="hdds_30yr_anomaly_annual_model_ec_earth_rca4",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
+            netcdf_main_dataset_name="hdds",
+            wms_main_layer_name="hdds",
+            thredds_url_pattern="indici5rcm/clipped_noppcne/hdds_an_20oc_EC-EARTH_RCA4_{scenario}_{time_window}_ls_VFVG.nc",
+            unit="ºC",
+            palette="default/seq-YlOrRd-inv",
+            color_scale_min=-2000,
+            color_scale_max=0,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "hdds")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "ec_earth_rca4")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw1")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw2")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="hdds_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
+            netcdf_main_dataset_name="hdds",
+            wms_main_layer_name="hdds",
+            thredds_url_pattern="indici5rcm/clipped_noppcne/hdds_an_20oc_HadGEM2-ES_RACMO22E_{scenario}_{time_window}_ls_VFVG.nc",
+            unit="ºC",
+            palette="default/seq-YlOrRd-inv",
+            color_scale_min=-2000,
+            color_scale_max=0,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "hdds")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "hadgem2_racmo22e")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw1")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw2")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
+            ],
+        ),
+        CoverageConfigurationCreate(
+            name="hdds_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
+            netcdf_main_dataset_name="hdds",
+            wms_main_layer_name="hdds",
+            thredds_url_pattern="indici5rcm/clipped_noppcne/hdds_an_20oc_MPI-ESM-LR_REMO2009_{scenario}_{time_window}_ls_VFVG.nc",
+            unit="ºC",
+            palette="default/seq-YlOrRd-inv",
+            color_scale_min=-2000,
+            color_scale_max=0,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_variable", "hdds")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("aggregation_period", "30yr")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("measure", "anomaly")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("climatological_model", "mpi_esm_lr_remo2009")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw1")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("time_window", "tw2")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp26")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp45")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("scenario", "rcp85")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("year_period", "year")
+                    ].id
+                ),
+            ],
+        ),
+    ]
+
+
+def get_related_map() -> dict[str, list[str]]:
+    return {
+        "hdds_annual_absolute_model_ensemble": [
+            "hdds_annual_absolute_model_ec_earth_cclm4_8_17",
+            "hdds_annual_absolute_model_ec_earth_racmo22e",
+            "hdds_annual_absolute_model_ec_earth_rca4",
+            "hdds_annual_absolute_model_hadgem2_es_racmo22e",
+            "hdds_annual_absolute_model_mpi_esm_lr_remo2009",
+        ],
+        "hdds_annual_absolute_model_ec_earth_cclm4_8_17": [
+            "hdds_annual_absolute_model_ensemble",
+            "hdds_annual_absolute_model_ec_earth_racmo22e",
+            "hdds_annual_absolute_model_ec_earth_rca4",
+            "hdds_annual_absolute_model_hadgem2_es_racmo22e",
+            "hdds_annual_absolute_model_mpi_esm_lr_remo2009",
+        ],
+        "hdds_annual_absolute_model_ec_earth_racmo22e": [
+            "hdds_annual_absolute_model_ensemble",
+            "hdds_annual_absolute_model_ec_earth_cclm4_8_17",
+            "hdds_annual_absolute_model_ec_earth_rca4",
+            "hdds_annual_absolute_model_hadgem2_es_racmo22e",
+            "hdds_annual_absolute_model_mpi_esm_lr_remo2009",
+        ],
+        "hdds_annual_absolute_model_ec_earth_rca4": [
+            "hdds_annual_absolute_model_ensemble",
+            "hdds_annual_absolute_model_ec_earth_cclm4_8_17",
+            "hdds_annual_absolute_model_ec_earth_racmo22e",
+            "hdds_annual_absolute_model_hadgem2_es_racmo22e",
+            "hdds_annual_absolute_model_mpi_esm_lr_remo2009",
+        ],
+        "hdds_annual_absolute_model_hadgem2_es_racmo22e": [
+            "hdds_annual_absolute_model_ensemble",
+            "hdds_annual_absolute_model_ec_earth_cclm4_8_17",
+            "hdds_annual_absolute_model_ec_earth_racmo22e",
+            "hdds_annual_absolute_model_ec_earth_rca4",
+            "hdds_annual_absolute_model_mpi_esm_lr_remo2009",
+        ],
+        "hdds_annual_absolute_model_mpi_esm_lr_remo2009": [
+            "hdds_annual_absolute_model_ensemble",
+            "hdds_annual_absolute_model_ec_earth_cclm4_8_17",
+            "hdds_annual_absolute_model_ec_earth_racmo22e",
+            "hdds_annual_absolute_model_ec_earth_rca4",
+            "hdds_annual_absolute_model_hadgem2_es_racmo22e",
+        ],
+        "hdds_30yr_anomaly_annual_agree_model_ensemble": [
+            "hdds_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
+            "hdds_30yr_anomaly_annual_model_ec_earth_racmo22e",
+            "hdds_30yr_anomaly_annual_model_ec_earth_rca4",
+            "hdds_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
+            "hdds_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
+        ],
+        "hdds_30yr_anomaly_annual_model_ec_earth_cclm4_8_17": [
+            "hdds_30yr_anomaly_annual_agree_model_ensemble",
+            "hdds_30yr_anomaly_annual_model_ec_earth_racmo22e",
+            "hdds_30yr_anomaly_annual_model_ec_earth_rca4",
+            "hdds_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
+            "hdds_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
+        ],
+        "hdds_30yr_anomaly_annual_model_ec_earth_racmo22e": [
+            "hdds_30yr_anomaly_annual_agree_model_ensemble",
+            "hdds_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
+            "hdds_30yr_anomaly_annual_model_ec_earth_rca4",
+            "hdds_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
+            "hdds_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
+        ],
+        "hdds_30yr_anomaly_annual_model_ec_earth_rca4": [
+            "hdds_30yr_anomaly_annual_agree_model_ensemble",
+            "hdds_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
+            "hdds_30yr_anomaly_annual_model_ec_earth_racmo22e",
+            "hdds_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
+            "hdds_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
+        ],
+        "hdds_30yr_anomaly_annual_model_hadgem2_es_racmo22e": [
+            "hdds_30yr_anomaly_annual_agree_model_ensemble",
+            "hdds_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
+            "hdds_30yr_anomaly_annual_model_ec_earth_racmo22e",
+            "hdds_30yr_anomaly_annual_model_ec_earth_rca4",
+            "hdds_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
+        ],
+        "hdds_30yr_anomaly_annual_model_mpi_esm_lr_remo2009": [
+            "hdds_30yr_anomaly_annual_agree_model_ensemble",
+            "hdds_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
+            "hdds_30yr_anomaly_annual_model_ec_earth_racmo22e",
+            "hdds_30yr_anomaly_annual_model_ec_earth_rca4",
+            "hdds_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
+        ],
+    }
+
+
+def get_uncertainty_map() -> dict[str, tuple[str, str]]:
+    return {
+        "hdds_annual_absolute_model_ensemble": (
+            "hdds_annual_absolute_model_ensemble_upper_uncertainty",
+            "hdds_annual_absolute_model_ensemble_lower_uncertainty",
+        ),
+    }

--- a/arpav_ppcv/bootstrapper/coverage_configurations/hwdi.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/hwdi.py
@@ -3,14 +3,15 @@ from ...schemas.coverages import (
     ConfigurationParameterPossibleValueCreate,
 )
 
-_DISPLAY_NAME_ENGLISH = "Consecutive dry days"
-_DISPLAY_NAME_ITALIAN = "Giorni secchi"
+_DISPLAY_NAME_ENGLISH = "Duration of heat waves"
+_DISPLAY_NAME_ITALIAN = "Durata delle ondate di calore"
 _DESCRIPTION_ENGLISH = (
-    "Maximum number of consecutive dry days (daily precipitation less than 1 mm)"
+    "Sequences of 5 consecutive days in which the temperature is 5°C higher than the "
+    "reference average for that day of the year"
 )
 _DESCRIPTION_ITALIAN = (
-    "Numero massimo di giorni consecutivi asciutti (precipitazione giornaliera "
-    "inferiore a 1 mm)"
+    "Sequenze di 5 giorni consecutivi in cui la temperatura è maggiore di 5°C rispetto "
+    "alla media di riferimento per quel giorno dell'anno"
 )
 
 
@@ -19,23 +20,23 @@ def generate_configurations(
 ) -> list[CoverageConfigurationCreate]:
     return [
         CoverageConfigurationCreate(
-            name="cdd_30yr_anomaly_seasonal_agree_model_ensemble",
+            name="hwdi_30yr_anomaly_seasonal_agree_model_ensemble",
             display_name_english=_DISPLAY_NAME_ENGLISH,
             display_name_italian=_DISPLAY_NAME_ITALIAN,
             description_english=_DESCRIPTION_ENGLISH,
             description_italian=_DESCRIPTION_ITALIAN,
-            netcdf_main_dataset_name="cdd",
-            wms_main_layer_name="consecutive_dry_days_index_per_time_period-uncertainty_group",
-            wms_secondary_layer_name="consecutive_dry_days_index_per_time_period",
-            thredds_url_pattern="ensembletwbc/std/clipped/eca_cdd_an_avgagree_{time_window}_{scenario}_{year_period}_ls_VFVGTAA.nc",
+            netcdf_main_dataset_name="heat_wave_duration_index_wrt_mean_of_reference_period",
+            wms_main_layer_name="heat_wave_duration_index_wrt_mean_of_reference_period-uncertainty_group",
+            wms_secondary_layer_name="heat_wave_duration_index_wrt_mean_of_reference_period",
+            thredds_url_pattern="ensembletwbc/std/clipped/heat_waves_anom_avgagree_55_{time_window}_{scenario}_{year_period}_VFVGTAA.nc",
             unit="gg",
-            palette="uncert-stippled/div-BrBG-inv",
-            color_scale_min=-40,
-            color_scale_max=40,
+            palette="uncert-stippled/seq-YlOrRd",
+            color_scale_min=0,
+            color_scale_max=50,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "cdd")
+                        ("climatological_variable", "hwdi")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -80,43 +81,28 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "DJF")
-                    ].id
-                ),
-                ConfigurationParameterPossibleValueCreate(
-                    configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "MAM")
-                    ].id
-                ),
-                ConfigurationParameterPossibleValueCreate(
-                    configuration_parameter_value_id=conf_param_values[
                         ("year_period", "JJA")
-                    ].id
-                ),
-                ConfigurationParameterPossibleValueCreate(
-                    configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "SON")
                     ].id
                 ),
             ],
         ),
         CoverageConfigurationCreate(
-            name="cdd_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17",
+            name="hwdi_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17",
             display_name_english=_DISPLAY_NAME_ENGLISH,
             display_name_italian=_DISPLAY_NAME_ITALIAN,
             description_english=_DESCRIPTION_ENGLISH,
             description_italian=_DESCRIPTION_ITALIAN,
-            netcdf_main_dataset_name="cdd",
-            wms_main_layer_name="consecutive_dry_days_index_per_time_period",
-            thredds_url_pattern="indici5rcm/clipped/eca_cdd_an_EC-EARTH_CCLM4-8-17_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc",
+            netcdf_main_dataset_name="heat_wave_duration_index_wrt_mean_of_reference_period",
+            wms_main_layer_name="heat_wave_duration_index_wrt_mean_of_reference_period",
+            thredds_url_pattern="indici5rcm/clipped/heat_waves_anom_EC-EARTH_CCLM4-8-17_{scenario}_{year_period}_55_{time_window}_VFVGTAA.nc",
             unit="gg",
-            palette="default/div-BrBG-inv",
-            color_scale_min=-40,
-            color_scale_max=40,
+            palette="default/seq-YlOrRd",
+            color_scale_min=0,
+            color_scale_max=50,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "cdd")
+                        ("climatological_variable", "hwdi")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -161,43 +147,28 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "DJF")
-                    ].id
-                ),
-                ConfigurationParameterPossibleValueCreate(
-                    configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "MAM")
-                    ].id
-                ),
-                ConfigurationParameterPossibleValueCreate(
-                    configuration_parameter_value_id=conf_param_values[
                         ("year_period", "JJA")
-                    ].id
-                ),
-                ConfigurationParameterPossibleValueCreate(
-                    configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "SON")
                     ].id
                 ),
             ],
         ),
         CoverageConfigurationCreate(
-            name="cdd_30yr_anomaly_seasonal_model_ec_earth_racmo22e",
+            name="hwdi_30yr_anomaly_seasonal_model_ec_earth_racmo22e",
             display_name_english=_DISPLAY_NAME_ENGLISH,
             display_name_italian=_DISPLAY_NAME_ITALIAN,
             description_english=_DESCRIPTION_ENGLISH,
             description_italian=_DESCRIPTION_ITALIAN,
-            netcdf_main_dataset_name="cdd",
-            wms_main_layer_name="consecutive_dry_days_index_per_time_period",
-            thredds_url_pattern="indici5rcm/clipped/eca_cdd_an_EC-EARTH_RACMO22E_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc",
+            netcdf_main_dataset_name="heat_wave_duration_index_wrt_mean_of_reference_period",
+            wms_main_layer_name="heat_wave_duration_index_wrt_mean_of_reference_period",
+            thredds_url_pattern="indici5rcm/clipped/heat_waves_anom_EC-EARTH_RACMO22E_{scenario}_{year_period}_55_{time_window}_VFVGTAA.nc",
             unit="gg",
-            palette="default/div-BrBG-inv",
-            color_scale_min=-40,
-            color_scale_max=40,
+            palette="default/seq-YlOrRd",
+            color_scale_min=0,
+            color_scale_max=50,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "cdd")
+                        ("climatological_variable", "hwdi")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -242,43 +213,28 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "DJF")
-                    ].id
-                ),
-                ConfigurationParameterPossibleValueCreate(
-                    configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "MAM")
-                    ].id
-                ),
-                ConfigurationParameterPossibleValueCreate(
-                    configuration_parameter_value_id=conf_param_values[
                         ("year_period", "JJA")
-                    ].id
-                ),
-                ConfigurationParameterPossibleValueCreate(
-                    configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "SON")
                     ].id
                 ),
             ],
         ),
         CoverageConfigurationCreate(
-            name="cdd_30yr_anomaly_seasonal_model_ec_earth_rca4",
+            name="hwdi_30yr_anomaly_seasonal_model_ec_earth_rca4",
             display_name_english=_DISPLAY_NAME_ENGLISH,
             display_name_italian=_DISPLAY_NAME_ITALIAN,
             description_english=_DESCRIPTION_ENGLISH,
             description_italian=_DESCRIPTION_ITALIAN,
-            netcdf_main_dataset_name="cdd",
-            wms_main_layer_name="consecutive_dry_days_index_per_time_period",
-            thredds_url_pattern="indici5rcm/clipped/eca_cdd_an_EC-EARTH_RCA4_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc",
+            netcdf_main_dataset_name="heat_wave_duration_index_wrt_mean_of_reference_period",
+            wms_main_layer_name="heat_wave_duration_index_wrt_mean_of_reference_period",
+            thredds_url_pattern="indici5rcm/clipped/heat_waves_anom_EC-EARTH_RCA4_{scenario}_{year_period}_55_{time_window}_VFVGTAA.nc",
             unit="gg",
-            palette="default/div-BrBG-inv",
-            color_scale_min=-40,
-            color_scale_max=40,
+            palette="default/seq-YlOrRd",
+            color_scale_min=0,
+            color_scale_max=50,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "cdd")
+                        ("climatological_variable", "hwdi")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -323,43 +279,28 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "DJF")
-                    ].id
-                ),
-                ConfigurationParameterPossibleValueCreate(
-                    configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "MAM")
-                    ].id
-                ),
-                ConfigurationParameterPossibleValueCreate(
-                    configuration_parameter_value_id=conf_param_values[
                         ("year_period", "JJA")
-                    ].id
-                ),
-                ConfigurationParameterPossibleValueCreate(
-                    configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "SON")
                     ].id
                 ),
             ],
         ),
         CoverageConfigurationCreate(
-            name="cdd_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e",
+            name="hwdi_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e",
             display_name_english=_DISPLAY_NAME_ENGLISH,
             display_name_italian=_DISPLAY_NAME_ITALIAN,
             description_english=_DESCRIPTION_ENGLISH,
             description_italian=_DESCRIPTION_ITALIAN,
-            netcdf_main_dataset_name="cdd",
-            wms_main_layer_name="consecutive_dry_days_index_per_time_period",
-            thredds_url_pattern="indici5rcm/clipped/eca_cdd_an_HadGEM2-ES_RACMO22E_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc",
+            netcdf_main_dataset_name="heat_wave_duration_index_wrt_mean_of_reference_period",
+            wms_main_layer_name="heat_wave_duration_index_wrt_mean_of_reference_period",
+            thredds_url_pattern="indici5rcm/clipped/heat_waves_anom_HadGEM2-ES_RACMO22E_{scenario}_{year_period}_55_{time_window}_VFVGTAA.nc",
             unit="gg",
-            palette="default/div-BrBG-inv",
-            color_scale_min=-40,
-            color_scale_max=40,
+            palette="default/seq-YlOrRd",
+            color_scale_min=0,
+            color_scale_max=50,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "cdd")
+                        ("climatological_variable", "hwdi")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -404,43 +345,28 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "DJF")
-                    ].id
-                ),
-                ConfigurationParameterPossibleValueCreate(
-                    configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "MAM")
-                    ].id
-                ),
-                ConfigurationParameterPossibleValueCreate(
-                    configuration_parameter_value_id=conf_param_values[
                         ("year_period", "JJA")
-                    ].id
-                ),
-                ConfigurationParameterPossibleValueCreate(
-                    configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "SON")
                     ].id
                 ),
             ],
         ),
         CoverageConfigurationCreate(
-            name="cdd_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009",
+            name="hwdi_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009",
             display_name_english=_DISPLAY_NAME_ENGLISH,
             display_name_italian=_DISPLAY_NAME_ITALIAN,
             description_english=_DESCRIPTION_ENGLISH,
             description_italian=_DESCRIPTION_ITALIAN,
-            netcdf_main_dataset_name="cdd",
-            wms_main_layer_name="consecutive_dry_days_index_per_time_period",
-            thredds_url_pattern="indici5rcm/clipped/eca_cdd_an_MPI-ESM-LR_REMO2009_{scenario}_{year_period}_{time_window}_ls_VFVGTAA.nc",
+            netcdf_main_dataset_name="heat_wave_duration_index_wrt_mean_of_reference_period",
+            wms_main_layer_name="heat_wave_duration_index_wrt_mean_of_reference_period",
+            thredds_url_pattern="indici5rcm/clipped/heat_waves_anom_MPI-ESM-LR_REMO2009_{scenario}_{year_period}_55_{time_window}_VFVGTAA.nc",
             unit="gg",
-            palette="default/div-BrBG-inv",
-            color_scale_min=-40,
-            color_scale_max=40,
+            palette="default/seq-YlOrRd",
+            color_scale_min=0,
+            color_scale_max=50,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "cdd")
+                        ("climatological_variable", "hwdi")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -485,22 +411,7 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "DJF")
-                    ].id
-                ),
-                ConfigurationParameterPossibleValueCreate(
-                    configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "MAM")
-                    ].id
-                ),
-                ConfigurationParameterPossibleValueCreate(
-                    configuration_parameter_value_id=conf_param_values[
                         ("year_period", "JJA")
-                    ].id
-                ),
-                ConfigurationParameterPossibleValueCreate(
-                    configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "SON")
                     ].id
                 ),
             ],
@@ -510,47 +421,47 @@ def generate_configurations(
 
 def get_related_map() -> dict[str, list[str]]:
     return {
-        "cdd_30yr_anomaly_seasonal_agree_model_ensemble": [
-            "cdd_30yr_anomaly_annual_model_ec_earth_cclm4_8_17",
-            "cdd_30yr_anomaly_annual_model_ec_earth_racmo22e",
-            "cdd_30yr_anomaly_annual_model_ec_earth_rca4",
-            "cdd_30yr_anomaly_annual_model_hadgem2_es_racmo22e",
-            "cdd_30yr_anomaly_annual_model_mpi_esm_lr_remo2009",
+        "hwdi_30yr_anomaly_seasonal_agree_model_ensemble": [
+            "hwdi_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17",
+            "hwdi_30yr_anomaly_seasonal_model_ec_earth_racmo22e",
+            "hwdi_30yr_anomaly_seasonal_model_ec_earth_rca4",
+            "hwdi_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e",
+            "hwdi_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009",
         ],
-        "cdd_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17": [
-            "cdd_30yr_anomaly_seasonal_agree_model_ensemble",
-            "cdd_30yr_anomaly_seasonal_model_ec_earth_racmo22e",
-            "cdd_30yr_anomaly_seasonal_model_ec_earth_rca4",
-            "cdd_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e",
-            "cdd_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009",
+        "hwdi_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17": [
+            "hwdi_30yr_anomaly_seasonal_agree_model_ensemble",
+            "hwdi_30yr_anomaly_seasonal_model_ec_earth_racmo22e",
+            "hwdi_30yr_anomaly_seasonal_model_ec_earth_rca4",
+            "hwdi_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e",
+            "hwdi_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009",
         ],
-        "cdd_30yr_anomaly_seasonal_model_ec_earth_racmo22e": [
-            "cdd_30yr_anomaly_seasonal_agree_model_ensemble",
-            "cdd_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17",
-            "cdd_30yr_anomaly_seasonal_model_ec_earth_rca4",
-            "cdd_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e",
-            "cdd_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009",
+        "hwdi_30yr_anomaly_seasonal_model_ec_earth_racmo22e": [
+            "hwdi_30yr_anomaly_seasonal_agree_model_ensemble",
+            "hwdi_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17",
+            "hwdi_30yr_anomaly_seasonal_model_ec_earth_rca4",
+            "hwdi_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e",
+            "hwdi_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009",
         ],
-        "cdd_30yr_anomaly_seasonal_model_ec_earth_rca4": [
-            "cdd_30yr_anomaly_seasonal_agree_model_ensemble",
-            "cdd_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17",
-            "cdd_30yr_anomaly_seasonal_model_ec_earth_racmo22e",
-            "cdd_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e",
-            "cdd_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009",
+        "hwdi_30yr_anomaly_seasonal_model_ec_earth_rca4": [
+            "hwdi_30yr_anomaly_seasonal_agree_model_ensemble",
+            "hwdi_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17",
+            "hwdi_30yr_anomaly_seasonal_model_ec_earth_racmo22e",
+            "hwdi_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e",
+            "hwdi_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009",
         ],
-        "cdd_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e": [
-            "cdd_30yr_anomaly_seasonal_agree_model_ensemble",
-            "cdd_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17",
-            "cdd_30yr_anomaly_seasonal_model_ec_earth_racmo22e",
-            "cdd_30yr_anomaly_seasonal_model_ec_earth_rca4",
-            "cdd_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009",
+        "hwdi_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e": [
+            "hwdi_30yr_anomaly_seasonal_agree_model_ensemble",
+            "hwdi_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17",
+            "hwdi_30yr_anomaly_seasonal_model_ec_earth_racmo22e",
+            "hwdi_30yr_anomaly_seasonal_model_ec_earth_rca4",
+            "hwdi_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009",
         ],
-        "cdd_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009": [
-            "cdd_30yr_anomaly_seasonal_agree_model_ensemble",
-            "cdd_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17",
-            "cdd_30yr_anomaly_seasonal_model_ec_earth_racmo22e",
-            "cdd_30yr_anomaly_seasonal_model_ec_earth_rca4",
-            "cdd_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e",
+        "hwdi_30yr_anomaly_seasonal_model_mpi_esm_lr_remo2009": [
+            "hwdi_30yr_anomaly_seasonal_agree_model_ensemble",
+            "hwdi_30yr_anomaly_seasonal_model_ec_earth_cclm4_8_17",
+            "hwdi_30yr_anomaly_seasonal_model_ec_earth_racmo22e",
+            "hwdi_30yr_anomaly_seasonal_model_ec_earth_rca4",
+            "hwdi_30yr_anomaly_seasonal_model_hadgem2_es_racmo22e",
         ],
     }
 

--- a/arpav_ppcv/main.py
+++ b/arpav_ppcv/main.py
@@ -178,7 +178,13 @@ def import_thredds_datasets(
         ),
     ],
     output_base_dir: Annotated[
-        Path, typer.Argument(help="Base path for downloaded NetCDF files.")
+        Path,
+        typer.Argument(
+            help=(
+                "Base path for downloaded NetCDF files. Example: "
+                "/home/appuser/data/datasets"
+            )
+        ),
     ],
     name_filter: Annotated[
         str,
@@ -201,15 +207,13 @@ def import_thredds_datasets(
 ):
     """Import NetCDF datasets from a THREDDS server."""
     with sqlmodel.Session(ctx.obj["engine"]) as session:
-        all_cov_confs = database.collect_all_coverage_configurations(session)
-        if name_filter:
-            relevant_cov_confs = [cc for cc in all_cov_confs if name_filter in cc.name]
-        else:
-            relevant_cov_confs = all_cov_confs
+        relevant_cov_confs = database.collect_all_coverage_configurations(
+            session, name_filter=name_filter
+        )
         urls = []
         for cov_conf in relevant_cov_confs:
             cov_conf_urls = crawler.get_coverage_configuration_urls(
-                session, base_thredds_url, cov_conf
+                base_thredds_url, cov_conf
             )
             urls.extend(cov_conf_urls)
 

--- a/arpav_ppcv/thredds/crawler.py
+++ b/arpav_ppcv/thredds/crawler.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import anyio
 import exceptiongroup
 import httpx
-import sqlmodel
 
 from ..schemas import coverages
 from .. import database
@@ -24,12 +23,11 @@ _THREDDS_FILE_SERVER_URL_FRAGMENT = "fileServer"
 
 
 def get_coverage_configuration_urls(
-    session: sqlmodel.Session,
     base_thredds_url: str,
     coverage_configuration: coverages.CoverageConfiguration,
 ) -> list[str]:
-    coverage_identifiers = database.list_allowed_coverage_identifiers(
-        session, coverage_configuration_id=coverage_configuration.id
+    coverage_identifiers = database.generate_coverage_identifiers(
+        coverage_configuration=coverage_configuration
     )
     result = []
     for cov_identifier in coverage_identifiers:


### PR DESCRIPTION
This PR adds the relevant bootstrap configuration for new forecast-related coverages:

- `HWDI`
- `CDDs`
- `HDDs`

Also included is a fix for some incorrect `CDD` name and descriptions

---

- fixes #207
- fixes #208