### PR TITLE
Add historical values to climate barometer time series endpoint

### DIFF
--- a/arpav_ppcv/bootstrapper/configurationparameters.py
+++ b/arpav_ppcv/bootstrapper/configurationparameters.py
@@ -683,6 +683,17 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                     description_english=("Datasets obtained from forecasts"),
                     description_italian=("Set di dati ottenuti dalle previsioni"),
                 ),
+                ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
+                    internal_value="barometro_climatico",
+                    display_name_english="Climate barometer",
+                    display_name_italian="Barometro climatico",
+                    description_english=(
+                        "Datasets providing an overview of the whole region"
+                    ),
+                    description_italian=(
+                        "Set di dati che forniscono una panoramica dell'intera regione"
+                    ),
+                ),
             ],
         ),
         ConfigurationParameterCreate(

--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/tas.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/tas.py
@@ -2329,17 +2329,12 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        ("archive", "barometro_climatico")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("climatological_variable", "tas")
-                    ].id
-                ),
-                ConfigurationParameterPossibleValueCreate(
-                    configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "barometro_climatico")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -2375,17 +2370,12 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        ("archive", "barometro_climatico")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("climatological_variable", "tas")
-                    ].id
-                ),
-                ConfigurationParameterPossibleValueCreate(
-                    configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "barometro_climatico")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -2426,17 +2416,12 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        ("archive", "barometro_climatico")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
                         ("climatological_variable", "tas")
-                    ].id
-                ),
-                ConfigurationParameterPossibleValueCreate(
-                    configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "barometro_climatico")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(

--- a/arpav_ppcv/bootstrapper/coverage_configurations/historical/tdd.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/historical/tdd.py
@@ -357,4 +357,36 @@ def generate_configurations(
             ),
             observation_variable_aggregation_type=ObservationAggregationType.MONTHLY,
         ),
+        CoverageConfigurationCreate(
+            name="tdd_barometro_climatico",
+            display_name_english=_DISPLAY_NAME_ENGLISH,
+            display_name_italian=_DISPLAY_NAME_ITALIAN,
+            description_english=_DESCRIPTION_ENGLISH,
+            description_italian=_DESCRIPTION_ITALIAN,
+            netcdf_main_dataset_name="TDd",
+            wms_main_layer_name="TDd",
+            thredds_url_pattern="cline_yr/fldmean/TDd_A00_*.nc",
+            unit_english=_UNIT,
+            palette="default/seq-YlOrRd",
+            color_scale_min=_COLOR_SCALE_MIN,
+            color_scale_max=_COLOR_SCALE_MAX,
+            possible_values=[
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("archive", "barometro_climatico")
+                    ].id
+                ),
+                ConfigurationParameterPossibleValueCreate(
+                    configuration_parameter_value_id=conf_param_values[
+                        ("historical_variable", _VARIABLE)
+                    ].id
+                ),
+            ],
+            observation_variable_id=(
+                v.id
+                if (v := variables.get(_RELATED_OBSERVATION_VARIABLE_NAME)) is not None
+                else None
+            ),
+            observation_variable_aggregation_type=ObservationAggregationType.MONTHLY,
+        ),
     ]

--- a/arpav_ppcv/schemas/base.py
+++ b/arpav_ppcv/schemas/base.py
@@ -22,6 +22,7 @@ class CoreConfParamName(enum.Enum):
     HISTORICAL_VARIABLE = "historical_variable"
     MEASURE = "measure"
     SCENARIO = "scenario"
+    UNCERTAINTY_TYPE = "uncertainty_type"
 
 
 class Season(enum.Enum):


### PR DESCRIPTION
This PR adds the additional `TDd` series to be shown in the climate barometer section of the frontend.

It contains some relevant changes:

`barometro_climatico` is now an additional possible value for the `archive` configuration parameter. This seems like a more logical way to categorize coverages intended to be shown in the climate barometer section.

The `/api/v2/coverages/time-series/climate-barometer` does not expect a coverage identifier to be given as a path parameter anymore, as all coverage configurations which are related to this section are correctly configured as so. The response now includes and additional series with the observation values of the `TDd` variable.

---

- fixes #266