### PR TITLE
Fixed invalid definitions of uncertainty datasets

### DIFF
--- a/arpav_ppcv/bootstrapper/coverage_configurations/cdds.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/cdds.py
@@ -970,7 +970,7 @@ def get_related_map() -> dict[str, list[str]]:
 def get_uncertainty_map() -> dict[str, tuple[str, str]]:
     return {
         "cdds_annual_absolute_model_ensemble": (
-            "cdds_annual_absolute_model_ensemble_upper_uncertainty",
             "cdds_annual_absolute_model_ensemble_lower_uncertainty",
+            "cdds_annual_absolute_model_ensemble_upper_uncertainty",
         ),
     }

--- a/arpav_ppcv/bootstrapper/coverage_configurations/fd.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/fd.py
@@ -988,7 +988,7 @@ def get_related_map() -> dict[str, list[str]]:
 def get_uncertainty_map() -> dict[str, tuple[str, str]]:
     return {
         "fd_annual_absolute_model_ensemble": (
-            "fd_annual_absolute_model_ensemble_upper_uncertainty",
             "fd_annual_absolute_model_ensemble_lower_uncertainty",
+            "fd_annual_absolute_model_ensemble_upper_uncertainty",
         ),
     }

--- a/arpav_ppcv/bootstrapper/coverage_configurations/hdds.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/hdds.py
@@ -970,7 +970,7 @@ def get_related_map() -> dict[str, list[str]]:
 def get_uncertainty_map() -> dict[str, tuple[str, str]]:
     return {
         "hdds_annual_absolute_model_ensemble": (
-            "hdds_annual_absolute_model_ensemble_upper_uncertainty",
             "hdds_annual_absolute_model_ensemble_lower_uncertainty",
+            "hdds_annual_absolute_model_ensemble_upper_uncertainty",
         ),
     }

--- a/arpav_ppcv/bootstrapper/coverage_configurations/pr.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/pr.py
@@ -2342,15 +2342,15 @@ def get_related_map() -> dict[str, list[str]]:
 def get_uncertainty_map() -> dict[str, tuple[str, str]]:
     return {
         "pr_seasonal_anomaly_model_ensemble": (
-            "pr_seasonal_anomaly_model_ensemble_upper_uncertainty",
             "pr_seasonal_anomaly_model_ensemble_lower_uncertainty",
+            "pr_seasonal_anomaly_model_ensemble_upper_uncertainty",
         ),
         "pr_seasonal_absolute_model_ensemble": (
-            "pr_seasonal_absolute_model_ensemble_upper_uncertainty",
             "pr_seasonal_absolute_model_ensemble_lower_uncertainty",
+            "pr_seasonal_absolute_model_ensemble_upper_uncertainty",
         ),
         "pr_annual_absolute_model_ensemble": (
-            "pr_annual_absolute_model_ensemble_upper_uncertainty",
             "pr_annual_absolute_model_ensemble_lower_uncertainty",
+            "pr_annual_absolute_model_ensemble_upper_uncertainty",
         ),
     }

--- a/arpav_ppcv/bootstrapper/coverage_configurations/snwdays.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/snwdays.py
@@ -969,7 +969,7 @@ def get_related_map() -> dict[str, list[str]]:
 def get_uncertainty_map() -> dict[str, tuple[str, str]]:
     return {
         "snwdays_annual_absolute_model_ensemble": (
-            "snwdays_annual_absolute_model_ensemble_upper_uncertainty",
             "snwdays_annual_absolute_model_ensemble_lower_uncertainty",
+            "snwdays_annual_absolute_model_ensemble_upper_uncertainty",
         ),
     }

--- a/arpav_ppcv/bootstrapper/coverage_configurations/su30.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/su30.py
@@ -988,7 +988,7 @@ def get_related_map() -> dict[str, list[str]]:
 def get_uncertainty_map() -> dict[str, tuple[str, str]]:
     return {
         "su30_annual_absolute_model_ensemble": (
-            "su30_annual_absolute_model_ensemble_upper_uncertainty",
             "su30_annual_absolute_model_ensemble_lower_uncertainty",
+            "su30_annual_absolute_model_ensemble_upper_uncertainty",
         ),
     }

--- a/arpav_ppcv/bootstrapper/coverage_configurations/tasmax.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/tasmax.py
@@ -1722,11 +1722,11 @@ def get_related_map() -> dict[str, list[str]]:
 def get_uncertainty_map() -> dict[str, tuple[str, str]]:
     return {
         "tasmax_seasonal_absolute_model_ensemble": (
-            "tasmax_seasonal_absolute_model_ensemble_upper_uncertainty",
             "tasmax_seasonal_absolute_model_ensemble_lower_uncertainty",
+            "tasmax_seasonal_absolute_model_ensemble_upper_uncertainty",
         ),
         "tasmax_annual_absolute_model_ensemble": (
-            "tasmax_annual_absolute_model_ensemble_upper_uncertainty",
             "tasmax_annual_absolute_model_ensemble_lower_uncertainty",
+            "tasmax_annual_absolute_model_ensemble_upper_uncertainty",
         ),
     }

--- a/arpav_ppcv/bootstrapper/coverage_configurations/tasmin.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/tasmin.py
@@ -1727,11 +1727,11 @@ def get_related_map() -> dict[str, list[str]]:
 def get_uncertainty_map() -> dict[str, tuple[str, str]]:
     return {
         "tasmin_seasonal_absolute_model_ensemble": (
-            "tasmin_seasonal_absolute_model_ensemble_upper_uncertainty",
             "tasmin_seasonal_absolute_model_ensemble_lower_uncertainty",
+            "tasmin_seasonal_absolute_model_ensemble_upper_uncertainty",
         ),
         "tasmin_annual_absolute_model_ensemble": (
-            "tasmin_annual_absolute_model_ensemble_upper_uncertainty",
             "tasmin_annual_absolute_model_ensemble_lower_uncertainty",
+            "tasmin_annual_absolute_model_ensemble_upper_uncertainty",
         ),
     }

--- a/arpav_ppcv/bootstrapper/coverage_configurations/tr.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/tr.py
@@ -988,7 +988,7 @@ def get_related_map() -> dict[str, list[str]]:
 def get_uncertainty_map() -> dict[str, tuple[str, str]]:
     return {
         "tr_annual_absolute_model_ensemble": (
-            "tr_annual_absolute_model_ensemble_upper_uncertainty",
             "tr_annual_absolute_model_ensemble_lower_uncertainty",
+            "tr_annual_absolute_model_ensemble_upper_uncertainty",
         )
     }


### PR DESCRIPTION
This PR fixes the invalid definitions of lower and upper uncertainties being used in the bootstrap - the order was switched whereby the lower uncertainty dataset needed to be the first and was being the last

---

- fixes #220