### PR TITLE
legend not working for some coverage configurations

### DIFF
--- a/arpav_ppcv/palette.py
+++ b/arpav_ppcv/palette.py
@@ -6,9 +6,11 @@ logger = logging.getLogger(__name__)
 
 
 def parse_palette(palette: str, palettes_dir: Path) -> Optional[list[str]]:
-    palette_name = palette.partition("/")[-1].lower()
-    name, to_invert = palette_name.rpartition("-inv")[:2]
-    is_inverted = to_invert != ""
+    palette_name = palette.split("/")[-1].lower()
+    if is_inverted := "-inv" in palette_name:
+        name = palette_name.replace("-inv", "")
+    else:
+        name = palette_name
     colors = []
     for file_path in [f for f in palettes_dir.iterdir() if f.is_file()]:
         if file_path.stem.lower() == name:

--- a/arpav_ppcv/webapp/admin/schemas.py
+++ b/arpav_ppcv/webapp/admin/schemas.py
@@ -52,7 +52,8 @@ class CoverageConfigurationRead(sqlmodel.SQLModel):
     wms_secondary_layer_name: Optional[str]
     coverage_id_pattern: str
     thredds_url_pattern: str
-    unit: str
+    unit_english: str
+    unit_italian: str
     palette: str
     color_scale_min: float
     color_scale_max: float

--- a/tests/test_palette.py
+++ b/tests/test_palette.py
@@ -1,0 +1,107 @@
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from arpav_ppcv import palette
+
+
+@pytest.mark.parametrize(
+    "palette_name, expected",
+    [
+        pytest.param(
+            "fake-palette1", ["#fake-color-1", "#fake-color-2", "#fake-color-3"]
+        ),
+        pytest.param(
+            "fake-palette1-inv", ["#fake-color-3", "#fake-color-2", "#fake-color-1"]
+        ),
+        pytest.param(
+            "default/fake-palette1", ["#fake-color-1", "#fake-color-2", "#fake-color-3"]
+        ),
+        pytest.param(
+            "uncert-stippled/fake-palette1",
+            ["#fake-color-1", "#fake-color-2", "#fake-color-3"],
+        ),
+        pytest.param(
+            "default/fake-palette1-inv",
+            ["#fake-color-3", "#fake-color-2", "#fake-color-1"],
+        ),
+        pytest.param(
+            "fake-palette2", ["#fake-color-4", "#fake-color-5", "#fake-color-6"]
+        ),
+        pytest.param(
+            "fake-palette2-inv", ["#fake-color-6", "#fake-color-5", "#fake-color-4"]
+        ),
+        pytest.param("other", None),
+        pytest.param("nonsense", None),
+    ],
+)
+def test_parse_palette(palette_name: str, expected: list[str]):
+    fake_palette1_contents = [
+        "#fake-color-1",
+        "#fake-color-2",
+        "#fake-color-3",
+    ]
+    fake_palette2_contents = [
+        "#fake-color-4",
+        "#fake-color-5",
+        "#fake-color-6",
+        "this is not a color",
+        "%this is also not a color",
+    ]
+    fake_other_contents = [
+        "something-else",
+    ]
+    fake_palette1 = mock.MagicMock(spec=Path)
+    fake_palette1.configure_mock(
+        **{
+            "stem": "fake-palette1",
+            "read_text.return_value": "\n".join(fake_palette1_contents),
+            "is_file.return_value": True,
+        }
+    )
+    fake_palette2 = mock.MagicMock(
+        spec=Path,
+        **{
+            "stem": "fake-palette2",
+            "read_text.return_value": "\n".join(fake_palette2_contents),
+            "is_file.return_value": True,
+        },
+    )
+    fake_other = mock.MagicMock(
+        spec=Path,
+        **{
+            "stem": "other",
+            "read_text.return_value": "\n".join(fake_other_contents),
+            "is_file.return_value": True,
+        },
+    )
+    mock_palettes_dir = mock.MagicMock(spec=Path)
+    mock_palettes_dir.iterdir.return_value = [
+        fake_palette1,
+        fake_palette2,
+        fake_other,
+    ]
+    result = palette.parse_palette(palette_name, mock_palettes_dir)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "colors, minimum, maximum, expected",
+    [
+        pytest.param(
+            ["first", "second"], -10, 20, [(-10.0, "first"), (20.0, "second")]
+        ),
+        pytest.param(
+            ["first", "second", "third"],
+            -10,
+            20,
+            [(-10.0, "first"), (5.0, "second"), (20.0, "third")],
+        ),
+    ],
+)
+def test_apply_palette(
+    colors: list[str], minimum: float, maximum: float, expected: list[tuple[float, str]]
+):
+    result = palette.apply_palette(colors, minimum, maximum)
+    assert result == expected


### PR DESCRIPTION
This PR introduces a couple of fixes to some regressions:

- palette path not parsed correctly for non inverted palettes
- admin coverage configuration list page not showing up

Also adds some tests for the palette parsing code

---

- fixes #242 
- fixes #243