### PR TITLE
Generate DB views for stationssegregated by observation variable

### DIFF
--- a/arpav_ppcv/bootstrapper/cliapp.py
+++ b/arpav_ppcv/bootstrapper/cliapp.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from typing import Annotated
 
 import geojson_pydantic
 import sqlmodel
@@ -8,6 +9,7 @@ from rich import print
 from sqlalchemy.exc import IntegrityError
 
 from .. import database
+from ..prefect.flows import observations as observations_flows
 from ..schemas import (
     municipalities,
 )
@@ -140,6 +142,23 @@ def bootstrap_municipality_centroids(
         session.execute(create_view_statement)
         session.execute(create_index_statement)
         session.commit()
+    print("Done!")
+
+
+@app.command("station-variables")
+def bootstrap_station_variables(
+    variable: Annotated[
+        str,
+        typer.Option(
+            help=(
+                "Name of the variable to process. If not provided, all "
+                "variables are processed."
+            )
+        ),
+    ] = None,
+):
+    """Refresh views with stations that have values for each variable."""
+    observations_flows.refresh_station_variables(variable_name=variable)
     print("Done!")
 
 

--- a/arpav_ppcv/config.py
+++ b/arpav_ppcv/config.py
@@ -38,6 +38,9 @@ class PrefectSettings(pydantic.BaseModel):
     observation_yearly_measurements_refresher_flow_cron_schedule: str = (
         "0 4 * * 1"  # run once every week, at 04:00 on monday
     )
+    station_variables_refresher_flow_cron_schedule: str = (
+        "0 5 * * 1"  # run once every week, at 05:00 on monday
+    )
 
 
 class ThreddsServerSettings(pydantic.BaseModel):
@@ -125,6 +128,7 @@ class ArpavPpcvSettings(BaseSettings):  # noqa
     cors_methods: list[str] = []
     allow_cors_credentials: bool = False
     coverage_download_settings: CoverageDownloadSettings = CoverageDownloadSettings()
+    variable_stations_db_schema: str = "stations"
 
     @pydantic.model_validator(mode="after")
     def ensure_test_db_dsn(self):

--- a/arpav_ppcv/prefect/cliapp.py
+++ b/arpav_ppcv/prefect/cliapp.py
@@ -14,6 +14,7 @@ def start_periodic_tasks(
     refresh_monthly_measurements: bool = False,
     refresh_seasonal_measurements: bool = False,
     refresh_yearly_measurements: bool = False,
+    refresh_station_variables: bool = False,
 ):
     """Starts a prefect worker to perform background tasks.
 
@@ -24,6 +25,8 @@ def start_periodic_tasks(
     - refreshing observation monthly measurements for known stations
     - refreshing observation seasonal measurements for known stations
     - refreshing observation yearly measurements for known stations
+    - refreshing the database views which contain available observation stations for
+      each indicator
 
     """
     settings: ArpavPpcvSettings = ctx.obj["settings"]
@@ -54,4 +57,12 @@ def start_periodic_tasks(
             cron=settings.prefect.observation_yearly_measurements_refresher_flow_cron_schedule,
         )
         to_serve.append(yearly_measurement_refresher_deployment)
+    if refresh_station_variables:
+        station_variables_deployment = (
+            observations_flows.refresh_station_variables.to_deployment(
+                name="station_variables_refresher",
+                cron=settings.prefect.station_variables_refresher_flow_cron_schedule,
+            )
+        )
+        to_serve.append(station_variables_deployment)
     prefect.serve(*to_serve)

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -130,6 +130,7 @@ services:
       "--refresh-monthly-measurements",
       "--refresh-seasonal-measurements",
       "--refresh-yearly-measurements",
+      "--refresh-station-variables",
     ]
     depends_on:
       prefect-server:

--- a/docker/martin/config.yaml
+++ b/docker/martin/config.yaml
@@ -2,7 +2,13 @@ listen_addresses: '0.0.0.0:3000'
 cache_size_mb: 512
 postgres:
   connection_string: ${DATABASE_URL}
-  auto_publish: false
+
+  auto_publish:
+    from_schemas:
+      - stations
+    tables:
+      id_columns: id
+
   tables:
 
     stations:


### PR DESCRIPTION
This PR adds a prefect flow that will periodically build a set of DB views representing observation stations for each indicator, _i.e._ one DB view for all stations that have `TDd` measurements, another DB view for all stations with measurements for `TXd`, etc.

These DB views are then exposed as vector tile layers in the martin tile server, thus becoming available for the frontend to show/hide, depending on the currently selected variable.

---

- fixes #270