### PR TITLE
Generate forecast menu dynamically

### DIFF
--- a/arpav_ppcv/operations.py
+++ b/arpav_ppcv/operations.py
@@ -3,10 +3,7 @@ import functools
 import io
 import logging
 import warnings
-from typing import (
-    Optional,
-    TypedDict,
-)
+from typing import Optional
 
 import anyio
 import cftime
@@ -898,23 +895,9 @@ def _get_spatial_buffer(
     return transform(inverse_coordinate_transformer, buffer_geom_projected)
 
 
-class ForecastVariableMenuTreeCombination(TypedDict):
-    configuration_parameter: coverages.ConfigurationParameter
-    values: list[coverages.ConfigurationParameterPossibleValue]
-
-
-class ForecastVariableMenuTree(TypedDict):
-    climatological_variable: coverages.ConfigurationParameterPossibleValue
-    aggregation_period: coverages.ConfigurationParameterPossibleValue
-    measure: coverages.ConfigurationParameterPossibleValue
-    combinations: dict[str, ForecastVariableMenuTreeCombination]
-
-
 def get_forecast_variable_parameters(
     session: sqlmodel.Session,
-) -> dict[str, ForecastVariableMenuTree]:
-    # - retrieve all the cov confs that have the variable
-    # - for each cov conf, aggregate by aggregation_period and measure
+) -> dict[str, coverages.ForecastVariableMenuTree]:
     result = {}
     all_cov_confs = database.collect_all_coverage_configurations(session)
     for cov_conf in all_cov_confs:

--- a/arpav_ppcv/schemas/coverages.py
+++ b/arpav_ppcv/schemas/coverages.py
@@ -7,6 +7,7 @@ from typing import (
     Optional,
     Final,
     TYPE_CHECKING,
+    TypedDict,
 )
 
 import pydantic
@@ -525,3 +526,15 @@ class CoverageInternal:
 
     def __hash__(self):
         return hash(self.identifier)
+
+
+class ForecastVariableMenuTreeCombination(TypedDict):
+    configuration_parameter: ConfigurationParameter
+    values: list[ConfigurationParameterValue]
+
+
+class ForecastVariableMenuTree(TypedDict):
+    climatological_variable: ConfigurationParameterValue
+    aggregation_period: ConfigurationParameterValue
+    measure: ConfigurationParameterValue
+    combinations: dict[str, ForecastVariableMenuTreeCombination]

--- a/arpav_ppcv/webapp/api_v2/routers/coverages.py
+++ b/arpav_ppcv/webapp/api_v2/routers/coverages.py
@@ -552,3 +552,24 @@ def get_time_series(
             raise HTTPException(status_code=400, detail="Invalid coverage_identifier")
     else:
         raise HTTPException(status_code=400, detail="Invalid coverage_identifier")
+
+
+@router.get(
+    "/variable-combinations",
+    response_model=coverage_schemas.ForecastVariableCombinationsList,
+)
+def get_variable_combinations(
+    db_session: Annotated[Session, Depends(dependencies.get_db_session)],
+):
+    variable_combinations = operations.get_forecast_variable_parameters(db_session)
+    var_combinations = []
+    for var_name, var_menu in variable_combinations.items():
+        var_combinations.append(
+            coverage_schemas.VariableCombinations.from_items(var_menu)
+        )
+    return coverage_schemas.ForecastVariableCombinationsList(
+        combinations=var_combinations,
+        translations=coverage_schemas.ForecastMenuTranslations.from_items(
+            list(variable_combinations.values())
+        ),
+    )

--- a/arpav_ppcv/webapp/api_v2/schemas/coverages.py
+++ b/arpav_ppcv/webapp/api_v2/schemas/coverages.py
@@ -4,7 +4,11 @@ import typing
 import pydantic
 from fastapi import Request
 
-from ....config import ArpavPpcvSettings
+from ....config import (
+    ArpavPpcvSettings,
+    LOCALE_EN,
+    LOCALE_IT,
+)
 from ....schemas import coverages as app_models
 from .base import WebResourceList
 
@@ -247,3 +251,108 @@ class ConfigurationParameterList(WebResourceList):
     items: list[ConfigurationParameterReadListItem]
     list_item_type = ConfigurationParameterReadListItem
     path_operation_name = "list_configuration_parameters"
+
+
+class ConfigurationParameterMenuTranslation(pydantic.BaseModel):
+    name: dict[str, str]
+    description: dict[str, str]
+
+
+class ForecastMenuTranslations(pydantic.BaseModel):
+    variable: dict[str, ConfigurationParameterMenuTranslation]
+    aggregation_period: dict[str, ConfigurationParameterMenuTranslation]
+    measure: dict[str, ConfigurationParameterMenuTranslation]
+    other_parameters: dict[str, dict[str, ConfigurationParameterMenuTranslation]]
+
+    @classmethod
+    def from_items(
+        cls, variable_menu_trees: typing.Sequence[app_models.ForecastVariableMenuTree]
+    ):
+        result = {}
+        for variable_menu_tree in variable_menu_trees:
+            variable_cp = variable_menu_tree["climatological_variable"]
+            aggregation_period_cp = variable_menu_tree["aggregation_period"]
+            measure_cp = variable_menu_tree["measure"]
+            vars = result.setdefault("variable", {})
+            vars[variable_cp.name] = ConfigurationParameterMenuTranslation(
+                name={
+                    LOCALE_EN.language: variable_cp.display_name_english,
+                    LOCALE_IT.language: variable_cp.display_name_english,
+                },
+                description={
+                    LOCALE_EN.language: variable_cp.description_english,
+                    LOCALE_IT.language: variable_cp.description_italian,
+                },
+            )
+            aggreg_periods = result.setdefault("aggregation_period", {})
+            aggreg_periods[
+                aggregation_period_cp.name
+            ] = ConfigurationParameterMenuTranslation(
+                name={
+                    LOCALE_EN.language: aggregation_period_cp.display_name_english,
+                    LOCALE_IT.language: aggregation_period_cp.display_name_english,
+                },
+                description={
+                    LOCALE_EN.language: aggregation_period_cp.description_english,
+                    LOCALE_IT.language: aggregation_period_cp.description_italian,
+                },
+            )
+            measures = result.setdefault("measure", {})
+            measures[measure_cp.name] = ConfigurationParameterMenuTranslation(
+                name={
+                    LOCALE_EN.language: measure_cp.display_name_english,
+                    LOCALE_IT.language: measure_cp.display_name_english,
+                },
+                description={
+                    LOCALE_EN.language: measure_cp.description_english,
+                    LOCALE_IT.language: measure_cp.description_italian,
+                },
+            )
+            others = result.setdefault("other_parameters", {})
+            for combination_info in variable_menu_tree["combinations"].values():
+                cp = combination_info["configuration_parameter"]
+                param_ = others.setdefault(cp.name, {})
+                for cpv in cp.allowed_values:
+                    param_[cpv.name] = ConfigurationParameterMenuTranslation(
+                        name={
+                            LOCALE_EN.language: cpv.display_name_english,
+                            LOCALE_IT.language: cpv.display_name_english,
+                        },
+                        description={
+                            LOCALE_EN.language: cpv.description_english,
+                            LOCALE_IT.language: cpv.description_italian,
+                        },
+                    )
+        return cls(
+            variable=result["variable"],
+            aggregation_period=result["aggregation_period"],
+            measure=result["measure"],
+            other_parameters=result["other_parameters"],
+        )
+
+
+class VariableCombinations(pydantic.BaseModel):
+    variable: str
+    aggregation_period: str
+    measure: str
+    other_parameters: dict[str, list[str]]
+
+    @classmethod
+    def from_items(cls, menu_tree: app_models.ForecastVariableMenuTree):
+        combinations = {}
+        for param_name, param_combinations in menu_tree["combinations"].items():
+            combinations[param_name] = []
+            for valid_value in param_combinations["values"]:
+                combinations[param_name].append(valid_value.name)
+
+        return cls(
+            variable=menu_tree["climatological_variable"].name,
+            aggregation_period=menu_tree["aggregation_period"].name,
+            measure=menu_tree["measure"].name,
+            other_parameters=combinations,
+        )
+
+
+class ForecastVariableCombinationsList(pydantic.BaseModel):
+    combinations: list[VariableCombinations]
+    translations: ForecastMenuTranslations

--- a/tests/notebooks/generic.ipynb
+++ b/tests/notebooks/generic.ipynb
@@ -134,7 +134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "97e789b2-721b-4e10-baa4-8b4bb39d3ade",
    "metadata": {},
    "outputs": [
@@ -196,17 +196,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "dd151151-4344-42e3-8a19-d2a6ad6d252a",
+   "execution_count": 8,
+   "id": "646bf16d-7858-424e-af2b-73dbd30413db",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "ConfigurationParameterValue(id=UUID('e6ff2bf7-67c4-48f9-ad3a-e0737cc2c07a'), display_name_italian='TAS', description_italian='Temperatura media', name='tas', display_name_english='TAS', description_english='Mean temperature', configuration_parameter_id=UUID('12dfb711-9c18-46ac-8fc5-0b902eb48964'))"
+       "ConfigurationParameterValue(id=UUID('e6ff2bf7-67c4-48f9-ad3a-e0737cc2c07a'), display_name_italian='TAS', description_italian='Temperatura media', display_name_english='TAS', name='tas', description_english='Mean temperature', configuration_parameter_id=UUID('12dfb711-9c18-46ac-8fc5-0b902eb48964'))"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -280,26 +280,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "9672f748-b3d4-48a1-b2f7-f0c60ec4f9d4",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[ConfigurationParameterValue(id=UUID('1021b1a8-9e9f-4c90-b483-9211bc17c2e0'), display_name_italian='Primavera', description_italian='Stagione climatologica primaverile (marzo, aprile, maggio)', name='MAM', display_name_english='Spring', description_english='Climatological spring season (March, April, May)', configuration_parameter_id=UUID('1f0a6946-ae9a-48d8-81ef-ef18b14ac767')),\n",
-       " ConfigurationParameterValue(id=UUID('731991b0-d6fd-48ad-976a-3519ee5e8e52'), display_name_italian='Estate', description_italian='Stagione climatologica estiva (giugno, luglio, agosto)', name='JJA', display_name_english='Summer', description_english='Climatological summer season (June, July, August)', configuration_parameter_id=UUID('1f0a6946-ae9a-48d8-81ef-ef18b14ac767')),\n",
-       " ConfigurationParameterValue(id=UUID('94b9b78b-e344-4288-a4e8-aa54f83ef63e'), display_name_italian='Autunno', description_italian='Stagione climatologica autunnale (settembre, ottobre, novembre)', name='SON', display_name_english='Autumn', description_english='Climatological autumn season (September, October, November)', configuration_parameter_id=UUID('1f0a6946-ae9a-48d8-81ef-ef18b14ac767')),\n",
-       " ConfigurationParameterValue(id=UUID('ff4e7c7b-7141-4d37-8979-3c5714ac4b4d'), display_name_italian='Inverno', description_italian='Stagione climatologica invernale (dicembre, gennaio, febbraio)', name='DJF', display_name_english='Winter', description_english='Climatological winter season (December, January, February)', configuration_parameter_id=UUID('1f0a6946-ae9a-48d8-81ef-ef18b14ac767'))]"
+       "ConfigurationParameterValue(id=UUID('ff4e7c7b-7141-4d37-8979-3c5714ac4b4d'), display_name_italian='Inverno', description_italian='Stagione climatologica invernale (dicembre, gennaio, febbraio)', display_name_english='Winter', name='DJF', description_english='Climatological winter season (December, January, February)', configuration_parameter_id=UUID('1f0a6946-ae9a-48d8-81ef-ef18b14ac767'))"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "result[\"tas-30yr-anomaly\"][\"combinations\"][\"year_period\"][\"values\"]"
+    "result[\"tas-30yr-anomaly\"][\"combinations\"][\"year_period\"][\"configuration_parameter\"].allowed_values[0]"
    ]
   },
   {


### PR DESCRIPTION
This PR implements new API endpoints for providing the frontend with an appropriate set of valid combinations for generating a navigation for forecast datasets.

Combinations of parameters are generated like this:

- one entry for each combination of `climatological_variable` - `aggregation_period` - `measure` (_e.g._ `tas-30yr-anomaly`)
- for that entry, list all valid combinations of the remaining parameters

This way of combining the existing parameters allows us to correctly represent entries like:

- how the `snwdays` dataset has both `30yr` `anomaly` and a `annual` `absolute` entries and they support different combinations of other parameters
- the `HWDI` dataset, which is only available in the `JJA` season
- the fact that `TAS` `annual` `anomaly` does not have a `time_window`, but `TAS` `30yr` `anomaly` does have it



for example:

```json
{
      "variable": "tas",
      "aggregation_period": "30yr",
      "measure": "anomaly",
      "other_parameters": {
        "year_period": [
          "MAM",
          "JJA",
          "SON",
          "DJF"
        ],
        "climatological_model": [
          "model_ensemble",
          "ec_earth_cclm_4_8_17",
          "ec_earth_racmo22e",
          "ec_earth_rca4",
          "hadgem2_racmo22e",
          "mpi_esm_lr_remo2009"
        ],
        "scenario": [
          "rcp45",
          "rcp26",
          "rcp85"
        ],
        "time_window": [
          "tw2",
          "tw1"
        ]
      }
    }
``` 

The new endpoint is reachable at:

```
/api/v2/variable-combinations
```

it returns an object with this structure:

```yaml
{
  combinations: []
  translations: {}
}
```

where `combinations` is a list of objects describing entries as mentioned above and `translations` is an object with the translation for the various parameters, allowing the construction of a localized navigation in both english and italian 


---

- fixes #211