### PR TITLE
Modify docker compose files to use secrets and configs

### DIFF
--- a/docker/compose.dev.yaml
+++ b/docker/compose.dev.yaml
@@ -45,11 +45,10 @@ services:
         published: 8899
       - target: 8080
         published: 8878
-    command: --configFile /traefik.toml
-    volumes:
-      - type: bind
-        source: $PWD/docker/traefik/dev-config.toml
+    configs:
+      - source: traefik-conf
         target: /traefik.toml
+    command: --configFile /traefik.toml
 
   frontend:
     image: "ghcr.io/geobeyond/arpav-ppcv/arpav-ppcv:${FRONTEND_GIT_BRANCH:-latest}"
@@ -161,14 +160,9 @@ services:
     ports:
       - target: 3000
         published: 3000
-    command: ["--config", "/martin-config.yaml"]
     environment:
       DATABASE_URL: postgres://arpav:arpavpassword@db/arpav_ppcv
       RUST_LOG: actix_web=info,martin=debug,tokio_postgres=debug
-    volumes:
-      - type: bind
-        source: /$PWD/docker/martin/config.yaml
-        target: /martin-config.yaml
 
   prefect-server:
     labels:
@@ -262,3 +256,9 @@ volumes:
   prefect-db-data:
   tolgee-app-data:
   tolgee-db-data:
+
+
+configs:
+
+  traefik-conf:
+    file: $PWD/docker/traefik/dev-config.toml

--- a/docker/compose.staging.yaml
+++ b/docker/compose.staging.yaml
@@ -38,7 +38,7 @@ services:
   # is another proxy running on top of this one, provided
   # by the staging env
   reverse-proxy:
-    command: --configFile /opt/traefik/traefik.toml
+    command: --configFile /traefik.toml
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.outside-router-arpav-backend.entrypoints=webSecure"
@@ -49,10 +49,9 @@ services:
     networks:
       - front
       - back
-    volumes:
-      - type: bind
-        source: /home/arpav/docker/traefik/staging-config.toml
-        target: /opt/traefik/traefik.toml
+    configs:
+      - source: traefik-conf
+        target: /traefik.toml
 
   frontend:
     env_file:
@@ -101,10 +100,6 @@ services:
       - "traefik.http.routers.martin-router.entrypoints=web"
       - "traefik.http.routers.martin-router.rule=Host(`arpav.geobeyond.dev`) && PathPrefix(`/vector-tiles`)"
       - "exposed.inside=true"
-    volumes:
-      - type: bind
-        source: /home/arpav/docker/martin/config.yaml
-        target: /martin-config.yaml
     restart: unless-stopped
 
   thredds:
@@ -188,3 +183,7 @@ volumes:
   db-data:
   prefect-db-data:
   tolgee-db-data:
+
+configs:
+  traefik-conf:
+    file: /home/arpav/docker/traefik/staging-config.toml

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -63,9 +63,8 @@ services:
       - type: bind
         source: /var/run/docker.sock
         target: /var/run/docker.sock
-      - type: bind
-        source: ${ARPAV_PPCV_TRAEFIK_BASIC_AUTH_USERS_FILE:-$PWD/docker/traefik/basicauth-users.txt}
-        target: /traefikauth/usersfile
+    secrets:
+      - traefik-users-file
 
   frontend:
     image: "ghcr.io/geobeyond/arpav-ppcv/arpav-ppcv:latest"
@@ -92,6 +91,9 @@ services:
 
   martin:
     image: 'ghcr.io/maplibre/martin:v0.13.0'
+    command: ["--config", "/martin-conf"]
+    configs:
+      - martin-conf
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.martin-router.rule=PathPrefix(`/vector-tiles`)"
@@ -112,7 +114,7 @@ services:
       - "traefik.http.middlewares.middleware-chain.chain.middlewares=prefect-auth,replace-prefect-path-middleware"
       - "traefik.http.middlewares.replace-prefect-path-middleware.replacepathregex.regex=/prefect/api"
       - "traefik.http.middlewares.replace-prefect-path-middleware.replacepathregex.replacement=/api"
-      - "traefik.http.middlewares.prefect-auth.basicauth.usersfile=/traefikauth/usersfile"
+      - "traefik.http.middlewares.prefect-auth.basicauth.usersfile=/run/secrets/traefik-users-file"
       - "traefik.http.routers.prefect-router.middlewares=middleware-chain"
     depends_on:
       prefect-db:
@@ -154,3 +156,15 @@ services:
     environment:
       PG_DATA: /var/lib/postgresql/data/pgdata
     healthcheck: *postgres-db-healthcheck
+
+
+configs:
+
+  martin-conf:
+    file: $PWD/docker/martin/config.yaml
+
+
+secrets:
+
+  traefik-users-file:
+    file: ${ARPAV_PPCV_TRAEFIK_BASIC_AUTH_USERS_FILE:-$PWD/docker/traefik/basicauth-users.txt}


### PR DESCRIPTION
In preparation for deployment to production env, and for sake of homogeneity, this PR modifies the existing docker compose files in order to use compose's [configs](https://docs.docker.com/reference/compose-file/configs/) and [secrets](https://docs.docker.com/reference/compose-file/secrets/) features