### PR TITLE
Added `data_precision` as a new property to coverage configurations

### DIFF
--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/pr.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/pr.py
@@ -11,6 +11,7 @@ _DISPLAY_NAME_ENGLISH = "Precipiation"
 _DISPLAY_NAME_ITALIAN = "Precipitazione"
 _DESCRIPTION_ENGLISH = "Daily precipitation near the ground"
 _DESCRIPTION_ITALIAN = "Precipitazioni giornaliere in prossimità del suolo"
+_DATA_PRECISION = 0
 
 
 def generate_configurations(
@@ -30,6 +31,7 @@ def generate_configurations(
             palette="default/div-BrBG",
             color_scale_min=-40,
             color_scale_max=40,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -106,6 +108,7 @@ def generate_configurations(
             palette="default/div-BrBG",
             color_scale_min=-40,
             color_scale_max=40,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -185,6 +188,7 @@ def generate_configurations(
             palette="default/div-BrBG",
             color_scale_min=-40,
             color_scale_max=40,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -264,6 +268,7 @@ def generate_configurations(
             palette="default/div-BrBG",
             color_scale_min=-40,
             color_scale_max=40,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -340,6 +345,7 @@ def generate_configurations(
             palette="default/div-BrBG",
             color_scale_min=-40,
             color_scale_max=40,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -419,6 +425,7 @@ def generate_configurations(
             palette="default/div-BrBG",
             color_scale_min=-40,
             color_scale_max=40,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -498,6 +505,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=0,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -579,6 +587,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=0,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -660,6 +669,7 @@ def generate_configurations(
             palette="default/seq-BuYl-inv",
             color_scale_min=0,
             color_scale_max=800,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -740,6 +750,7 @@ def generate_configurations(
             palette="default/seq-BuYl-inv",
             color_scale_min=0,
             color_scale_max=3200,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -805,6 +816,7 @@ def generate_configurations(
             palette="default/seq-BuYl-inv",
             color_scale_min=0,
             color_scale_max=800,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -888,6 +900,7 @@ def generate_configurations(
             palette="default/seq-BuYl-inv",
             color_scale_min=0,
             color_scale_max=800,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -956,6 +969,7 @@ def generate_configurations(
             palette="default/seq-BuYl-inv",
             color_scale_min=0,
             color_scale_max=800,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1039,6 +1053,7 @@ def generate_configurations(
             palette="default/seq-BuYl-inv",
             color_scale_min=0,
             color_scale_max=3200,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1107,6 +1122,7 @@ def generate_configurations(
             palette="default/seq-BuYl-inv",
             color_scale_min=0,
             color_scale_max=800,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1187,6 +1203,7 @@ def generate_configurations(
             palette="default/seq-BuYl-inv",
             color_scale_min=0,
             color_scale_max=3200,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1252,6 +1269,7 @@ def generate_configurations(
             palette="default/seq-BuYl-inv",
             color_scale_min=0,
             color_scale_max=800,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1335,6 +1353,7 @@ def generate_configurations(
             palette="default/seq-BuYl-inv",
             color_scale_min=0,
             color_scale_max=3200,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1403,6 +1422,7 @@ def generate_configurations(
             palette="default/seq-BuYl-inv",
             color_scale_min=0,
             color_scale_max=800,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1486,6 +1506,7 @@ def generate_configurations(
             palette="default/seq-BuYl-inv",
             color_scale_min=0,
             color_scale_max=3200,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1554,6 +1575,7 @@ def generate_configurations(
             palette="default/seq-BuYl-inv",
             color_scale_min=0,
             color_scale_max=800,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1635,6 +1657,7 @@ def generate_configurations(
             palette="default/seq-BuYl-inv",
             color_scale_min=0,
             color_scale_max=800,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1716,6 +1739,7 @@ def generate_configurations(
             palette="default/seq-BuYl-inv",
             color_scale_min=0,
             color_scale_max=3200,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1782,6 +1806,7 @@ def generate_configurations(
             palette="default/seq-BuYl-inv",
             color_scale_min=0,
             color_scale_max=3200,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1849,6 +1874,7 @@ def generate_configurations(
             palette="uncert-stippled/div-BrBG",
             color_scale_min=-40,
             color_scale_max=40,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1935,6 +1961,7 @@ def generate_configurations(
             palette="default/div-BrBG",
             color_scale_min=-40,
             color_scale_max=40,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -2024,6 +2051,7 @@ def generate_configurations(
             palette="default/div-BrBG",
             color_scale_min=-40,
             color_scale_max=40,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -2113,6 +2141,7 @@ def generate_configurations(
             palette="default/div-BrBG",
             color_scale_min=-40,
             color_scale_max=40,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -2199,6 +2228,7 @@ def generate_configurations(
             palette="default/div-BrBG",
             color_scale_min=-40,
             color_scale_max=40,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -2288,6 +2318,7 @@ def generate_configurations(
             palette="default/div-BrBG",
             color_scale_min=-40,
             color_scale_max=40,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[

--- a/arpav_ppcv/bootstrapper/coverage_configurations/historical/prcptot.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/historical/prcptot.py
@@ -16,6 +16,7 @@ _VARIABLE = "prcptot"
 _UNIT = "mm"
 _COLOR_SCALE_MIN = 300
 _COLOR_SCALE_MAX = 1300
+_DATA_PRECISION = 0
 _RELATED_OBSERVATION_VARIABLE_NAME = "PRCPTOT"
 
 
@@ -162,6 +163,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=_COLOR_SCALE_MIN,
             color_scale_max=_COLOR_SCALE_MAX,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -209,6 +211,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=_COLOR_SCALE_MIN,
             color_scale_max=_COLOR_SCALE_MAX,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -271,6 +274,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=_COLOR_SCALE_MIN,
             color_scale_max=_COLOR_SCALE_MAX,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[

--- a/arpav_ppcv/migrations/versions/4df282a0319d_added_precision_to_cov_conf.py
+++ b/arpav_ppcv/migrations/versions/4df282a0319d_added_precision_to_cov_conf.py
@@ -1,0 +1,47 @@
+"""added precision to cov conf
+
+Revision ID: 4df282a0319d
+Revises: c6f618a7f88f
+Create Date: 2024-10-16 13:39:58.363787
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+from sqlalchemy.ext.declarative import declarative_base
+
+Base = declarative_base()
+_table_name = "coverageconfiguration"
+_column_name = "data_precision"
+
+class CoverageConfiguration(Base):
+    __tablename__ = _table_name
+
+    id = sa.Column(sa.UUID, primary_key=True)
+    data_precision = sa.Column(sa.Integer, nullable=True)
+
+
+# revision identifiers, used by Alembic.
+revision: str = "4df282a0319d"
+down_revision: Union[str, None] = "c6f618a7f88f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    op.add_column(
+        _table_name,
+        sa.Column(_column_name, sa.Integer(), nullable=True)
+    )
+    session = sa.orm.Session(bind=bind)
+    for cov_conf in session.query(CoverageConfiguration):
+        cov_conf.data_precision = 3
+    session.commit()
+    op.alter_column(_table_name, _column_name, nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_column('coverageconfiguration', 'data_precision')

--- a/arpav_ppcv/schemas/coverages.py
+++ b/arpav_ppcv/schemas/coverages.py
@@ -187,6 +187,7 @@ class CoverageConfiguration(sqlmodel.SQLModel, table=True):
     palette: str
     color_scale_min: float = 0.0
     color_scale_max: float = 1.0
+    data_precision: int = 3
     observation_variable_id: Optional[uuid.UUID] = sqlmodel.Field(
         default=None, foreign_key="variable.id"
     )
@@ -444,6 +445,7 @@ class CoverageConfigurationCreate(sqlmodel.SQLModel):
     palette: str
     color_scale_min: float
     color_scale_max: float
+    data_precision: int = 3
     possible_values: list["ConfigurationParameterPossibleValueCreate"]
     observation_variable_id: Optional[uuid.UUID] = None
     observation_variable_aggregation_type: Optional[
@@ -479,6 +481,7 @@ class CoverageConfigurationUpdate(sqlmodel.SQLModel):
     palette: Optional[str] = None
     color_scale_min: Optional[float] = None
     color_scale_max: Optional[float] = None
+    data_precision: Optional[int] = None
     observation_variable_id: Optional[uuid.UUID] = None
     observation_variable_aggregation_type: Optional[
         base.ObservationAggregationType

--- a/arpav_ppcv/webapp/admin/schemas.py
+++ b/arpav_ppcv/webapp/admin/schemas.py
@@ -58,6 +58,7 @@ class CoverageConfigurationRead(sqlmodel.SQLModel):
     palette: str
     color_scale_min: float
     color_scale_max: float
+    data_precision: int
     possible_values: list[ConfigurationParameterPossibleValueRead]
     observation_variable_aggregation_type: ObservationAggregationType
     observation_variable: Optional["ObservationVariableRead"]

--- a/arpav_ppcv/webapp/admin/views/coverages.py
+++ b/arpav_ppcv/webapp/admin/views/coverages.py
@@ -358,9 +358,23 @@ class CoverageConfigurationView(ModelView):
         starlette_admin.StringField("coverage_id_pattern", disabled=True),
         starlette_admin.StringField("unit_english", required=True),
         starlette_admin.StringField("unit_italian", required=True),
-        starlette_admin.StringField("palette", required=True),
+        starlette_admin.StringField(
+            "palette",
+            required=True,
+            help_text=(
+                "Name of the palette that should used by the THREDDS WMS server. "
+                "Available values can be found at https://reading-escience-centre.gitbooks.io/ncwms-user-guide/content/04-usage.html#getmap"
+            ),
+        ),
         starlette_admin.FloatField("color_scale_min", required=True),
         starlette_admin.FloatField("color_scale_max", required=True),
+        starlette_admin.IntegerField(
+            "data_precision",
+            required=True,
+            help_text=(
+                "Number of decimal places to be used when displaying data values"
+            ),
+        ),
         fields.RelatedObservationsVariableField(
             "observation_variable",
             help_text="Related observation variable",
@@ -419,6 +433,7 @@ class CoverageConfigurationView(ModelView):
         "palette",
         "color_scale_min",
         "color_scale_max",
+        "data_precision",
         "observation_variable",
         "observation_variable_aggregation_type",
         "uncertainty_lower_bounds_coverage_configuration",
@@ -594,6 +609,7 @@ class CoverageConfigurationView(ModelView):
                 palette=data["palette"],
                 color_scale_min=data["color_scale_min"],
                 color_scale_max=data["color_scale_max"],
+                data_precision=data["data_precision"],
                 possible_values=possible_values_create,
                 observation_variable_id=(
                     related_obs_variable.id if related_obs_variable else None
@@ -678,6 +694,7 @@ class CoverageConfigurationView(ModelView):
                 palette=data.get("palette"),
                 color_scale_min=data.get("color_scale_min"),
                 color_scale_max=data.get("color_scale_max"),
+                data_precision=data.get("data_precision"),
                 possible_values=possible_values,
                 observation_variable_id=(
                     related_obs_variable.id if related_obs_variable else None

--- a/arpav_ppcv/webapp/api_v2/schemas/coverages.py
+++ b/arpav_ppcv/webapp/api_v2/schemas/coverages.py
@@ -136,6 +136,7 @@ class CoverageConfigurationReadDetail(CoverageConfigurationReadListItem):
     description_english: str | None
     description_italian: str | None
     legend: CoverageImageLegend
+    data_precision: int
 
     @classmethod
     def from_db_instance(


### PR DESCRIPTION
This PR adds a new `data_precision` property to coverage configurations. This property's purpose is to let the frontend know how many decimal places to use when displaying data values for the respective coverage configuration. 

This property can be set on a per coverage configuration basis on the admin section and is exposed as an additional property in the API at the `/api/v2/coverages/coverage-configurations/{coverage_configuration_id}` endpoint.

Image of this new property's editable form in the admin:

![image](https://github.com/user-attachments/assets/71a18da6-f094-4efa-8d12-3a072e3af949)


And as included in the API:

![image](https://github.com/user-attachments/assets/2f5de86c-b0a0-407b-b705-6b128194b0ff)


---

- fixes #278