### PR TITLE
Modified name validator

### DIFF
--- a/arpav_ppcv/schemas/coverages.py
+++ b/arpav_ppcv/schemas/coverages.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from . import observations
 
 logger = logging.getLogger(__name__)
-_NAME_PATTERN: Final[str] = r"^[a-z][a-z0-9_]+$"
+_NAME_PATTERN: Final[str] = r"^[a-z0-9_]+$"
 
 
 class ConfigurationParameterValue(sqlmodel.SQLModel, table=True):


### PR DESCRIPTION
This PR modifies the validation pattern used for edition of a coverage configuration's, configuration parameter's and configuration parameter values' `name` property, in order to allow numbers and the underscore to be used as the first character. 

Previously, the pattern only allowed numbers, letter and the underscore, BUT disallowed numbers and the underscore in the first character. This was found to be problematic as it prevented using the name `30yr` for a conf param value of `aggreation_period`.

This PR thus lifts the previous restriction, making it so `name` can now accept a number, underscore or letter in its first character 

---

- fixes #261