### PR TITLE
Removed incorrect bootstrap configurations for tasmin and fd

### DIFF
--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/fd.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/fd.py
@@ -566,7 +566,7 @@ def generate_configurations(
             description_english=_DESCRIPTION_ENGLISH,
             description_italian=_DESCRIPTION_ITALIAN,
             netcdf_main_dataset_name="fd",
-            wms_main_layer_name="fd_uncertainty_group",
+            wms_main_layer_name="fd-uncertainty_group",
             wms_secondary_layer_name="fd",
             thredds_url_pattern="ensembletwbc/std/clipped/ecafdan_0_avgagree_{time_window}_{scenario}_ls_VFVG.nc",
             unit_english="days",

--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/tasmin.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/tasmin.py
@@ -1247,11 +1247,6 @@ def generate_configurations(
                 ),
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
-                        (CoreConfParamName.UNCERTAINTY_TYPE.value, "lower_bound")
-                    ].id
-                ),
-                ConfigurationParameterPossibleValueCreate(
-                    configuration_parameter_value_id=conf_param_values[
                         ("time_window", "tw1")
                     ].id
                 ),


### PR DESCRIPTION
This PR has a fix for some invalid coverage configurations, namely for the `TASMIN` and `FD` forecast datasets.

Since the fix is just with bootstrap configurations, I already applied it to the staging env, as seen in my comment here:

https://github.com/geobeyond/Arpav-PPCV-backend/issues/273#issuecomment-2411527885

---

- fixes #273