### PR TITLE
Prevent deleting/modifying name of core conf parameters via admin UI

### DIFF
--- a/arpav_ppcv/bootstrapper/configurationparameters.py
+++ b/arpav_ppcv/bootstrapper/configurationparameters.py
@@ -1,3 +1,4 @@
+from ..schemas.base import CoreConfParamName
 from ..schemas.coverages import (
     ConfigurationParameterCreate,
     ConfigurationParameterValueCreateEmbeddedInConfigurationParameter,
@@ -7,7 +8,7 @@ from ..schemas.coverages import (
 def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
     return [
         ConfigurationParameterCreate(
-            name="historical_variable",
+            name=CoreConfParamName.HISTORICAL_VARIABLE.value,
             display_name_english="Variable",
             display_name_italian="Variabile",
             description_english="Historical variable",
@@ -103,7 +104,7 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
             ],
         ),
         ConfigurationParameterCreate(
-            name="climatological_variable",
+            name=CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value,
             display_name_english="Variable",
             display_name_italian="Variabile",
             description_english="Climatological variable",
@@ -203,7 +204,7 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
             ],
         ),
         ConfigurationParameterCreate(
-            name="scenario",
+            name=CoreConfParamName.SCENARIO.value,
             display_name_english="Scenario",
             display_name_italian="Scenario",
             description_english="Climate model scenario",
@@ -498,7 +499,7 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
             ],
         ),
         ConfigurationParameterCreate(
-            name="measure",
+            name=CoreConfParamName.MEASURE.value,
             display_name_english="Measurement type",
             display_name_italian="Tipo di misurazione",
             description_english="Type of climatological measurement",
@@ -529,7 +530,7 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
             ],
         ),
         ConfigurationParameterCreate(
-            name="climatological_model",
+            name=CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
             display_name_english="Forecast model",
             display_name_italian="Modello di previsione",
             description_english=(
@@ -600,7 +601,7 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
             ],
         ),
         ConfigurationParameterCreate(
-            name="aggregation_period",
+            name=CoreConfParamName.AGGREGATION_PERIOD.value,
             display_name_english="Temporal aggregation period",
             display_name_italian="Periodo di aggregazione temporale",
             description_english="Aggregation period for climatological datasets",
@@ -662,7 +663,7 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
             ],
         ),
         ConfigurationParameterCreate(
-            name="archive",
+            name=CoreConfParamName.ARCHIVE.value,
             display_name_english="Dataset archive",
             display_name_italian="archivio di dataset",
             description_english="The archive that the dataset belongs to",

--- a/arpav_ppcv/schemas/base.py
+++ b/arpav_ppcv/schemas/base.py
@@ -14,6 +14,16 @@ class Translatable(typing.Protocol):
         ...
 
 
+class CoreConfParamName(enum.Enum):
+    AGGREGATION_PERIOD = "aggregation_period"
+    ARCHIVE = "archive"
+    CLIMATOLOGICAL_MODEL = "climatological_model"
+    CLIMATOLOGICAL_VARIABLE = "climatological_variable"
+    HISTORICAL_VARIABLE = "historical_variable"
+    MEASURE = "measure"
+    SCENARIO = "scenario"
+
+
 class Season(enum.Enum):
     WINTER = "WINTER"
     SPRING = "SPRING"


### PR DESCRIPTION
As stated in #265, some of the configuration parameters which are created when first bootstrapping the system are crucial to ensure correct operation and should not be deleted nor have its `name` property changed.

This PR implements a way to enforce the restrictions mentioned above via the admin UI. This is done by checking if the `name` of the configuration parameter being edited is one of the core parameters and then fail if the action being requested is either a rename of the `name` or a deletion of the conf param.

This should make the system safer to administer by the client.

---

- fixes #265