### PR TITLE
Added name of station to time series output schema

### DIFF
--- a/arpav_ppcv/operations.py
+++ b/arpav_ppcv/operations.py
@@ -607,7 +607,11 @@ def get_coverage_time_series(
     ],
     Optional[
         dict[
-            tuple[observations.Variable, base.ObservationDataSmoothingStrategy],
+            tuple[
+                observations.Station,
+                observations.Variable,
+                base.ObservationDataSmoothingStrategy,
+            ],
             pd.Series,
         ]
     ],
@@ -705,7 +709,11 @@ def get_coverage_time_series(
                     ),
                 )
                 observation_result[
-                    (variable, base.ObservationDataSmoothingStrategy.NO_SMOOTHING)
+                    (
+                        station,
+                        variable,
+                        base.ObservationDataSmoothingStrategy.NO_SMOOTHING,
+                    )
                 ] = station_df[variable.name].squeeze()
                 for smoothing_strategy in additional_observation_smoothing_strategies:
                     (
@@ -714,9 +722,9 @@ def get_coverage_time_series(
                     ) = process_station_data_smoothing_strategy(
                         station_df, variable.name, smoothing_strategy
                     )
-                    observation_result[(variable, smoothing_strategy)] = station_df[
-                        smoothed_column
-                    ].squeeze()
+                    observation_result[
+                        (station, variable, smoothing_strategy)
+                    ] = station_df[smoothed_column].squeeze()
             else:
                 logger.info("No station data found, skipping...")
         else:
@@ -724,7 +732,7 @@ def get_coverage_time_series(
                 "Cannot include observation data - no observation variable is related "
                 "to this coverage configuration"
             )
-    return (coverage_result, observation_result)
+    return coverage_result, observation_result
 
 
 def extract_nearby_station_data(

--- a/arpav_ppcv/schemas/observations.py
+++ b/arpav_ppcv/schemas/observations.py
@@ -121,6 +121,9 @@ class Station(StationBase, table=True):
         }
     )
 
+    def __hash__(self):
+        return hash(self.id)
+
 
 class StationCreate(sqlmodel.SQLModel):
     code: str

--- a/arpav_ppcv/webapp/api_v2/routers/coverages.py
+++ b/arpav_ppcv/webapp/api_v2/routers/coverages.py
@@ -719,10 +719,10 @@ def get_time_series(
                 )
             if observations_series is not None:
                 for observation_info, pd_series in observations_series.items():
-                    variable, smoothing_strategy = observation_info
+                    station, variable, smoothing_strategy = observation_info
                     series.append(
                         TimeSeries.from_observation_series(
-                            pd_series, variable, smoothing_strategy
+                            pd_series, station, variable, smoothing_strategy
                         )
                     )
             return TimeSeriesList(series=series)

--- a/arpav_ppcv/webapp/api_v2/schemas/base.py
+++ b/arpav_ppcv/webapp/api_v2/schemas/base.py
@@ -82,6 +82,7 @@ class TimeSeries(pydantic.BaseModel):
     def from_observation_series(
         cls,
         series: pd.Series,
+        station: observations_schemas.Station,
         variable: observations_schemas.Variable,
         smoothing_strategy: base_schemas.ObservationDataSmoothingStrategy,
         extra_info: typing.Optional[dict[str, str | int | float | dict]] = None,
@@ -120,6 +121,7 @@ class TimeSeries(pydantic.BaseModel):
             ],
             info={
                 "processing_method": smoothing_strategy.value,
+                "station": station.name,
                 "variable": variable.name,
                 "series_elaboration": series_elaboration.value,
                 "derived_series": (


### PR DESCRIPTION
This PR adds the name of the relevant station to the `info` property of a time series output, in the observation series (if any).
---

- fixes #257