### PR TITLE
Added bootstrap config for cdds and hdds related to observations

### DIFF
--- a/arpav_ppcv/bootstrapper/cliapp.py
+++ b/arpav_ppcv/bootstrapper/cliapp.py
@@ -205,13 +205,13 @@ def bootstrap_coverage_configurations(
         cdd_forecast.generate_configurations(conf_param_values)
     )
     coverage_configurations.extend(
-        cdds_forecast.generate_configurations(conf_param_values)
+        cdds_forecast.generate_configurations(conf_param_values, variables)
     )
     coverage_configurations.extend(
         fd_forecast.generate_configurations(conf_param_values, variables)
     )
     coverage_configurations.extend(
-        hdds_forecast.generate_configurations(conf_param_values)
+        hdds_forecast.generate_configurations(conf_param_values, variables)
     )
     coverage_configurations.extend(
         hwdi_forecast.generate_configurations(conf_param_values)

--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/cdds.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/cdds.py
@@ -1,4 +1,7 @@
-from ....schemas.base import CoreConfParamName
+from ....schemas.base import (
+    CoreConfParamName,
+    ObservationAggregationType,
+)
 from ....schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
@@ -18,6 +21,7 @@ _DESCRIPTION_ITALIAN = (
 
 def generate_configurations(
     conf_param_values,
+    variables,
 ) -> list[CoverageConfigurationCreate]:
     return [
         CoverageConfigurationCreate(
@@ -80,6 +84,10 @@ def generate_configurations(
                     ].id
                 ),
             ],
+            observation_variable_id=(
+                v.id if (v := variables.get("CDD_jrc")) is not None else None
+            ),
+            observation_variable_aggregation_type=ObservationAggregationType.YEARLY,
         ),
         CoverageConfigurationCreate(
             name="cdds_annual_absolute_model_ec_earth_cclm4_8_17",
@@ -530,7 +538,6 @@ def generate_configurations(
                 ),
             ],
         ),
-        # ---
         CoverageConfigurationCreate(
             name="cdds_30yr_anomaly_annual_agree_model_ensemble",
             display_name_english=_DISPLAY_NAME_ENGLISH,

--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/hdds.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/hdds.py
@@ -1,4 +1,7 @@
-from ....schemas.base import CoreConfParamName
+from ....schemas.base import (
+    CoreConfParamName,
+    ObservationAggregationType,
+)
 from ....schemas.coverages import (
     CoverageConfigurationCreate,
     ConfigurationParameterPossibleValueCreate,
@@ -18,6 +21,7 @@ _DESCRIPTION_ITALIAN = (
 
 def generate_configurations(
     conf_param_values,
+    variables,
 ) -> list[CoverageConfigurationCreate]:
     return [
         CoverageConfigurationCreate(
@@ -80,6 +84,10 @@ def generate_configurations(
                     ].id
                 ),
             ],
+            observation_variable_id=(
+                v.id if (v := variables.get("HDD_it")) is not None else None
+            ),
+            observation_variable_aggregation_type=ObservationAggregationType.YEARLY,
         ),
         CoverageConfigurationCreate(
             name="hdds_annual_absolute_model_ec_earth_cclm4_8_17",

--- a/arpav_ppcv/bootstrapper/variables.py
+++ b/arpav_ppcv/bootstrapper/variables.py
@@ -4,6 +4,28 @@ from ..schemas.observations import VariableCreate
 def generate_variable_configurations() -> list[VariableCreate]:
     return [
         VariableCreate(
+            name="HDD_it",
+            display_name_english="Heating degree days",
+            display_name_italian="Gradi giorno di riscaldamento",
+            description_english=("Heating degree days, with Tbase 20 °C for Tavg"),
+            description_italian=(
+                "Gradi giorno di riscaldamento, con Tbase 20 °C per Tavg"
+            ),
+            unit_english="ºC",
+        ),
+        VariableCreate(
+            name="CDD_jrc",
+            display_name_english="Cooling degree days",
+            display_name_italian="Gradi giorno di raffrescamento",
+            description_english=(
+                "Cooling degree days, with Tbase 21 °C and threshold 24 °C for Tavg"
+            ),
+            description_italian=(
+                "Gradi giorno di raffrescamento, con Tbase 21 °C e soglia 24 °C per Tavg"
+            ),
+            unit_english="ºC",
+        ),
+        VariableCreate(
             name="TDd",
             display_name_english="Mean temperature (from observation station)",
             display_name_italian="Temperatura media (dalla stazione di osservazione)",


### PR DESCRIPTION
This PR adds the relevant configuration to the bootstrap scripts in order to create the `HDD_it` and `CDD_jrc` variables, which are then used to get the related observation data from the third-party stations API and subsequently to show the measurements in our time-series API endpoints.

These two new observation variables are also related to their respective forecast variables:

- `CDD_jrc` -> `CDDS`
- `HDD_it` -> `HDDS`

---

- fixes #276