### PR TITLE
Replaced mentions of core conf param names by string with their corresponding enum value

### DIFF
--- a/arpav_ppcv/bootstrapper/configurationparameters.py
+++ b/arpav_ppcv/bootstrapper/configurationparameters.py
@@ -287,7 +287,7 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
             ],
         ),
         ConfigurationParameterCreate(
-            name="year_period",
+            name=CoreConfParamName.YEAR_PERIOD.value,
             display_name_english="Year period",
             display_name_italian="Periodo dell'anno",
             description_english="Yearly temporal aggregation period",
@@ -352,7 +352,7 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
             ],
         ),
         ConfigurationParameterCreate(
-            name="historical_year_period",
+            name=CoreConfParamName.HISTORICAL_YEAR_PERIOD.value,
             display_name_english="year period - historical data",
             display_name_italian="periodo dell'anno - dati storici",
             description_english="Yearly temporal aggregation period for historical data",
@@ -591,13 +591,6 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                     description_english="MPI-ESM-LR-REMO2009 model",
                     description_italian="Modello MPI-ESM-LR-REMO2009",
                 ),
-                ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
-                    internal_value="barometro_climatico",
-                    display_name_english="Climate barometer",
-                    display_name_italian="Barometro climatico",
-                    description_english="Regional overview",
-                    description_italian="Panoramica regionale",
-                ),
             ],
         ),
         ConfigurationParameterCreate(
@@ -630,7 +623,7 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
             ],
         ),
         ConfigurationParameterCreate(
-            name="uncertainty_type",
+            name=CoreConfParamName.UNCERTAINTY_TYPE.value,
             display_name_english="Uncertainty type",
             display_name_italian="Tipologia dei limiti di incertezza",
             description_english="Type of uncertainty that this configuration represents",

--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/cdd.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/cdd.py
@@ -2,6 +2,7 @@ from ....schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
 )
+from ....schemas.base import CoreConfParamName
 
 _DISPLAY_NAME_ENGLISH = "Consecutive dry days"
 _DISPLAY_NAME_ITALIAN = "Giorni secchi"
@@ -36,27 +37,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "cdd")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "cdd")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -71,37 +72,37 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "winter")
+                        (CoreConfParamName.YEAR_PERIOD.value, "winter")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "spring")
+                        (CoreConfParamName.YEAR_PERIOD.value, "spring")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "summer")
+                        (CoreConfParamName.YEAR_PERIOD.value, "summer")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "autumn")
+                        (CoreConfParamName.YEAR_PERIOD.value, "autumn")
                     ].id
                 ),
             ],
@@ -123,27 +124,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "cdd")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "cdd")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_cclm_4_8_17",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -158,37 +162,37 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "winter")
+                        (CoreConfParamName.YEAR_PERIOD.value, "winter")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "spring")
+                        (CoreConfParamName.YEAR_PERIOD.value, "spring")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "summer")
+                        (CoreConfParamName.YEAR_PERIOD.value, "summer")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "autumn")
+                        (CoreConfParamName.YEAR_PERIOD.value, "autumn")
                     ].id
                 ),
             ],
@@ -210,27 +214,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "cdd")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "cdd")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -245,17 +252,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -297,27 +304,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "cdd")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "cdd")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_rca4")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "ec_earth_rca4")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -332,17 +339,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -384,27 +391,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "cdd")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "cdd")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "hadgem2_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "hadgem2_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -419,17 +429,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -471,27 +481,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "cdd")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "cdd")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "mpi_esm_lr_remo2009")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "mpi_esm_lr_remo2009",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -506,17 +519,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(

--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/cdds.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/cdds.py
@@ -1,3 +1,4 @@
+from ....schemas.base import CoreConfParamName
 from ....schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
@@ -35,47 +36,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "cdds")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "cdds")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -96,47 +97,50 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "cdds")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "cdds")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_cclm_4_8_17",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -157,47 +161,50 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "cdds")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "cdds")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -218,47 +225,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "cdds")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "cdds")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_rca4")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "ec_earth_rca4")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -279,42 +286,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "cdds")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "cdds")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "hadgem2_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "hadgem2_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -340,42 +350,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "cdds")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "cdds")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "mpi_esm_lr_remo2009")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "mpi_esm_lr_remo2009",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -401,47 +414,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "cdds")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "cdds")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "upper_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "upper_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -467,47 +480,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "cdds")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "cdds")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "lower_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "lower_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -535,27 +548,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "cdds")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "cdds")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -570,17 +583,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -606,27 +619,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "cdds")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "cdds")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_cclm_4_8_17",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -641,17 +657,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -677,27 +693,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "cdds")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "cdds")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -712,17 +731,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -748,27 +767,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "cdds")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "cdds")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_rca4")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "ec_earth_rca4")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -783,17 +802,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -819,27 +838,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "cdds")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "cdds")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "hadgem2_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "hadgem2_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -854,17 +876,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -890,27 +912,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "cdds")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "cdds")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "mpi_esm_lr_remo2009")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "mpi_esm_lr_remo2009",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -925,17 +950,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(

--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/fd.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/fd.py
@@ -1,4 +1,7 @@
-from ....schemas.base import ObservationAggregationType
+from ....schemas.base import (
+    CoreConfParamName,
+    ObservationAggregationType,
+)
 from ....schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
@@ -31,47 +34,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "fd")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "fd")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -97,47 +100,50 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "fd")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "fd")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_cclm_4_8_17",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -163,47 +169,50 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "fd")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "fd")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -229,47 +238,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "fd")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "fd")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_rca4")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "ec_earth_rca4")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -295,42 +304,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "fd")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "fd")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "hadgem2_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "hadgem2_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -361,42 +373,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "fd")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "fd")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "mpi_esm_lr_remo2009")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "mpi_esm_lr_remo2009",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -427,47 +442,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "fd")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "fd")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "upper_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "upper_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -494,47 +509,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "fd")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "fd")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "lower_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "lower_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -562,27 +577,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "fd")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "fd")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -597,17 +612,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -634,27 +649,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "fd")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "fd")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_cclm_4_8_17",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -669,17 +687,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -706,27 +724,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "fd")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "fd")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -741,17 +762,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -778,27 +799,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "fd")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "fd")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_rca4")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "ec_earth_rca4")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -813,17 +834,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -850,27 +871,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "fd")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "fd")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "hadgem2_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "hadgem2_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -885,17 +909,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -922,27 +946,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "fd")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "fd")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "mpi_esm_lr_remo2009")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "mpi_esm_lr_remo2009",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -957,17 +984,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(

--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/hdds.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/hdds.py
@@ -1,3 +1,4 @@
+from ....schemas.base import CoreConfParamName
 from ....schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
@@ -35,47 +36,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "hdds")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "hdds")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -96,47 +97,50 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "hdds")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "hdds")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_cclm_4_8_17",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -157,47 +161,50 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "hdds")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "hdds")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -218,47 +225,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "hdds")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "hdds")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_rca4")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "ec_earth_rca4")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -279,47 +286,50 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "hdds")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "hdds")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "hadgem2_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "hadgem2_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -340,47 +350,50 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "hdds")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "hdds")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "mpi_esm_lr_remo2009")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "mpi_esm_lr_remo2009",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -401,47 +414,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "hdds")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "hdds")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "upper_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "upper_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -467,47 +480,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "hdds")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "hdds")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "lower_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "lower_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -535,27 +548,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "hdds")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "hdds")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -570,17 +583,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -606,27 +619,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "hdds")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "hdds")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_cclm_4_8_17",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -641,17 +657,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -677,27 +693,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "hdds")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "hdds")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -712,17 +731,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -748,27 +767,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "hdds")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "hdds")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_rca4")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "ec_earth_rca4")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -783,17 +802,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -819,27 +838,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "hdds")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "hdds")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "hadgem2_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "hadgem2_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -854,17 +876,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -890,27 +912,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "hdds")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "hdds")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "mpi_esm_lr_remo2009")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "mpi_esm_lr_remo2009",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -925,17 +950,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(

--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/hwdi.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/hwdi.py
@@ -1,3 +1,4 @@
+from ....schemas.base import CoreConfParamName
 from ....schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
@@ -37,27 +38,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "hwdi")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "hwdi")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -72,22 +73,22 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "summer")
+                        (CoreConfParamName.YEAR_PERIOD.value, "summer")
                     ].id
                 ),
             ],
@@ -109,27 +110,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "hwdi")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "hwdi")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_cclm_4_8_17",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -144,22 +148,22 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "summer")
+                        (CoreConfParamName.YEAR_PERIOD.value, "summer")
                     ].id
                 ),
             ],
@@ -181,27 +185,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "hwdi")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "hwdi")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -216,22 +223,22 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "summer")
+                        (CoreConfParamName.YEAR_PERIOD.value, "summer")
                     ].id
                 ),
             ],
@@ -253,27 +260,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "hwdi")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "hwdi")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_rca4")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "ec_earth_rca4")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -288,22 +295,22 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "summer")
+                        (CoreConfParamName.YEAR_PERIOD.value, "summer")
                     ].id
                 ),
             ],
@@ -325,27 +332,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "hwdi")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "hwdi")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "hadgem2_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "hadgem2_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -360,22 +370,22 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "summer")
+                        (CoreConfParamName.YEAR_PERIOD.value, "summer")
                     ].id
                 ),
             ],
@@ -397,27 +407,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "hwdi")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "hwdi")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "mpi_esm_lr_remo2009")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "mpi_esm_lr_remo2009",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -432,17 +445,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(

--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/pr.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/pr.py
@@ -1,4 +1,7 @@
-from ....schemas.base import ObservationAggregationType
+from ....schemas.base import (
+    CoreConfParamName,
+    ObservationAggregationType,
+)
 from ....schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
@@ -30,62 +33,62 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "pr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "pr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "winter")
+                        (CoreConfParamName.YEAR_PERIOD.value, "winter")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "spring")
+                        (CoreConfParamName.YEAR_PERIOD.value, "spring")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "summer")
+                        (CoreConfParamName.YEAR_PERIOD.value, "summer")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "autumn")
+                        (CoreConfParamName.YEAR_PERIOD.value, "autumn")
                     ].id
                 ),
             ],
@@ -106,57 +109,60 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "pr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "pr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_cclm_4_8_17",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "winter")
+                        (CoreConfParamName.YEAR_PERIOD.value, "winter")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "spring")
+                        (CoreConfParamName.YEAR_PERIOD.value, "spring")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "summer")
+                        (CoreConfParamName.YEAR_PERIOD.value, "summer")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -182,42 +188,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "pr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "pr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -258,42 +267,42 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "pr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "pr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_rca4")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "ec_earth_rca4")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -334,42 +343,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "pr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "pr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "hadgem2_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "hadgem2_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -410,42 +422,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "pr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "pr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "mpi_esm_lr_remo2009")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "mpi_esm_lr_remo2009",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -486,47 +501,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "pr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "pr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "upper_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "upper_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -567,47 +582,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "pr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "pr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "lower_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "lower_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -648,42 +663,42 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "pr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "pr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -728,42 +743,42 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "pr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "pr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -793,42 +808,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "pr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "pr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_cclm_4_8_17",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -873,42 +891,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "pr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "pr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_cclm_4_8_17",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -938,42 +959,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "pr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "pr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1018,42 +1042,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "pr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "pr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1083,42 +1110,42 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "pr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "pr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_rca4")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "ec_earth_rca4")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1163,42 +1190,42 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "pr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "pr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_rca4")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "ec_earth_rca4")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1228,42 +1255,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "pr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "pr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "hadgem2_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "hadgem2_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1308,42 +1338,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "pr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "pr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "hadgem2_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "hadgem2_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1373,42 +1406,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "pr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "pr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "mpi_esm_lr_remo2009")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "mpi_esm_lr_remo2009",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1453,42 +1489,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "pr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "pr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "mpi_esm_lr_remo2009")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "mpi_esm_lr_remo2009",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1518,47 +1557,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "pr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "pr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "upper_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "upper_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1599,47 +1638,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "pr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "pr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "lower_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "lower_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1680,47 +1719,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "pr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "pr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "upper_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "upper_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1746,47 +1785,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "pr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "pr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "lower_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "lower_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1813,27 +1852,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "pr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "pr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1848,17 +1887,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1899,27 +1938,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "pr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "pr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_cclm_4_8_17",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1934,17 +1976,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1985,27 +2027,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "pr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "pr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -2020,17 +2065,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -2071,27 +2116,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "pr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "pr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_rca4")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "ec_earth_rca4")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -2106,17 +2151,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -2157,27 +2202,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "pr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "pr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "hadgem2_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "hadgem2_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -2192,17 +2240,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -2243,27 +2291,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "pr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "pr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "mpi_esm_lr_remo2009")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "mpi_esm_lr_remo2009",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -2278,17 +2329,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(

--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/r95ptot.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/r95ptot.py
@@ -1,3 +1,4 @@
+from ....schemas.base import CoreConfParamName
 from ....schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
@@ -35,27 +36,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "r95ptot")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "r95ptot")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -70,37 +71,37 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "winter")
+                        (CoreConfParamName.YEAR_PERIOD.value, "winter")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "spring")
+                        (CoreConfParamName.YEAR_PERIOD.value, "spring")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "summer")
+                        (CoreConfParamName.YEAR_PERIOD.value, "summer")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "autumn")
+                        (CoreConfParamName.YEAR_PERIOD.value, "autumn")
                     ].id
                 ),
             ],
@@ -121,27 +122,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "r95ptot")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "r95ptot")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_cclm_4_8_17",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -156,27 +160,27 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "winter")
+                        (CoreConfParamName.YEAR_PERIOD.value, "winter")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "spring")
+                        (CoreConfParamName.YEAR_PERIOD.value, "spring")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -207,27 +211,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "r95ptot")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "r95ptot")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -242,17 +249,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -293,27 +300,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "r95ptot")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "r95ptot")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_rca4")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "ec_earth_rca4")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -328,17 +335,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -379,27 +386,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "r95ptot")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "r95ptot")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "hadgem2_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "hadgem2_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -414,17 +424,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -465,27 +475,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "r95ptot")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "r95ptot")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "mpi_esm_lr_remo2009")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "mpi_esm_lr_remo2009",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -500,17 +513,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(

--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/snwdays.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/snwdays.py
@@ -1,3 +1,4 @@
+from ....schemas.base import CoreConfParamName
 from ....schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
@@ -35,47 +36,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "snwdays")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "snwdays")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -97,47 +98,50 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "snwdays")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "snwdays")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_cclm_4_8_17",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -159,47 +163,50 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "snwdays")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "snwdays")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -221,47 +228,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "snwdays")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "snwdays")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_rca4")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "ec_earth_rca4")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -283,47 +290,50 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "snwdays")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "snwdays")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "hadgem2_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "hadgem2_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -345,47 +355,50 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "snwdays")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "snwdays")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "mpi_esm_lr_remo2009")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "mpi_esm_lr_remo2009",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -407,52 +420,52 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "snwdays")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "snwdays")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "upper_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "upper_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -474,52 +487,52 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "snwdays")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "snwdays")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "lower_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "lower_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -543,27 +556,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "snwdays")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "snwdays")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -578,22 +591,22 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -615,27 +628,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "snwdays")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "snwdays")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_cclm_4_8_17",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -650,22 +666,22 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -687,27 +703,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "snwdays")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "snwdays")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -722,22 +741,22 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -759,27 +778,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "snwdays")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "snwdays")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_rca4")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "ec_earth_rca4")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -794,17 +813,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -831,27 +850,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "snwdays")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "snwdays")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "hadgem2_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "hadgem2_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -866,17 +888,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -903,27 +925,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "snwdays")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "snwdays")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "mpi_esm_lr_remo2009")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "mpi_esm_lr_remo2009",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -938,17 +963,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(

--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/su30.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/su30.py
@@ -1,4 +1,7 @@
-from ....schemas.base import ObservationAggregationType
+from ....schemas.base import (
+    CoreConfParamName,
+    ObservationAggregationType,
+)
 from ....schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
@@ -31,47 +34,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "su30")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "su30")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -97,47 +100,50 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "su30")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "su30")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_cclm_4_8_17",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -163,47 +169,50 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "su30")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "su30")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -229,47 +238,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "su30")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "su30")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_rca4")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "ec_earth_rca4")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -295,47 +304,50 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "su30")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "su30")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "hadgem2_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "hadgem2_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -361,47 +373,50 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "su30")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "su30")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "mpi_esm_lr_remo2009")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "mpi_esm_lr_remo2009",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -427,52 +442,52 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "su30")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "su30")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "upper_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "upper_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -494,52 +509,52 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "su30")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "su30")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "lower_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "lower_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -562,27 +577,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "su30")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "su30")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -597,22 +612,22 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -634,27 +649,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "su30")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "su30")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_cclm_4_8_17",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -669,22 +687,22 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -706,27 +724,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "su30")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "su30")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -741,22 +762,22 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -778,27 +799,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "su30")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "su30")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_rca4")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "ec_earth_rca4")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -813,17 +834,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -850,27 +871,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "su30")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "su30")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "hadgem2_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "hadgem2_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -885,17 +909,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -922,27 +946,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "su30")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "su30")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "mpi_esm_lr_remo2009")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "mpi_esm_lr_remo2009",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -957,17 +984,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(

--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/tas.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/tas.py
@@ -1,4 +1,7 @@
-from ....schemas.base import ObservationAggregationType
+from ....schemas.base import (
+    CoreConfParamName,
+    ObservationAggregationType,
+)
 from ....schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
@@ -30,62 +33,62 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "winter")
+                        (CoreConfParamName.YEAR_PERIOD.value, "winter")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "spring")
+                        (CoreConfParamName.YEAR_PERIOD.value, "spring")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "summer")
+                        (CoreConfParamName.YEAR_PERIOD.value, "summer")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "autumn")
+                        (CoreConfParamName.YEAR_PERIOD.value, "autumn")
                     ].id
                 ),
             ],
@@ -106,62 +109,65 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_cclm_4_8_17",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "winter")
+                        (CoreConfParamName.YEAR_PERIOD.value, "winter")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "spring")
+                        (CoreConfParamName.YEAR_PERIOD.value, "spring")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "summer")
+                        (CoreConfParamName.YEAR_PERIOD.value, "summer")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "autumn")
+                        (CoreConfParamName.YEAR_PERIOD.value, "autumn")
                     ].id
                 ),
             ],
@@ -182,47 +188,50 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "winter")
+                        (CoreConfParamName.YEAR_PERIOD.value, "winter")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -258,42 +267,42 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_rca4")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "ec_earth_rca4")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -334,42 +343,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "hadgem2_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "hadgem2_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -410,42 +422,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "mpi_esm_lr_remo2009")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "mpi_esm_lr_remo2009",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -486,47 +501,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "upper_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "upper_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -567,47 +582,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "lower_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "lower_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -648,42 +663,42 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -728,42 +743,42 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -793,42 +808,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_cclm_4_8_17",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -873,42 +891,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_cclm_4_8_17",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -938,42 +959,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1018,42 +1042,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1083,42 +1110,42 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_rca4")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "ec_earth_rca4")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1163,42 +1190,42 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_rca4")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "ec_earth_rca4")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1228,42 +1255,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "hadgem2_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "hadgem2_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1308,42 +1338,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "hadgem2_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "hadgem2_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1373,42 +1406,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "mpi_esm_lr_remo2009")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "mpi_esm_lr_remo2009",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1453,42 +1489,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "mpi_esm_lr_remo2009")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "mpi_esm_lr_remo2009",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1518,47 +1557,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "upper_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "upper_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1599,47 +1638,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "lower_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "lower_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1680,47 +1719,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "upper_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "upper_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1746,47 +1785,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "lower_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "lower_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1813,27 +1852,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1848,17 +1887,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1899,27 +1938,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_cclm_4_8_17",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1934,17 +1976,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1985,27 +2027,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -2020,17 +2065,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -2071,27 +2116,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_rca4")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "ec_earth_rca4")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -2106,17 +2151,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -2157,27 +2202,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "hadgem2_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "hadgem2_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -2192,17 +2240,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -2243,27 +2291,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "mpi_esm_lr_remo2009")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "mpi_esm_lr_remo2009",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -2278,17 +2329,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -2329,27 +2380,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "barometro_climatico")
+                        (CoreConfParamName.ARCHIVE.value, "barometro_climatico")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
             ],
@@ -2370,32 +2421,32 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "barometro_climatico")
+                        (CoreConfParamName.ARCHIVE.value, "barometro_climatico")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "lower_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "lower_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
             ],
@@ -2416,32 +2467,32 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "barometro_climatico")
+                        (CoreConfParamName.ARCHIVE.value, "barometro_climatico")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tas")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tas")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "upper_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "upper_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
             ],

--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/tasmax.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/tasmax.py
@@ -1,4 +1,7 @@
-from ....schemas.base import ObservationAggregationType
+from ....schemas.base import (
+    CoreConfParamName,
+    ObservationAggregationType,
+)
 from ....schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
@@ -30,62 +33,62 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmax")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmax")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "winter")
+                        (CoreConfParamName.YEAR_PERIOD.value, "winter")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "spring")
+                        (CoreConfParamName.YEAR_PERIOD.value, "spring")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "summer")
+                        (CoreConfParamName.YEAR_PERIOD.value, "summer")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "autumn")
+                        (CoreConfParamName.YEAR_PERIOD.value, "autumn")
                     ].id
                 ),
             ],
@@ -110,47 +113,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmax")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmax")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -175,62 +178,65 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmax")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmax")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_cclm_4_8_17",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "winter")
+                        (CoreConfParamName.YEAR_PERIOD.value, "winter")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "spring")
+                        (CoreConfParamName.YEAR_PERIOD.value, "spring")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "summer")
+                        (CoreConfParamName.YEAR_PERIOD.value, "summer")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "autumn")
+                        (CoreConfParamName.YEAR_PERIOD.value, "autumn")
                     ].id
                 ),
             ],
@@ -255,47 +261,50 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmax")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmax")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_cclm_4_8_17",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -320,42 +329,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmax")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmax")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -400,42 +412,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmax")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmax")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -465,42 +480,42 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmax")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmax")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_rca4")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "ec_earth_rca4")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -545,42 +560,42 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmax")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmax")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_rca4")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "ec_earth_rca4")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -610,42 +625,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmax")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmax")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "hadgem2_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "hadgem2_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -690,42 +708,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmax")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmax")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "hadgem2_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "hadgem2_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -755,42 +776,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmax")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmax")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "mpi_esm_lr_remo2009")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "mpi_esm_lr_remo2009",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -835,42 +859,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmax")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmax")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "mpi_esm_lr_remo2009")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "mpi_esm_lr_remo2009",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -900,47 +927,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmax")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmax")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "upper_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "upper_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -981,47 +1008,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmax")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmax")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "lower_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "lower_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1062,47 +1089,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmax")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmax")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "upper_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "upper_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1128,47 +1155,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmax")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmax")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "lower_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "lower_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1195,27 +1222,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmax")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmax")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1230,17 +1257,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1281,27 +1308,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmax")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmax")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_cclm_4_8_17",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1316,17 +1346,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1367,27 +1397,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmax")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmax")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1402,17 +1435,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1453,27 +1486,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmax")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmax")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_rca4")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "ec_earth_rca4")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1488,17 +1521,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1539,27 +1572,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmax")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmax")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "hadgem2_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "hadgem2_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1574,17 +1610,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1625,27 +1661,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmax")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmax")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "mpi_esm_lr_remo2009")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "mpi_esm_lr_remo2009",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1660,17 +1699,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(

--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/tasmin.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/tasmin.py
@@ -1,4 +1,7 @@
-from ....schemas.base import ObservationAggregationType
+from ....schemas.base import (
+    CoreConfParamName,
+    ObservationAggregationType,
+)
 from ....schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
@@ -30,62 +33,62 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmin")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmin")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "winter")
+                        (CoreConfParamName.YEAR_PERIOD.value, "winter")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "spring")
+                        (CoreConfParamName.YEAR_PERIOD.value, "spring")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "summer")
+                        (CoreConfParamName.YEAR_PERIOD.value, "summer")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "autumn")
+                        (CoreConfParamName.YEAR_PERIOD.value, "autumn")
                     ].id
                 ),
             ],
@@ -110,47 +113,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmin")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmin")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -175,62 +178,65 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmin")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmin")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_cclm_4_8_17",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "winter")
+                        (CoreConfParamName.YEAR_PERIOD.value, "winter")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "spring")
+                        (CoreConfParamName.YEAR_PERIOD.value, "spring")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "summer")
+                        (CoreConfParamName.YEAR_PERIOD.value, "summer")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "autumn")
+                        (CoreConfParamName.YEAR_PERIOD.value, "autumn")
                     ].id
                 ),
             ],
@@ -255,47 +261,50 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmin")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmin")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_cclm_4_8_17",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -320,52 +329,55 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmin")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmin")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "winter")
+                        (CoreConfParamName.YEAR_PERIOD.value, "winter")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "spring")
+                        (CoreConfParamName.YEAR_PERIOD.value, "spring")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -400,42 +412,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmin")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmin")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -465,42 +480,42 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmin")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmin")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_rca4")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "ec_earth_rca4")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -545,42 +560,42 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmin")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmin")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_rca4")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "ec_earth_rca4")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -610,42 +625,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmin")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmin")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "hadgem2_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "hadgem2_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -690,42 +708,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmin")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmin")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "hadgem2_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "hadgem2_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -755,42 +776,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmin")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmin")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "mpi_esm_lr_remo2009")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "mpi_esm_lr_remo2009",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -835,42 +859,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmin")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmin")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "mpi_esm_lr_remo2009")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "mpi_esm_lr_remo2009",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -900,47 +927,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmin")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmin")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "upper_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "upper_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -981,47 +1008,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmin")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmin")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "lower_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "lower_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1062,47 +1089,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmin")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmin")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "upper_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "upper_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1128,47 +1155,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmin")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmin")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "lower_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "lower_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1195,32 +1222,32 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmin")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmin")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "lower_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "lower_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1235,17 +1262,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1286,27 +1313,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmin")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmin")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_cclm_4_8_17",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1321,17 +1351,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1372,27 +1402,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmin")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmin")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1407,17 +1440,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1458,27 +1491,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmin")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmin")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_rca4")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "ec_earth_rca4")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1493,17 +1526,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1544,27 +1577,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmin")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmin")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "hadgem2_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "hadgem2_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1579,17 +1615,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1630,27 +1666,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tasmin")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tasmin")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "mpi_esm_lr_remo2009")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "mpi_esm_lr_remo2009",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -1665,17 +1704,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(

--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/tr.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/tr.py
@@ -1,4 +1,7 @@
-from ....schemas.base import ObservationAggregationType
+from ....schemas.base import (
+    CoreConfParamName,
+    ObservationAggregationType,
+)
 from ....schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
@@ -31,47 +34,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -97,47 +100,50 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_cclm_4_8_17",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -163,47 +169,50 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -229,47 +238,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_rca4")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "ec_earth_rca4")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("year_period", "all_year")
+                        (CoreConfParamName.YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -295,42 +304,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "hadgem2_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "hadgem2_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -361,42 +373,45 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "mpi_esm_lr_remo2009")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "mpi_esm_lr_remo2009",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -427,47 +442,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "upper_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "upper_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -494,47 +509,47 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("uncertainty_type", "lower_bound")
+                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "lower_bound")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -562,27 +577,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "model_ensemble")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "model_ensemble")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -597,17 +612,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -634,27 +649,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_cclm_4_8_17")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_cclm_4_8_17",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -669,17 +687,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -706,27 +724,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "ec_earth_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -741,17 +762,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -778,27 +799,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "ec_earth_rca4")
+                        (CoreConfParamName.CLIMATOLOGICAL_MODEL.value, "ec_earth_rca4")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -813,17 +834,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -850,27 +871,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "hadgem2_racmo22e")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "hadgem2_racmo22e",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -885,17 +909,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -922,27 +946,30 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "forecast")
+                        (CoreConfParamName.ARCHIVE.value, "forecast")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_variable", "tr")
+                        (CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, "tr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "anomaly")
+                        (CoreConfParamName.MEASURE.value, "anomaly")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("climatological_model", "mpi_esm_lr_remo2009")
+                        (
+                            CoreConfParamName.CLIMATOLOGICAL_MODEL.value,
+                            "mpi_esm_lr_remo2009",
+                        )
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -957,17 +984,17 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp26")
+                        (CoreConfParamName.SCENARIO.value, "rcp26")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp45")
+                        (CoreConfParamName.SCENARIO.value, "rcp45")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("scenario", "rcp85")
+                        (CoreConfParamName.SCENARIO.value, "rcp85")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(

--- a/arpav_ppcv/bootstrapper/coverage_configurations/historical/cdds.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/historical/cdds.py
@@ -1,3 +1,4 @@
+from ....schemas.base import CoreConfParamName
 from ....schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
@@ -40,17 +41,17 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", _ARCHIVE)
+                        (CoreConfParamName.ARCHIVE.value, _ARCHIVE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_variable", _VARIABLE)
+                        (CoreConfParamName.HISTORICAL_VARIABLE.value, _VARIABLE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -60,12 +61,12 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "all_year")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -86,27 +87,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", _ARCHIVE)
+                        (CoreConfParamName.ARCHIVE.value, _ARCHIVE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_variable", _VARIABLE)
+                        (CoreConfParamName.HISTORICAL_VARIABLE.value, _VARIABLE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "all_year")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],

--- a/arpav_ppcv/bootstrapper/coverage_configurations/historical/fd.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/historical/fd.py
@@ -1,4 +1,7 @@
-from ....schemas.base import ObservationAggregationType
+from ....schemas.base import (
+    CoreConfParamName,
+    ObservationAggregationType,
+)
 from ....schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
@@ -38,17 +41,17 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", _ARCHIVE)
+                        (CoreConfParamName.ARCHIVE.value, _ARCHIVE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_variable", _VARIABLE)
+                        (CoreConfParamName.HISTORICAL_VARIABLE.value, _VARIABLE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -58,12 +61,12 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "all_year")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -85,27 +88,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", _ARCHIVE)
+                        (CoreConfParamName.ARCHIVE.value, _ARCHIVE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_variable", _VARIABLE)
+                        (CoreConfParamName.HISTORICAL_VARIABLE.value, _VARIABLE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "all_year")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],

--- a/arpav_ppcv/bootstrapper/coverage_configurations/historical/hdds.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/historical/hdds.py
@@ -1,3 +1,4 @@
+from ....schemas.base import CoreConfParamName
 from ....schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
@@ -40,17 +41,17 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", _ARCHIVE)
+                        (CoreConfParamName.ARCHIVE.value, _ARCHIVE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_variable", _VARIABLE)
+                        (CoreConfParamName.HISTORICAL_VARIABLE.value, _VARIABLE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -60,12 +61,12 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "all_year")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -86,27 +87,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", _ARCHIVE)
+                        (CoreConfParamName.ARCHIVE.value, _ARCHIVE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_variable", _VARIABLE)
+                        (CoreConfParamName.HISTORICAL_VARIABLE.value, _VARIABLE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "all_year")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],

--- a/arpav_ppcv/bootstrapper/coverage_configurations/historical/prcptot.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/historical/prcptot.py
@@ -1,4 +1,7 @@
-from ....schemas.base import ObservationAggregationType
+from ....schemas.base import (
+    CoreConfParamName,
+    ObservationAggregationType,
+)
 from ....schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
@@ -36,17 +39,17 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", _ARCHIVE)
+                        (CoreConfParamName.ARCHIVE.value, _ARCHIVE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_variable", _VARIABLE)
+                        (CoreConfParamName.HISTORICAL_VARIABLE.value, _VARIABLE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -56,92 +59,92 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "all_year")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "winter")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "winter")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "spring")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "spring")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "summer")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "summer")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "autumn")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "autumn")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "january")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "january")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "february")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "february")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "march")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "march")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "april")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "april")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "may")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "may")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "june")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "june")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "july")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "july")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "august")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "august")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "september")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "september")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "october")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "october")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "november")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "november")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "december")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "december")
                     ].id
                 ),
             ],
@@ -162,27 +165,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", _ARCHIVE)
+                        (CoreConfParamName.ARCHIVE.value, _ARCHIVE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_variable", _VARIABLE)
+                        (CoreConfParamName.HISTORICAL_VARIABLE.value, _VARIABLE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "all_year")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -209,42 +212,42 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", _ARCHIVE)
+                        (CoreConfParamName.ARCHIVE.value, _ARCHIVE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_variable", _VARIABLE)
+                        (CoreConfParamName.HISTORICAL_VARIABLE.value, _VARIABLE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "winter")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "winter")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "spring")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "spring")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "summer")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "summer")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "autumn")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "autumn")
                     ].id
                 ),
             ],
@@ -271,82 +274,82 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", _ARCHIVE)
+                        (CoreConfParamName.ARCHIVE.value, _ARCHIVE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_variable", _VARIABLE)
+                        (CoreConfParamName.HISTORICAL_VARIABLE.value, _VARIABLE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "january")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "january")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "february")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "february")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "march")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "march")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "april")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "april")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "may")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "may")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "june")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "june")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "july")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "july")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "august")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "august")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "september")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "september")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "october")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "october")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "november")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "november")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "december")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "december")
                     ].id
                 ),
             ],

--- a/arpav_ppcv/bootstrapper/coverage_configurations/historical/su30.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/historical/su30.py
@@ -1,4 +1,7 @@
-from ....schemas.base import ObservationAggregationType
+from ....schemas.base import (
+    CoreConfParamName,
+    ObservationAggregationType,
+)
 from ....schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
@@ -38,17 +41,17 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", _ARCHIVE)
+                        (CoreConfParamName.ARCHIVE.value, _ARCHIVE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_variable", _VARIABLE)
+                        (CoreConfParamName.HISTORICAL_VARIABLE.value, _VARIABLE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -58,12 +61,12 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "all_year")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -85,27 +88,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", _ARCHIVE)
+                        (CoreConfParamName.ARCHIVE.value, _ARCHIVE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_variable", _VARIABLE)
+                        (CoreConfParamName.HISTORICAL_VARIABLE.value, _VARIABLE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "all_year")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],

--- a/arpav_ppcv/bootstrapper/coverage_configurations/historical/tdd.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/historical/tdd.py
@@ -1,4 +1,7 @@
-from ....schemas.base import ObservationAggregationType
+from ....schemas.base import (
+    CoreConfParamName,
+    ObservationAggregationType,
+)
 from ....schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
@@ -36,17 +39,17 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", _ARCHIVE)
+                        (CoreConfParamName.ARCHIVE.value, _ARCHIVE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_variable", _VARIABLE)
+                        (CoreConfParamName.HISTORICAL_VARIABLE.value, _VARIABLE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -56,92 +59,92 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "all_year")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "winter")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "winter")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "spring")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "spring")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "summer")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "summer")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "autumn")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "autumn")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "january")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "january")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "february")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "february")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "march")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "march")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "april")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "april")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "may")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "may")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "june")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "june")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "july")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "july")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "august")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "august")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "september")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "september")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "october")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "october")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "november")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "november")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "december")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "december")
                     ].id
                 ),
             ],
@@ -162,27 +165,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", _ARCHIVE)
+                        (CoreConfParamName.ARCHIVE.value, _ARCHIVE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_variable", _VARIABLE)
+                        (CoreConfParamName.HISTORICAL_VARIABLE.value, _VARIABLE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "all_year")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -209,42 +212,42 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", _ARCHIVE)
+                        (CoreConfParamName.ARCHIVE.value, _ARCHIVE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_variable", _VARIABLE)
+                        (CoreConfParamName.HISTORICAL_VARIABLE.value, _VARIABLE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "winter")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "winter")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "spring")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "spring")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "summer")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "summer")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "autumn")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "autumn")
                     ].id
                 ),
             ],
@@ -271,82 +274,82 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", _ARCHIVE)
+                        (CoreConfParamName.ARCHIVE.value, _ARCHIVE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_variable", _VARIABLE)
+                        (CoreConfParamName.HISTORICAL_VARIABLE.value, _VARIABLE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "january")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "january")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "february")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "february")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "march")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "march")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "april")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "april")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "may")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "may")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "june")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "june")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "july")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "july")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "august")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "august")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "september")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "september")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "october")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "october")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "november")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "november")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "december")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "december")
                     ].id
                 ),
             ],
@@ -373,12 +376,12 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", "barometro_climatico")
+                        (CoreConfParamName.ARCHIVE.value, "barometro_climatico")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_variable", _VARIABLE)
+                        (CoreConfParamName.HISTORICAL_VARIABLE.value, _VARIABLE)
                     ].id
                 ),
             ],

--- a/arpav_ppcv/bootstrapper/coverage_configurations/historical/tnd.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/historical/tnd.py
@@ -1,4 +1,7 @@
-from ....schemas.base import ObservationAggregationType
+from ....schemas.base import (
+    CoreConfParamName,
+    ObservationAggregationType,
+)
 from ....schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
@@ -36,17 +39,17 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", _ARCHIVE)
+                        (CoreConfParamName.ARCHIVE.value, _ARCHIVE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_variable", _VARIABLE)
+                        (CoreConfParamName.HISTORICAL_VARIABLE.value, _VARIABLE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -56,92 +59,92 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "all_year")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "winter")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "winter")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "spring")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "spring")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "summer")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "summer")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "autumn")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "autumn")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "january")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "january")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "february")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "february")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "march")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "march")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "april")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "april")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "may")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "may")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "june")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "june")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "july")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "july")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "august")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "august")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "september")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "september")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "october")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "october")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "november")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "november")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "december")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "december")
                     ].id
                 ),
             ],
@@ -162,27 +165,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", _ARCHIVE)
+                        (CoreConfParamName.ARCHIVE.value, _ARCHIVE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_variable", _VARIABLE)
+                        (CoreConfParamName.HISTORICAL_VARIABLE.value, _VARIABLE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "all_year")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -209,42 +212,42 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", _ARCHIVE)
+                        (CoreConfParamName.ARCHIVE.value, _ARCHIVE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_variable", _VARIABLE)
+                        (CoreConfParamName.HISTORICAL_VARIABLE.value, _VARIABLE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "winter")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "winter")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "spring")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "spring")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "summer")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "summer")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "autumn")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "autumn")
                     ].id
                 ),
             ],
@@ -271,77 +274,77 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", _ARCHIVE)
+                        (CoreConfParamName.ARCHIVE.value, _ARCHIVE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_variable", _VARIABLE)
+                        (CoreConfParamName.HISTORICAL_VARIABLE.value, _VARIABLE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "february")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "february")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "march")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "march")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "april")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "april")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "may")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "may")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "june")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "june")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "july")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "july")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "august")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "august")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "september")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "september")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "october")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "october")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "november")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "november")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "december")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "december")
                     ].id
                 ),
             ],

--- a/arpav_ppcv/bootstrapper/coverage_configurations/historical/tr.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/historical/tr.py
@@ -1,4 +1,7 @@
-from ....schemas.base import ObservationAggregationType
+from ....schemas.base import (
+    CoreConfParamName,
+    ObservationAggregationType,
+)
 from ....schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
@@ -36,17 +39,17 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", _ARCHIVE)
+                        (CoreConfParamName.ARCHIVE.value, _ARCHIVE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_variable", _VARIABLE)
+                        (CoreConfParamName.HISTORICAL_VARIABLE.value, _VARIABLE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -56,12 +59,12 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "all_year")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -82,27 +85,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", _ARCHIVE)
+                        (CoreConfParamName.ARCHIVE.value, _ARCHIVE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_variable", _VARIABLE)
+                        (CoreConfParamName.HISTORICAL_VARIABLE.value, _VARIABLE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "all_year")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],

--- a/arpav_ppcv/bootstrapper/coverage_configurations/historical/txd.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/historical/txd.py
@@ -1,4 +1,7 @@
-from ....schemas.base import ObservationAggregationType
+from ....schemas.base import (
+    CoreConfParamName,
+    ObservationAggregationType,
+)
 from ....schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
@@ -36,17 +39,17 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", _ARCHIVE)
+                        (CoreConfParamName.ARCHIVE.value, _ARCHIVE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_variable", _VARIABLE)
+                        (CoreConfParamName.HISTORICAL_VARIABLE.value, _VARIABLE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "30yr")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "30yr")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
@@ -56,92 +59,92 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "all_year")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "winter")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "winter")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "spring")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "spring")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "summer")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "summer")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "autumn")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "autumn")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "january")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "january")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "february")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "february")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "march")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "march")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "april")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "april")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "may")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "may")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "june")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "june")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "july")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "july")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "august")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "august")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "september")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "september")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "october")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "october")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "november")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "november")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "december")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "december")
                     ].id
                 ),
             ],
@@ -162,27 +165,27 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", _ARCHIVE)
+                        (CoreConfParamName.ARCHIVE.value, _ARCHIVE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_variable", _VARIABLE)
+                        (CoreConfParamName.HISTORICAL_VARIABLE.value, _VARIABLE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "all_year")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "all_year")
                     ].id
                 ),
             ],
@@ -209,42 +212,42 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", _ARCHIVE)
+                        (CoreConfParamName.ARCHIVE.value, _ARCHIVE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_variable", _VARIABLE)
+                        (CoreConfParamName.HISTORICAL_VARIABLE.value, _VARIABLE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "winter")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "winter")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "spring")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "spring")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "summer")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "summer")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "autumn")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "autumn")
                     ].id
                 ),
             ],
@@ -271,82 +274,82 @@ def generate_configurations(
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("archive", _ARCHIVE)
+                        (CoreConfParamName.ARCHIVE.value, _ARCHIVE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_variable", _VARIABLE)
+                        (CoreConfParamName.HISTORICAL_VARIABLE.value, _VARIABLE)
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("aggregation_period", "annual")
+                        (CoreConfParamName.AGGREGATION_PERIOD.value, "annual")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("measure", "absolute")
+                        (CoreConfParamName.MEASURE.value, "absolute")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "january")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "january")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "february")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "february")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "march")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "march")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "april")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "april")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "may")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "may")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "june")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "june")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "july")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "july")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "august")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "august")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "september")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "september")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "october")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "october")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "november")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "november")
                     ].id
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        ("historical_year_period", "december")
+                        (CoreConfParamName.HISTORICAL_YEAR_PERIOD.value, "december")
                     ].id
                 ),
             ],

--- a/arpav_ppcv/database.py
+++ b/arpav_ppcv/database.py
@@ -1461,7 +1461,7 @@ def ensure_uncertainty_type_configuration_parameters_exist(
     we must ensure it and its respective values exist. This can happen if an admin
     user deletes them by accident.
     """
-    param_name = "uncertainty_type"
+    param_name = base.CoreConfParamName.UNCERTAINTY_TYPE.value
     lower_bound_name = "lower_bound"
     upper_bound_name = "upper_bound"
     param = get_configuration_parameter_by_name(session, param_name)

--- a/arpav_ppcv/operations.py
+++ b/arpav_ppcv/operations.py
@@ -939,7 +939,7 @@ def get_historical_variable_parameters(
 ) -> dict[str, coverages.HistoricalVariableMenuTree]:
     result = {}
     historical_filter = database.get_configuration_parameter_value_by_names(
-        session, "archive", "historical"
+        session, base.CoreConfParamName.ARCHIVE.value, "historical"
     )
     relevant_cov_confs = database.collect_all_coverage_configurations(
         session, configuration_parameter_values_filter=[historical_filter]
@@ -949,7 +949,7 @@ def get_historical_variable_parameters(
             pv
             for pv in cov_conf.possible_values
             if pv.configuration_parameter_value.configuration_parameter.name
-            == "historical_variable"
+            == base.CoreConfParamName.HISTORICAL_VARIABLE.value
         ]
         if (num_pvs := len(variable_pvs)) >= 1:
             variable_pv = variable_pvs[0]
@@ -969,7 +969,7 @@ def get_historical_variable_parameters(
             pv
             for pv in cov_conf.possible_values
             if pv.configuration_parameter_value.configuration_parameter.name
-            == "aggregation_period"
+            == base.CoreConfParamName.AGGREGATION_PERIOD.value
         ]
         if (num_aggreg_periods := len(aggreg_period_pvs)) >= 1:
             aggreg_period_pv = aggreg_period_pvs[0]
@@ -993,16 +993,16 @@ def get_historical_variable_parameters(
         )
         aggregated_variable = result.setdefault(result_key, {})
         aggregated_variable[
-            "historical_variable"
+            base.CoreConfParamName.HISTORICAL_VARIABLE.value
         ] = variable_pv.configuration_parameter_value
         aggregated_variable[
-            "aggregation_period"
+            base.CoreConfParamName.AGGREGATION_PERIOD.value
         ] = aggreg_period_pv.configuration_parameter_value
         combinations = aggregated_variable.setdefault("combinations", {})
         params_to_ignore = (
-            "climatological_variable",
-            "aggregation_period",
-            "uncertainty_type",
+            base.CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value,
+            base.CoreConfParamName.AGGREGATION_PERIOD.value,
+            base.CoreConfParamName.UNCERTAINTY_TYPE.value,
         )
         for pv in cov_conf.possible_values:
             param_name = pv.configuration_parameter_value.configuration_parameter.name
@@ -1023,7 +1023,7 @@ def get_forecast_variable_parameters(
 ) -> dict[str, coverages.ForecastVariableMenuTree]:
     result = {}
     forecast_filter = database.get_configuration_parameter_value_by_names(
-        session, "archive", "forecast"
+        session, base.CoreConfParamName.ARCHIVE.value, "forecast"
     )
     relevant_cov_confs = database.collect_all_coverage_configurations(
         session, configuration_parameter_values_filter=[forecast_filter]
@@ -1033,7 +1033,7 @@ def get_forecast_variable_parameters(
             pv
             for pv in cov_conf.possible_values
             if pv.configuration_parameter_value.configuration_parameter.name
-            == "climatological_variable"
+            == base.CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value
         ]
         if (num_pvs := len(variable_pvs)) >= 1:
             variable_pv = variable_pvs[0]
@@ -1054,7 +1054,7 @@ def get_forecast_variable_parameters(
             pv
             for pv in cov_conf.possible_values
             if pv.configuration_parameter_value.configuration_parameter.name
-            == "aggregation_period"
+            == base.CoreConfParamName.AGGREGATION_PERIOD.value
         ]
         if (num_aggreg_periods := len(aggreg_period_pvs)) >= 1:
             aggreg_period_pv = aggreg_period_pvs[0]
@@ -1075,7 +1075,7 @@ def get_forecast_variable_parameters(
             pv
             for pv in cov_conf.possible_values
             if pv.configuration_parameter_value.configuration_parameter.name
-            == "measure"
+            == base.CoreConfParamName.MEASURE.value
         ]
         if (num_measures := len(measure_pvs)) >= 1:
             measure_pv = measure_pvs[0]
@@ -1101,18 +1101,20 @@ def get_forecast_variable_parameters(
         )
         aggregated_variable = result.setdefault(result_key, {})
         aggregated_variable[
-            "climatological_variable"
+            base.CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value
         ] = variable_pv.configuration_parameter_value
         aggregated_variable[
-            "aggregation_period"
+            base.CoreConfParamName.AGGREGATION_PERIOD.value
         ] = aggreg_period_pv.configuration_parameter_value
-        aggregated_variable["measure"] = measure_pv.configuration_parameter_value
+        aggregated_variable[
+            base.CoreConfParamName.MEASURE.value
+        ] = measure_pv.configuration_parameter_value
         combinations = aggregated_variable.setdefault("combinations", {})
         params_to_ignore = (
-            "climatological_variable",
-            "aggregation_period",
-            "measure",
-            "uncertainty_type",
+            base.CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value,
+            base.CoreConfParamName.AGGREGATION_PERIOD.value,
+            base.CoreConfParamName.MEASURE.value,
+            base.CoreConfParamName.UNCERTAINTY_TYPE.value,
         )
         for pv in cov_conf.possible_values:
             param_name = pv.configuration_parameter_value.configuration_parameter.name

--- a/arpav_ppcv/schemas/base.py
+++ b/arpav_ppcv/schemas/base.py
@@ -20,9 +20,11 @@ class CoreConfParamName(enum.Enum):
     CLIMATOLOGICAL_MODEL = "climatological_model"
     CLIMATOLOGICAL_VARIABLE = "climatological_variable"
     HISTORICAL_VARIABLE = "historical_variable"
+    HISTORICAL_YEAR_PERIOD = "historical_year_period"
     MEASURE = "measure"
     SCENARIO = "scenario"
     UNCERTAINTY_TYPE = "uncertainty_type"
+    YEAR_PERIOD = "year_period"
 
 
 class Season(enum.Enum):

--- a/arpav_ppcv/schemas/coverages.py
+++ b/arpav_ppcv/schemas/coverages.py
@@ -286,7 +286,7 @@ class CoverageConfiguration(sqlmodel.SQLModel, table=True):
         for pv in self.possible_values:
             if (
                 pv.configuration_parameter_value.configuration_parameter.name
-                == "archive"
+                == base.CoreConfParamName.ARCHIVE.value
             ):
                 result = pv.configuration_parameter_value.name
                 break
@@ -391,8 +391,8 @@ class CoverageConfiguration(sqlmodel.SQLModel, table=True):
             is_temporal_aggregation = (
                 used_value.configuration_parameter_value.configuration_parameter.name
                 in (
-                    "year_period",
-                    "historical_year_period",
+                    base.CoreConfParamName.YEAR_PERIOD.value,
+                    base.CoreConfParamName.HISTORICAL_YEAR_PERIOD.value,
                 )
             )
             if is_temporal_aggregation:

--- a/arpav_ppcv/thredds/utils.py
+++ b/arpav_ppcv/thredds/utils.py
@@ -3,6 +3,7 @@ import logging
 import httpx
 
 from . import models
+from ..schemas.base import CoreConfParamName
 
 logger = logging.getLogger(__name__)
 
@@ -22,9 +23,9 @@ def build_dataset_service_url(
 
 
 def get_parameter_internal_value(name: str, value: str) -> str:
-    if name == "scenario":
+    if name == CoreConfParamName.SCENARIO.value:
         parsed_value = models.ForecastScenario[value.upper()].value.code
-    elif name == "year_period":
+    elif name == CoreConfParamName.YEAR_PERIOD.value:
         parsed_value = models.ForecastYearPeriod[value.upper()].value.code
     else:
         parsed_value = value

--- a/arpav_ppcv/webapp/api_v2/routers/coverages.py
+++ b/arpav_ppcv/webapp/api_v2/routers/coverages.py
@@ -36,6 +36,7 @@ from ....thredds import (
     utils as thredds_utils,
 )
 from ....schemas.base import (
+    CoreConfParamName,
     CoverageDataSmoothingStrategy,
     ObservationDataSmoothingStrategy,
 )
@@ -387,7 +388,7 @@ def list_forecast_data_download_links(
     for v in climatological_variable or []:
         if (
             conf_param_value := db.get_configuration_parameter_value_by_names(
-                db_session, "climatological_variable", v
+                db_session, CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value, v
             )
         ) is not None:
             valid_variables.append(conf_param_value)
@@ -396,13 +397,13 @@ def list_forecast_data_download_links(
     else:
         if len(valid_variables) == 0:
             valid_variables = db.get_configuration_parameter_by_name(
-                db_session, "climatological_variable"
+                db_session, CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value
             ).allowed_values
     valid_aggregation_periods = []
     for a in aggregation_period or []:
         if (
             conf_param_value := db.get_configuration_parameter_value_by_names(
-                db_session, "aggregation_period", a
+                db_session, CoreConfParamName.AGGREGATION_PERIOD.value, a
             )
         ) is not None:
             valid_aggregation_periods.append(conf_param_value)
@@ -411,13 +412,13 @@ def list_forecast_data_download_links(
     else:
         if len(valid_aggregation_periods) == 0:
             valid_aggregation_periods = db.get_configuration_parameter_by_name(
-                db_session, "aggregation_period"
+                db_session, CoreConfParamName.AGGREGATION_PERIOD.value
             ).allowed_values
     valid_climatological_models = []
     for m in climatological_model or []:
         if (
             conf_param_value := db.get_configuration_parameter_value_by_names(
-                db_session, "climatological_model", m
+                db_session, CoreConfParamName.CLIMATOLOGICAL_MODEL.value, m
             )
         ) is not None:
             valid_climatological_models.append(conf_param_value)
@@ -426,13 +427,13 @@ def list_forecast_data_download_links(
     else:
         if len(valid_climatological_models) == 0:
             valid_climatological_models = db.get_configuration_parameter_by_name(
-                db_session, "climatological_model"
+                db_session, CoreConfParamName.CLIMATOLOGICAL_MODEL.value
             ).allowed_values
     valid_scenarios = []
     for s in scenario or []:
         if (
             conf_param_value := db.get_configuration_parameter_value_by_names(
-                db_session, "scenario", s
+                db_session, CoreConfParamName.SCENARIO.value, s
             )
         ) is not None:
             valid_scenarios.append(conf_param_value)
@@ -441,7 +442,7 @@ def list_forecast_data_download_links(
     else:
         if len(valid_scenarios) == 0:
             valid_scenarios = db.get_configuration_parameter_by_name(
-                db_session, "scenario"
+                db_session, CoreConfParamName.SCENARIO.value
             ).allowed_values
     coverage_identifiers = []
     for combination in itertools.product(
@@ -457,7 +458,7 @@ def list_forecast_data_download_links(
         )
         param_values_filter = [
             db.get_configuration_parameter_value_by_names(
-                db_session, "archive", "forecast"
+                db_session, CoreConfParamName.ARCHIVE.value, "forecast"
             ),
             variable,
             aggregation_period,

--- a/arpav_ppcv/webapp/api_v2/schemas/coverages.py
+++ b/arpav_ppcv/webapp/api_v2/schemas/coverages.py
@@ -9,6 +9,7 @@ from ....config import (
     LOCALE_IT,
 )
 from ....schemas import coverages as app_models
+from ....schemas.base import CoreConfParamName
 from . import base
 
 
@@ -327,9 +328,13 @@ class ForecastMenuTranslations(pydantic.BaseModel):
     ):
         result = {}
         for variable_menu_tree in variable_menu_trees:
-            variable_cp = variable_menu_tree["climatological_variable"]
-            aggregation_period_cp = variable_menu_tree["aggregation_period"]
-            measure_cp = variable_menu_tree["measure"]
+            variable_cp = variable_menu_tree[
+                CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value
+            ]
+            aggregation_period_cp = variable_menu_tree[
+                CoreConfParamName.AGGREGATION_PERIOD.value
+            ]
+            measure_cp = variable_menu_tree[CoreConfParamName.MEASURE.value]
             vars = result.setdefault("variable", {})
             vars[variable_cp.name] = ConfigurationParameterMenuTranslation(
                 name={
@@ -341,7 +346,9 @@ class ForecastMenuTranslations(pydantic.BaseModel):
                     LOCALE_IT.language: variable_cp.description_italian,
                 },
             )
-            aggreg_periods = result.setdefault("aggregation_period", {})
+            aggreg_periods = result.setdefault(
+                CoreConfParamName.AGGREGATION_PERIOD.value, {}
+            )
             aggreg_periods[
                 aggregation_period_cp.name
             ] = ConfigurationParameterMenuTranslation(
@@ -354,7 +361,7 @@ class ForecastMenuTranslations(pydantic.BaseModel):
                     LOCALE_IT.language: aggregation_period_cp.description_italian,
                 },
             )
-            measures = result.setdefault("measure", {})
+            measures = result.setdefault(CoreConfParamName.MEASURE.value, {})
             measures[measure_cp.name] = ConfigurationParameterMenuTranslation(
                 name={
                     LOCALE_EN.language: measure_cp.display_name_english,
@@ -382,8 +389,8 @@ class ForecastMenuTranslations(pydantic.BaseModel):
                     )
         return cls(
             variable=result["variable"],
-            aggregation_period=result["aggregation_period"],
-            measure=result["measure"],
+            aggregation_period=result[CoreConfParamName.AGGREGATION_PERIOD.value],
+            measure=result[CoreConfParamName.MEASURE.value],
             other_parameters=result["other_parameters"],
         )
 
@@ -399,8 +406,12 @@ class HistoricalMenuTranslations(pydantic.BaseModel):
     ):
         result = {}
         for variable_menu_tree in variable_menu_trees:
-            variable_cp = variable_menu_tree["historical_variable"]
-            aggregation_period_cp = variable_menu_tree["aggregation_period"]
+            variable_cp = variable_menu_tree[
+                CoreConfParamName.HISTORICAL_VARIABLE.value
+            ]
+            aggregation_period_cp = variable_menu_tree[
+                CoreConfParamName.AGGREGATION_PERIOD.value
+            ]
             vars = result.setdefault("variable", {})
             vars[variable_cp.name] = ConfigurationParameterMenuTranslation(
                 name={
@@ -412,7 +423,9 @@ class HistoricalMenuTranslations(pydantic.BaseModel):
                     LOCALE_IT.language: variable_cp.description_italian,
                 },
             )
-            aggreg_periods = result.setdefault("aggregation_period", {})
+            aggreg_periods = result.setdefault(
+                CoreConfParamName.AGGREGATION_PERIOD.value, {}
+            )
             aggreg_periods[
                 aggregation_period_cp.name
             ] = ConfigurationParameterMenuTranslation(
@@ -442,7 +455,7 @@ class HistoricalMenuTranslations(pydantic.BaseModel):
                     )
         return cls(
             variable=result["variable"],
-            aggregation_period=result["aggregation_period"],
+            aggregation_period=result[CoreConfParamName.AGGREGATION_PERIOD.value],
             other_parameters=result["other_parameters"],
         )
 
@@ -462,9 +475,11 @@ class ForecastVariableCombinations(pydantic.BaseModel):
                 combinations[param_name].append(valid_value.name)
 
         return cls(
-            variable=menu_tree["climatological_variable"].name,
-            aggregation_period=menu_tree["aggregation_period"].name,
-            measure=menu_tree["measure"].name,
+            variable=menu_tree[CoreConfParamName.CLIMATOLOGICAL_VARIABLE.value].name,
+            aggregation_period=menu_tree[
+                CoreConfParamName.AGGREGATION_PERIOD.value
+            ].name,
+            measure=menu_tree[CoreConfParamName.MEASURE.value].name,
             other_parameters=combinations,
         )
 
@@ -483,8 +498,10 @@ class HistoricalVariableCombinations(pydantic.BaseModel):
                 combinations[param_name].append(valid_value.name)
 
         return cls(
-            variable=menu_tree["historical_variable"].name,
-            aggregation_period=menu_tree["aggregation_period"].name,
+            variable=menu_tree[CoreConfParamName.HISTORICAL_VARIABLE.value].name,
+            aggregation_period=menu_tree[
+                CoreConfParamName.AGGREGATION_PERIOD.value
+            ].name,
             other_parameters=combinations,
         )
 


### PR DESCRIPTION
This PR replaces mentions of core configuration parameter names by their corresponding enum value. This is to help with system maintainability and allowing easier track of core conf param usage throughout the codebase.

For example, mentions of `"scenario"` got refactored to `CoreConfParamName.SCENARIO.value`.