### PR TITLE
281 bootstrap values for the data precision of coverages

### DIFF
--- a/arpav_ppcv/bootstrapper/configurationparameters.py
+++ b/arpav_ppcv/bootstrapper/configurationparameters.py
@@ -20,7 +20,7 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                     display_name_italian="Temperatura media",
                     description_english="Average of average temperatures",
                     description_italian="Media delle temperature medie",
-                    sort_order=1,
+                    sort_order=0,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="tnd",
@@ -28,7 +28,7 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                     display_name_italian="Temperatura minima",
                     description_english="Average of minimum temperatures",
                     description_italian="Media delle temperature minime",
-                    sort_order=2,
+                    sort_order=0,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="txd",
@@ -36,69 +36,69 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                     display_name_italian="Temperatura massima",
                     description_english="Average of maximum temperatures",
                     description_italian="Media delle temperature massime",
-                    sort_order=3,
+                    sort_order=0,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="tr",
-                    display_name_english="Tropical nights",
-                    display_name_italian="Notti tropicali",
+                    display_name_english="Tropical nights (TR)",
+                    display_name_italian="Notti tropicali (TR)",
                     description_english=(
-                        "Number of days with minimum temperature higher than 20°C"
+                        "Number of days with minimum temperature larger than 20°C"
                     ),
                     description_italian=(
                         "Numero di giorni con temperatura minima maggiore di 20°C"
                     ),
-                    sort_order=4,
+                    sort_order=3,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="su30",
-                    display_name_english="Hot days",
-                    display_name_italian="Giorni caldi",
+                    display_name_english="Summer days (SU30)",
+                    display_name_italian="Giorni caldi (SU30)",
                     description_english=(
-                        "Number of days with maximum temperature above 30°C"
+                        "Number of days with maximum temperature larger than 30°C"
                     ),
                     description_italian=(
                         "Numero di giorni con temperatura massima maggiore di 30°C"
                     ),
-                    sort_order=5,
+                    sort_order=4,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="fd",
-                    display_name_english="Frosty days",
-                    display_name_italian="Giorni di gelo",
+                    display_name_english="Frost days (FD)",
+                    display_name_italian="Giorni di gelo (FD)",
                     description_english=(
-                        "Number of days with minimum temperature below 0°C"
+                        "Number of days with minimum temperature less than 0°C"
                     ),
                     description_italian=(
                         "Numero di giorni con temperatura minima minore di 0°C"
                     ),
-                    sort_order=6,
+                    sort_order=5,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="hdds",
-                    display_name_english="Heating degree days",
-                    display_name_italian="Gradi giorno di riscaldamento",
+                    display_name_english="Heating degree days (HDDs)",
+                    display_name_italian="Gradi giorno di riscaldamento (HDDs)",
                     description_english=(
                         "Sum of 20°C minus the average daily temperature if the "
-                        "average daily temperature is less than 20°C."
+                        "average daily temperature is less than 20°C"
                     ),
                     description_italian=(
                         "Somma di 20°C meno la temperatura media giornaliera se la "
-                        "temperatura media giornaliera è minore di 20°C."
+                        "temperatura media giornaliera è minore di 20°C"
                     ),
                     sort_order=7,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="cdds",
-                    display_name_english="Cooling degree days",
-                    display_name_italian="Gradi giorno di raffrescamento",
+                    display_name_english="Cooling degree days (CDDs)",
+                    display_name_italian="Gradi giorno di raffrescamento (CDDs)",
                     description_english=(
-                        "Sum of the average daily temperature minus 21°C if the average "
-                        "daily temperature is greater than 24°C."
+                        "Sum of the average daily temperature minus 21°C if the "
+                        "average daily temperature is larger than 24°C"
                     ),
                     description_italian=(
                         "Somma della temperatura media giornaliera meno 21°C se la "
-                        "temperatura media giornaliera è maggiore di 24°C."
+                        "temperatura media giornaliera è maggiore di 24°C"
                     ),
                     sort_order=8,
                 ),
@@ -108,7 +108,7 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                     display_name_italian="Precipitazione",
                     description_english="Daily precipitation near the ground",
                     description_italian="Precipitazione giornaliera vicino al suolo",
-                    sort_order=9,
+                    sort_order=0,
                 ),
             ],
         ),
@@ -121,107 +121,167 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
             allowed_values=[
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="cdd",
-                    display_name_english="CDD",
-                    display_name_italian="CDD",
-                    description_english="Consecutive Dry Days",
-                    description_italian="Giorni secchi",
-                    sort_order=4,
+                    display_name_english="Consecutive dry days (CDD)",
+                    display_name_italian="Giorni secchi (CDD)",
+                    description_english=(
+                        "Maximum number of consecutive dry days (daily precipitation "
+                        "less than 1 mm)"
+                    ),
+                    description_italian=(
+                        "Numero massimo di giorni consecutivi asciutti "
+                        "(precipitazione giornaliera inferiore a 1 mm)"
+                    ),
+                    sort_order=11,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="cdds",
-                    display_name_english="CDDs",
-                    display_name_italian="CDDs",
-                    description_english="Cooling degree days",
-                    description_italian="Gradi giorno di raffrescamento",
-                    sort_order=5,
+                    display_name_english="Cooling degree days (CDDs)",
+                    display_name_italian="Gradi giorno di raffrescamento (CDDs)",
+                    description_english=(
+                        "Sum of the average daily temperature minus 21°C if the "
+                        "average daily temperature is larger than 24°C"
+                    ),
+                    description_italian=(
+                        "Somma della temperatura media giornaliera meno 21°C se la "
+                        "temperatura media giornaliera è maggiore di 24°C"
+                    ),
+                    sort_order=8,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="fd",
-                    display_name_english="FD",
-                    display_name_italian="FD",
-                    description_english="Frozen Days",
-                    description_italian="Giorni di gelo",
-                    sort_order=6,
+                    display_name_english="Frost days (FD)",
+                    display_name_italian="Giorni di gelo (FD)",
+                    description_english=(
+                        "Number of days with minimum temperature less than 0ºC"
+                    ),
+                    description_italian=(
+                        "Numero di giorni con temperatura minima minore di 0°C"
+                    ),
+                    sort_order=5,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="hdds",
-                    display_name_english="HDDs",
-                    display_name_italian="HDDs",
-                    description_english="Heating degree days",
-                    description_italian="Gradi giorno di riscaldamento",
+                    display_name_english="Heating degree days (HDDs)",
+                    display_name_italian="Gradi giorno di riscaldamento (HDDs)",
+                    description_english=(
+                        "Sum of 20°C minus the average daily temperature if the "
+                        "average daily temperature is less than 20°C"
+                    ),
+                    description_italian=(
+                        "Somma di 20°C meno la temperatura media giornaliera se la "
+                        "temperatura media giornaliera è minore di 20°C"
+                    ),
                     sort_order=7,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="hwdi",
-                    display_name_english="HWDI",
-                    display_name_italian="HWDI",
-                    description_english="Duration of heat waves",
-                    description_italian="Durata delle ondate di calore",
-                    sort_order=8,
+                    display_name_english="Heat waves duration index (HWDI)",
+                    display_name_italian="Durata delle ondate di calore (HWDI)",
+                    description_english=(
+                        "Number of days in which the maximum temperature is 5°C "
+                        "higher than the average for at least 5 consecutive days"
+                    ),
+                    description_italian=(
+                        "Numero di giorni in cui la temperatura massima è maggiore "
+                        "di 5°C rispetto alla media per  almeno 5 giorni consecutivi"
+                    ),
+                    sort_order=6,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="pr",
-                    display_name_english="PR",
-                    display_name_italian="PR",
-                    description_english="Rainfall",
-                    description_italian="Precipitazione",
+                    display_name_english="Precipitation (PR)",
+                    display_name_italian="Precipitazione (PR)",
+                    description_english="Daily precipitation near the ground",
+                    description_italian="Precipitazione giornaliera vicino al suolo",
                     sort_order=9,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="r95ptot",
-                    display_name_english="R95pTOT",
-                    display_name_italian="R95pTOT",
-                    description_english="Extreme rainfall",
-                    description_italian="Precipitazione estrema",
+                    display_name_english="Extreme precipitation (R95pTOT)",
+                    display_name_italian="Precipitazione estrema (R95pTOT)",
+                    description_english=(
+                        "Total cumulative precipitation above the 95th percentile "
+                        "with respect to the reference period"
+                    ),
+                    description_italian=(
+                        "Precipitazione totale cumulata al di sopra del 95o "
+                        "percentile del periodo di riferimento"
+                    ),
                     sort_order=10,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="snwdays",
-                    display_name_english="SNWDAYS",
-                    display_name_italian="SNWDAYS",
-                    description_english="Days with new snow",
-                    description_italian="Giorni con neve nuova",
-                    sort_order=11,
-                ),
-                ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
-                    internal_value="su30",
-                    display_name_english="SU30",
-                    display_name_italian="SU30",
-                    description_english="Hot days",
-                    description_italian="Giorni caldi",
+                    display_name_english="Snow days (SNWDAYS)",
+                    display_name_italian="Giorni con neve nuova (SNWDAYS)",
+                    description_english=(
+                        "Number of days with average temperature less than 2°C and "
+                        "daily precipitation larger than 1 mm"
+                    ),
+                    description_italian=(
+                        "Numero di giorni con temperatura media minore di 2°C e "
+                        "precipitazione giornaliera maggiore di 1 mm"
+                    ),
                     sort_order=12,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
+                    internal_value="su30",
+                    display_name_english="Summer days (SU30)",
+                    display_name_italian="Giorni caldi (SU30)",
+                    description_english=(
+                        "Number of days with maximum temperature larger than 30°C"
+                    ),
+                    description_italian=(
+                        "Numero di giorni con temperatura massima maggiore di 30°C"
+                    ),
+                    sort_order=4,
+                ),
+                ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="tas",
-                    display_name_english="TAS",
-                    display_name_italian="TAS",
-                    description_english="Mean temperature",
-                    description_italian="Temperatura media",
-                    sort_order=1,
+                    display_name_english="Mean temperature (TAS)",
+                    display_name_italian="Temperatura media (TAS)",
+                    description_english=(
+                        "Daily mean air temperature close to the ground"
+                    ),
+                    description_italian=(
+                        "Temperatura media giornaliera dell'aria vicino al suolo"
+                    ),
+                    sort_order=0,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="tasmax",
-                    display_name_english="TASMAX",
-                    display_name_italian="TASMAX",
-                    description_english="Maximum temperature",
-                    description_italian="Temperatura massima",
+                    display_name_english="Maximum temperature (TASMAX)",
+                    display_name_italian="Temperatura massima (TASMAX)",
+                    description_english=(
+                        "Daily maximum air temperature close to the ground"
+                    ),
+                    description_italian=(
+                        "Temperatura massima giornaliera dell'aria vicino al suolo"
+                    ),
                     sort_order=2,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="tasmin",
-                    display_name_english="TASMIN",
-                    display_name_italian="TASMIN",
-                    description_english="Minimum temperature",
-                    description_italian="Temperatura minima",
-                    sort_order=3,
+                    display_name_english="Minimum temperature (TASMIN)",
+                    display_name_italian="Temperatura minima (TASMIN)",
+                    description_english=(
+                        "Daily minimum air temperature close to the ground"
+                    ),
+                    description_italian=(
+                        "Temperatura minima giornaliera dell'aria vicino al suolo"
+                    ),
+                    sort_order=1,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="tr",
-                    display_name_english="TR",
-                    display_name_italian="TR",
-                    description_english="Tropical nights",
-                    description_italian="Notti tropicali",
-                    sort_order=13,
+                    display_name_english="Tropical nights (TR)",
+                    display_name_italian="Notti tropicali (TR)",
+                    description_english=(
+                        "Number of days with minimum temperature larger than 20°C"
+                    ),
+                    description_italian=(
+                        "Numero di giorni con temperatura minima maggiore di 20°C"
+                    ),
+                    sort_order=3,
                 ),
             ],
         ),
@@ -237,42 +297,28 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                     display_name_english="RCP2.6",
                     display_name_italian="RCP2.6",
                     description_english=(
-                        "Representation Concentration Pathway (RCP) scenario that "
-                        "assumes climate forcing values of 2.6 W/m2"
+                        "Strong greenhouse gas emissions mitigation scenario"
                     ),
                     description_italian=(
-                        "Scenario Representation Concentration Pathway (RCP) che "
-                        "presuppone valori di forzante climatica di 2,6 W/m2"
+                        "Scenario forte mitigazione emissioni gas serra"
                     ),
-                    sort_order=3,
+                    sort_order=0,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="rcp45",
                     display_name_english="RCP4.5",
                     display_name_italian="RCP4.5",
-                    description_english=(
-                        "Representation Concentration Pathway (RCP) scenario that "
-                        "assumes climate forcing values of 4.5 W/m2"
-                    ),
-                    description_italian=(
-                        "Scenario Representation Concentration Pathway (RCP) che "
-                        "presuppone valori di forzante climatica di 4,5 W/m2"
-                    ),
-                    sort_order=2,
+                    description_english="Stabilization scenario",
+                    description_italian="Scenario intermedio di stabilizzazione",
+                    sort_order=1,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="rcp85",
                     display_name_english="RCP8.5",
                     display_name_italian="RCP8.5",
-                    description_english=(
-                        "Representation Concentration Pathway (RCP) scenario that "
-                        "assumes climate forcing values of 8.5 W/m2"
-                    ),
-                    description_italian=(
-                        "Scenario Representation Concentration Pathway (RCP) che "
-                        "presuppone valori di forzante climatica di 8,5 W/m2"
-                    ),
-                    sort_order=1,
+                    description_english="No mitigation scenario",
+                    description_italian="Scenario nessuna mitigazione",
+                    sort_order=2,
                 ),
             ],
         ),
@@ -285,31 +331,19 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
             allowed_values=[
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="tw1",
-                    display_name_english="TW1",
-                    display_name_italian="TW1",
-                    description_english=(
-                        "Represents the first anomaly time window, which spans the "
-                        "period 2021-2050, with regard to the 1976-2005 period"
-                    ),
-                    description_italian=(
-                        "Rappresenta la prima finestra temporale di anomalia, che "
-                        "abbraccia il periodo 2021-2050, rispetto al periodo 1976-2005"
-                    ),
-                    sort_order=1,
+                    display_name_english="2021-2050",
+                    display_name_italian="2021-2050",
+                    description_english="Anomaly 2021-2050 with respect to 1976-2005",
+                    description_italian="Anomalia 2021-2050 rispetto a 1976-2005",
+                    sort_order=0,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="tw2",
-                    display_name_english="TW2",
-                    display_name_italian="TW2",
-                    description_english=(
-                        "Represents the second anomaly time window, which spans the "
-                        "period 2071-2100, with regard to the 1976-2005 period"
-                    ),
-                    description_italian=(
-                        "Rappresenta la seconda finestra temporale di anomalia, che "
-                        "abbraccia il periodo 2071-2100, rispetto al periodo 1976-2005"
-                    ),
-                    sort_order=2,
+                    display_name_english="2071-2100",
+                    display_name_italian="2071-2100",
+                    description_english="Anomaly 2071-2100 with respect to 1976-2005",
+                    description_italian="Anomalia 2071-2100 rispetto a 1976-2005",
+                    sort_order=1,
                 ),
             ],
         ),
@@ -325,61 +359,45 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                     internal_value="DJF",
                     display_name_english="Winter",
                     display_name_italian="Inverno",
-                    description_english=(
-                        "Climatological winter season (December, January, February)"
-                    ),
-                    description_italian=(
-                        "Stagione climatologica invernale (dicembre, gennaio, febbraio)"
-                    ),
-                    sort_order=1,
+                    description_english="December, January, February",
+                    description_italian="Dicembre, gennaio, febbraio",
+                    sort_order=4,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     name="spring",
                     internal_value="MAM",
                     display_name_english="Spring",
                     display_name_italian="Primavera",
-                    description_english=(
-                        "Climatological spring season (March, April, May)"
-                    ),
-                    description_italian=(
-                        "Stagione climatologica primaverile (marzo, aprile, maggio)"
-                    ),
-                    sort_order=2,
+                    description_english="March, April, May",
+                    description_italian="Marzo, aprile, maggio",
+                    sort_order=1,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     name="summer",
                     internal_value="JJA",
                     display_name_english="Summer",
                     display_name_italian="Estate",
-                    description_english=(
-                        "Climatological summer season (June, July, August)"
-                    ),
-                    description_italian=(
-                        "Stagione climatologica estiva (giugno, luglio, agosto)"
-                    ),
-                    sort_order=3,
+                    description_english="June, July, August",
+                    description_italian="Giugno, luglio, agosto",
+                    sort_order=2,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     name="autumn",
                     internal_value="SON",
                     display_name_english="Autumn",
                     display_name_italian="Autunno",
-                    description_english=(
-                        "Climatological autumn season (September, October, November)"
-                    ),
-                    description_italian=(
-                        "Stagione climatologica autunnale (settembre, ottobre, novembre)"
-                    ),
-                    sort_order=4,
+                    description_english="September, October, November",
+                    description_italian="Settembre, ottobre, novembre",
+                    sort_order=3,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="year",
                     name="all_year",
                     display_name_english="Year",
                     display_name_italian="Anno",
-                    description_english="Whole year",
-                    description_italian="L'intero anno",
-                    sort_order=5,
+                    description_english="Solar year (from January to December)",
+                    description_italian="Anno solare (da gennaio a dicembre)",
+                    sort_order=0,
                 ),
             ],
         ),
@@ -399,7 +417,7 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                     display_name_italian="Inverno",
                     description_english="Winter season",
                     description_italian="Stagione invernale",
-                    sort_order=1,
+                    sort_order=4,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="S02",
@@ -408,7 +426,7 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                     display_name_italian="Primavera",
                     description_english="Spring season",
                     description_italian="Stagione primaverile",
-                    sort_order=2,
+                    sort_order=1,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="S03",
@@ -417,7 +435,7 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                     display_name_italian="Estate",
                     description_english="Summer season",
                     description_italian="Stagione estiva",
-                    sort_order=3,
+                    sort_order=2,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="S04",
@@ -426,16 +444,16 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                     display_name_italian="Autunno",
                     description_english="Autumn season",
                     description_italian="Stagione autunnale",
-                    sort_order=4,
+                    sort_order=3,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="A00",
                     name="all_year",
                     display_name_english="Year",
                     display_name_italian="Anno",
-                    description_english="Whole year",
-                    description_italian="L'intero anno",
-                    sort_order=5,
+                    description_english="Solar year (from January to December)",
+                    description_italian="Anno solare (da gennaio a dicembre)",
+                    sort_order=0,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="M01",
@@ -444,7 +462,7 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                     display_name_italian="Gennaio",
                     description_english="Month of January",
                     description_italian="mese di gennaio",
-                    sort_order=6,
+                    sort_order=0,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="M02",
@@ -453,7 +471,7 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                     display_name_italian="Febbraio",
                     description_english="Month of february",
                     description_italian="mese di febbraio",
-                    sort_order=7,
+                    sort_order=0,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="M03",
@@ -462,7 +480,7 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                     display_name_italian="Marzo",
                     description_english="Month of march",
                     description_italian="mese di marzo",
-                    sort_order=8,
+                    sort_order=0,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="M04",
@@ -471,7 +489,7 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                     display_name_italian="Aprile",
                     description_english="Month of april",
                     description_italian="mese di aprile",
-                    sort_order=9,
+                    sort_order=0,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="M05",
@@ -480,7 +498,7 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                     display_name_italian="Maggio",
                     description_english="Month of may",
                     description_italian="mese di maggio",
-                    sort_order=10,
+                    sort_order=0,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="M06",
@@ -489,7 +507,7 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                     display_name_italian="Giugno",
                     description_english="Month of sune",
                     description_italian="mese di giugno",
-                    sort_order=11,
+                    sort_order=0,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="M07",
@@ -498,7 +516,7 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                     display_name_italian="Luglio",
                     description_english="Month of july",
                     description_italian="mese di luglio",
-                    sort_order=12,
+                    sort_order=0,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="M08",
@@ -507,7 +525,7 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                     display_name_italian="Agosto",
                     description_english="Month of august",
                     description_italian="mese di agosto",
-                    sort_order=13,
+                    sort_order=0,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="M09",
@@ -516,7 +534,7 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                     display_name_italian="Settembre",
                     description_english="Month of september",
                     description_italian="mese di settembre",
-                    sort_order=14,
+                    sort_order=0,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="M10",
@@ -525,7 +543,7 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                     display_name_italian="Ottobre",
                     description_english="Month of october",
                     description_italian="mese di ottobre",
-                    sort_order=15,
+                    sort_order=0,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="M11",
@@ -534,7 +552,7 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                     display_name_italian="Novembre",
                     description_english="Month of november",
                     description_italian="mese di novembre",
-                    sort_order=16,
+                    sort_order=0,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="M12",
@@ -543,7 +561,7 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                     display_name_italian="Dicembre",
                     description_english="Month of december",
                     description_italian="mese di dicembre",
-                    sort_order=17,
+                    sort_order=0,
                 ),
             ],
         ),
@@ -558,25 +576,21 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                     internal_value="absolute",
                     display_name_english="Absolute value",
                     display_name_italian="Valore assoluto",
-                    description_english=(
-                        "Represents the climatological variable's absolute value"
-                    ),
-                    description_italian=(
-                        "Rappresenta il valore assoluto della variabile climatologica"
-                    ),
-                    sort_order=1,
+                    description_english="Actual value in the selected period",
+                    description_italian="Valore effettivo nel periodo selezionato",
+                    sort_order=0,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="anomaly",
-                    display_name_english="Climatological anomaly",
-                    display_name_italian="Anomalia climatologica",
+                    display_name_english="Anomaly",
+                    display_name_italian="Anomalia",
                     description_english=(
-                        "Represents climatological anomaly values for the variable"
+                        "Change in the future with respect to the reference period"
                     ),
                     description_italian=(
-                        "Rappresenta i valori di anomalia climatologica per la variabile"
+                        "Variazione nel futuro rispetto al periodo di riferimento"
                     ),
-                    sort_order=2,
+                    sort_order=1,
                 ),
             ],
         ),
@@ -594,59 +608,51 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
             allowed_values=[
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="model_ensemble",
-                    display_name_english="5 Model ensemble",
-                    display_name_italian="Insieme di 5 modelli",
-                    description_english=(
-                        "Ensemble of five climatological models: EC-EARTH CCLM4-8-17, "
-                        "EC-EARTH RACMO22E, EC-EARTH RCA4, HadGEM RACMO22E, "
-                        "MPI-ESM-LR-REMO2009"
-                    ),
-                    description_italian=(
-                        "Insieme di cinque modelli climatologici: EC-EARTH CCLM4-8-17, "
-                        "EC-EARTH RACMO22E, EC-EARTH RCA4, HadGEM RACMO22E, "
-                        "MPI-ESM-LR-REMO2009"
-                    ),
-                    sort_order=1,
+                    display_name_english="Ensemble mean",
+                    display_name_italian="Media ensemble",
+                    description_english="Ensemble mean of five considered models",
+                    description_italian="Media ensemble 5 modelli considerati",
+                    sort_order=0,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="ec_earth_cclm_4_8_17",
-                    display_name_english="EC-EARTH CCLM4-8-17",
-                    display_name_italian="EC-EARTH CCLM4-8-17",
-                    description_english="EC-Earth CCLM4-8-17 model",
-                    description_italian="Modello EC-Earth CCLM4-8-17",
-                    sort_order=2,
+                    display_name_english="EC-EARTH_CCLM4-8-17",
+                    display_name_italian="EC-EARTH_CCLM4-8-17",
+                    description_english="Global: EC-EARTH. Regional: CCLM4-8-17",
+                    description_italian="Globale: EC-EARTH. Regionale: CCLM4-8-17",
+                    sort_order=1,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="ec_earth_racmo22e",
-                    display_name_english="EC-EARTH RACMO22E",
-                    display_name_italian="EC-EARTH RACMO22E",
-                    description_english="EC-Earth RACMO22E model",
-                    description_italian="Modello EC-Earth RACMO22E",
-                    sort_order=3,
+                    display_name_english="EC-EARTH_RACMO22E",
+                    display_name_italian="EC-EARTH_RACMO22E",
+                    description_english="Global: EC-EARTH. Regional: RACMO22E",
+                    description_italian="Globale: EC-EARTH. Regionale: RACMO22E",
+                    sort_order=2,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="ec_earth_rca4",
-                    display_name_english="EC-EARTH RCA4",
-                    display_name_italian="EC-EARTH RCA4",
-                    description_english="EC-Earth RCA4 model",
-                    description_italian="Modello EC-Earth RCA4",
-                    sort_order=4,
+                    display_name_english="EC-EARTH_RCA4",
+                    display_name_italian="EC-EARTH_RCA4",
+                    description_english="Global: EC-EARTH. Regional: RCA4",
+                    description_italian="Globale EC-EARTH. Regionale: RCA4",
+                    sort_order=3,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="hadgem2_racmo22e",
-                    display_name_english="HadGEM RACMO22E",
-                    display_name_italian="HadGEM RACMO22E",
-                    description_english="HadGEM RACMO22E model",
-                    description_italian="Modello HadGEM RACMO22E",
-                    sort_order=5,
+                    display_name_english="HadGEM2-ES_RACMO22E",
+                    display_name_italian="HadGEM2-ES_RACMO22E",
+                    description_english="Global: HadGEM2-ES. Regional: RACMO22E",
+                    description_italian="Globale: HadGEM2-ES. Regionale: RACMO22E",
+                    sort_order=4,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="mpi_esm_lr_remo2009",
-                    display_name_english="MPI-ESM-LR-REMO2009",
-                    display_name_italian="MPI-ESM-LR-REMO2009",
-                    description_english="MPI-ESM-LR-REMO2009 model",
-                    description_italian="Modello MPI-ESM-LR-REMO2009",
-                    sort_order=6,
+                    display_name_english="MPI-ESM-LR_REMO2009",
+                    display_name_italian="MPI-ESM-LR_REMO2009",
+                    description_english="Global: MPI-ESM-LR. Regional: REMO2009",
+                    description_italian="Globale: MPI-ESM-LR. Regionale: REMO2009",
+                    sort_order=5,
                 ),
             ],
         ),
@@ -659,25 +665,19 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
             allowed_values=[
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="30yr",
-                    display_name_english="30 Years",
-                    display_name_italian="30 anni",
-                    description_english="Datasets contain aggregation of 30 years",
-                    description_italian=(
-                        "I set di dati contengono un'aggregazione di 30 anni"
-                    ),
-                    sort_order=2,
+                    display_name_english="30-year",
+                    display_name_italian="Trentennale",
+                    description_english="Average over the selected 30-year period",
+                    description_italian="Media sul trentennio selezionato",
+                    sort_order=1,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="annual",
                     display_name_english="Annual",
                     display_name_italian="Annuale",
-                    description_english=(
-                        "Datasets contain aggregation of yearly values"
-                    ),
-                    description_italian=(
-                        "I set di dati contengono aggregazioni di valori annuali"
-                    ),
-                    sort_order=1,
+                    description_english="Average over the selected year",
+                    description_italian="Media sull'anno selezionato",
+                    sort_order=0,
                 ),
             ],
         ),
@@ -729,7 +729,7 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                     display_name_italian="Dati storici",
                     description_english=("Datasets obtained from historical data"),
                     description_italian=("Set di dati ottenuti da dati storici"),
-                    sort_order=1,
+                    sort_order=0,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="forecast",
@@ -737,19 +737,15 @@ def generate_configuration_parameters() -> list[ConfigurationParameterCreate]:
                     display_name_italian="Dati di previsione",
                     description_english=("Datasets obtained from forecasts"),
                     description_italian=("Set di dati ottenuti dalle previsioni"),
-                    sort_order=2,
+                    sort_order=0,
                 ),
                 ConfigurationParameterValueCreateEmbeddedInConfigurationParameter(
                     internal_value="barometro_climatico",
                     display_name_english="Climate barometer",
                     display_name_italian="Barometro climatico",
-                    description_english=(
-                        "Datasets providing an overview of the whole region"
-                    ),
-                    description_italian=(
-                        "Set di dati che forniscono una panoramica dell'intera regione"
-                    ),
-                    sort_order=3,
+                    description_english="Regional overview",
+                    description_italian="Panoramica regionale",
+                    sort_order=0,
                 ),
             ],
         ),

--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/cdd.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/cdd.py
@@ -13,6 +13,7 @@ _DESCRIPTION_ITALIAN = (
     "Numero massimo di giorni consecutivi asciutti (precipitazione giornaliera "
     "inferiore a 1 mm)"
 )
+_DATA_PRECISION = 0
 
 
 def generate_configurations(
@@ -34,6 +35,7 @@ def generate_configurations(
             palette="uncert-stippled/div-BrBG-inv",
             color_scale_min=-40,
             color_scale_max=40,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -121,6 +123,7 @@ def generate_configurations(
             palette="default/div-BrBG-inv",
             color_scale_min=-40,
             color_scale_max=40,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -211,6 +214,7 @@ def generate_configurations(
             palette="default/div-BrBG-inv",
             color_scale_min=-40,
             color_scale_max=40,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -301,6 +305,7 @@ def generate_configurations(
             palette="default/div-BrBG-inv",
             color_scale_min=-40,
             color_scale_max=40,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -388,6 +393,7 @@ def generate_configurations(
             palette="default/div-BrBG-inv",
             color_scale_min=-40,
             color_scale_max=40,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -478,6 +484,7 @@ def generate_configurations(
             palette="default/div-BrBG-inv",
             color_scale_min=-40,
             color_scale_max=40,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[

--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/cdds.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/cdds.py
@@ -17,6 +17,7 @@ _DESCRIPTION_ITALIAN = (
     "Somma della temperatura media giornaliera meno 21°C se la temperatura media "
     "giornaliera è maggiore di 24°C"
 )
+_DATA_PRECISION = 0
 
 
 def generate_configurations(
@@ -37,6 +38,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=1000,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -102,6 +104,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=1000,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -166,6 +169,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=1000,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -230,6 +234,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=1000,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -291,6 +296,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=1000,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -355,6 +361,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=1000,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -419,6 +426,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=1000,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -485,6 +493,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=1000,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -552,6 +561,7 @@ def generate_configurations(
             palette="uncert-stippled/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=1000,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -623,6 +633,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=1000,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -697,6 +708,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=1000,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -771,6 +783,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=1000,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -842,6 +855,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=1000,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -916,6 +930,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=1000,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[

--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/fd.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/fd.py
@@ -11,6 +11,7 @@ _DISPLAY_NAME_ENGLISH = "Frosty days"
 _DISPLAY_NAME_ITALIAN = "Giorni di gelo"
 _DESCRIPTION_ENGLISH = "Number of days with minimum temperature less than 0 °C"
 _DESCRIPTION_ITALIAN = "Numero di giorni con temperatura minima inferiore a 0 °C"
+_DATA_PRECISION = 0
 
 
 def generate_configurations(
@@ -31,6 +32,7 @@ def generate_configurations(
             palette="default/seq-Blues-inv",
             color_scale_min=0,
             color_scale_max=200,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -97,6 +99,7 @@ def generate_configurations(
             palette="default/seq-Blues-inv",
             color_scale_min=0,
             color_scale_max=200,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -166,6 +169,7 @@ def generate_configurations(
             palette="default/seq-Blues-inv",
             color_scale_min=0,
             color_scale_max=200,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -235,6 +239,7 @@ def generate_configurations(
             palette="default/seq-Blues-inv",
             color_scale_min=0,
             color_scale_max=200,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -301,6 +306,7 @@ def generate_configurations(
             palette="default/seq-Blues-inv",
             color_scale_min=0,
             color_scale_max=200,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -370,6 +376,7 @@ def generate_configurations(
             palette="default/seq-Blues-inv",
             color_scale_min=0,
             color_scale_max=200,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -439,6 +446,7 @@ def generate_configurations(
             palette="default/seq-Blues-inv",
             color_scale_min=0,
             color_scale_max=200,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -506,6 +514,7 @@ def generate_configurations(
             palette="default/seq-Blues-inv",
             color_scale_min=0,
             color_scale_max=200,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -574,6 +583,7 @@ def generate_configurations(
             palette="uncert-stippled/seq-YlOrRd-inv",
             color_scale_min=-85,
             color_scale_max=5,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -646,6 +656,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd-inv",
             color_scale_min=-85,
             color_scale_max=5,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -721,6 +732,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd-inv",
             color_scale_min=-85,
             color_scale_max=5,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -796,6 +808,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd-inv",
             color_scale_min=-85,
             color_scale_max=5,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -868,6 +881,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd-inv",
             color_scale_min=-85,
             color_scale_max=5,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -943,6 +957,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd-inv",
             color_scale_min=-85,
             color_scale_max=5,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[

--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/hdds.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/hdds.py
@@ -17,6 +17,7 @@ _DESCRIPTION_ITALIAN = (
     "Somma di 20°C meno la temperatura media giornaliera se la temperatura media "
     "giornaliera è minore di 20°C"
 )
+_DATA_PRECISION = 0
 
 
 def generate_configurations(
@@ -37,6 +38,7 @@ def generate_configurations(
             palette="default/seq-Blues-inv",
             color_scale_min=0,
             color_scale_max=7000,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -102,6 +104,7 @@ def generate_configurations(
             palette="default/seq-Blues-inv",
             color_scale_min=0,
             color_scale_max=7000,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -166,6 +169,7 @@ def generate_configurations(
             palette="default/seq-Blues-inv",
             color_scale_min=0,
             color_scale_max=7000,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -230,6 +234,7 @@ def generate_configurations(
             palette="default/seq-Blues-inv",
             color_scale_min=0,
             color_scale_max=7000,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -291,6 +296,7 @@ def generate_configurations(
             palette="default/seq-Blues-inv",
             color_scale_min=0,
             color_scale_max=7000,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -355,6 +361,7 @@ def generate_configurations(
             palette="default/seq-Blues-inv",
             color_scale_min=0,
             color_scale_max=7000,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -419,6 +426,7 @@ def generate_configurations(
             palette="default/seq-Blues-inv",
             color_scale_min=0,
             color_scale_max=7000,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -485,6 +493,7 @@ def generate_configurations(
             palette="default/seq-Blues-inv",
             color_scale_min=0,
             color_scale_max=7000,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -553,6 +562,7 @@ def generate_configurations(
             palette="uncert-stippled/seq-YlOrRd-inv",
             color_scale_min=-2000,
             color_scale_max=0,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -624,6 +634,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd-inv",
             color_scale_min=-2000,
             color_scale_max=0,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -698,6 +709,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd-inv",
             color_scale_min=-2000,
             color_scale_max=0,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -772,6 +784,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd-inv",
             color_scale_min=-2000,
             color_scale_max=0,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -843,6 +856,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd-inv",
             color_scale_min=-2000,
             color_scale_max=0,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -917,6 +931,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd-inv",
             color_scale_min=-2000,
             color_scale_max=0,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[

--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/hwdi.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/hwdi.py
@@ -14,6 +14,7 @@ _DESCRIPTION_ITALIAN = (
     "Sequenze di 5 giorni consecutivi in cui la temperatura è maggiore di 5°C rispetto "
     "alla media di riferimento per quel giorno dell'anno"
 )
+_DATA_PRECISION = 0
 
 
 def generate_configurations(
@@ -35,6 +36,7 @@ def generate_configurations(
             palette="uncert-stippled/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=50,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -107,6 +109,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=50,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -182,6 +185,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=50,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -257,6 +261,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=50,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -329,6 +334,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=50,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -404,6 +410,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=50,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[

--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/r95ptot.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/r95ptot.py
@@ -13,6 +13,7 @@ _DESCRIPTION_ITALIAN = (
     "Precipitazioni cumulative totali superiori al 95° percentile del periodo di "
     "riferimento"
 )
+_DATA_PRECISION = 0
 
 
 def generate_configurations(
@@ -33,6 +34,7 @@ def generate_configurations(
             palette="uncert-stippled/div-BrBG",
             color_scale_min=-160,
             color_scale_max=160,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -119,6 +121,7 @@ def generate_configurations(
             palette="default/div-BrBG",
             color_scale_min=-160,
             color_scale_max=160,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -208,6 +211,7 @@ def generate_configurations(
             palette="default/div-BrBG",
             color_scale_min=-160,
             color_scale_max=160,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -297,6 +301,7 @@ def generate_configurations(
             palette="default/div-BrBG",
             color_scale_min=-160,
             color_scale_max=160,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -383,6 +388,7 @@ def generate_configurations(
             palette="default/div-BrBG",
             color_scale_min=-160,
             color_scale_max=160,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -472,6 +478,7 @@ def generate_configurations(
             palette="default/div-BrBG",
             color_scale_min=-160,
             color_scale_max=160,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[

--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/snwdays.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/snwdays.py
@@ -13,6 +13,7 @@ _DESCRIPTION_ITALIAN = (
     "Numero massimo di giorni asciutti consecutivi (precipitazioni giornaliere "
     "inferiori a 1 mm)"
 )
+_DATA_PRECISION = 0
 
 
 def generate_configurations(
@@ -33,6 +34,7 @@ def generate_configurations(
             palette="default/seq-BuYl-inv",
             color_scale_min=0,
             color_scale_max=100,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -95,6 +97,7 @@ def generate_configurations(
             palette="default/seq-BuYl-inv",
             color_scale_min=0,
             color_scale_max=100,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -160,6 +163,7 @@ def generate_configurations(
             palette="default/seq-BuYl-inv",
             color_scale_min=0,
             color_scale_max=100,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -225,6 +229,7 @@ def generate_configurations(
             palette="default/seq-BuYl-inv",
             color_scale_min=0,
             color_scale_max=100,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -287,6 +292,7 @@ def generate_configurations(
             palette="default/seq-BuYl-inv",
             color_scale_min=0,
             color_scale_max=100,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -352,6 +358,7 @@ def generate_configurations(
             palette="default/seq-BuYl-inv",
             color_scale_min=0,
             color_scale_max=100,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -417,6 +424,7 @@ def generate_configurations(
             palette="default/seq-BuYl-inv",
             color_scale_min=0,
             color_scale_max=100,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -484,6 +492,7 @@ def generate_configurations(
             palette="default/seq-BuYl-inv",
             color_scale_min=0,
             color_scale_max=100,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -553,6 +562,7 @@ def generate_configurations(
             palette="uncert-stippled/seq-YlOrBr-inv",
             color_scale_min=-50,
             color_scale_max=0,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -625,6 +635,7 @@ def generate_configurations(
             palette="default/seq-YlOrBr-inv",
             color_scale_min=-50,
             color_scale_max=0,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -700,6 +711,7 @@ def generate_configurations(
             palette="default/seq-YlOrBr-inv",
             color_scale_min=-50,
             color_scale_max=0,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -775,6 +787,7 @@ def generate_configurations(
             palette="default/seq-YlOrBr-inv",
             color_scale_min=-50,
             color_scale_max=0,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -847,6 +860,7 @@ def generate_configurations(
             palette="default/seq-YlOrBr-inv",
             color_scale_min=-50,
             color_scale_max=0,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -922,6 +936,7 @@ def generate_configurations(
             palette="default/seq-YlOrBr-inv",
             color_scale_min=-50,
             color_scale_max=0,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[

--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/su30.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/su30.py
@@ -11,6 +11,7 @@ _DISPLAY_NAME_ENGLISH = "Hot days"
 _DISPLAY_NAME_ITALIAN = "Giorni caldi"
 _DESCRIPTION_ENGLISH = "Number of days with maximum temperature greater than 30 °C"
 _DESCRIPTION_ITALIAN = "Numero di giorni con temperatura massima superiore a 30 °C"
+_DATA_PRECISION = 0
 
 
 def generate_configurations(
@@ -31,6 +32,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=100,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -97,6 +99,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=100,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -166,6 +169,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=100,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -235,6 +239,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=100,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -301,6 +306,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=100,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -370,6 +376,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=100,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -439,6 +446,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=100,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -506,6 +514,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=100,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -574,6 +583,7 @@ def generate_configurations(
             palette="uncert-stippled/seq-YlOrRd",
             color_scale_min=-5,
             color_scale_max=75,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -646,6 +656,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-5,
             color_scale_max=75,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -721,6 +732,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-5,
             color_scale_max=75,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -796,6 +808,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-5,
             color_scale_max=75,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -868,6 +881,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-5,
             color_scale_max=75,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -943,6 +957,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-5,
             color_scale_max=75,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[

--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/tas.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/tas.py
@@ -11,6 +11,7 @@ _DISPLAY_NAME_ENGLISH = "Average temperature"
 _DISPLAY_NAME_ITALIAN = "Temperatura media"
 _DESCRIPTION_ENGLISH = "Average daily air temperature near the ground"
 _DESCRIPTION_ITALIAN = "Temperatura media giornaliera dell'aria vicino al suolo"
+_DATA_PRECISION = 1
 
 
 def generate_configurations(
@@ -30,6 +31,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=6,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -106,6 +108,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=6,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -185,6 +188,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=6,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -264,6 +268,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=6,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -340,6 +345,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=6,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -419,6 +425,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=6,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -498,6 +505,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=0,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -579,6 +587,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=0,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -660,6 +669,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -740,6 +750,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -805,6 +816,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -888,6 +900,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -956,6 +969,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1039,6 +1053,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1107,6 +1122,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1187,6 +1203,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1252,6 +1269,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1335,6 +1353,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1403,6 +1422,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1486,6 +1506,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1554,6 +1575,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1635,6 +1657,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1716,6 +1739,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1782,6 +1806,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1849,6 +1874,7 @@ def generate_configurations(
             palette="uncert-stippled/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=6,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1935,6 +1961,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=6,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -2024,6 +2051,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=6,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -2113,6 +2141,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=6,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -2199,6 +2228,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=6,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -2288,6 +2318,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=6,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -2377,6 +2408,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -2418,6 +2450,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -2464,6 +2497,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[

--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/tasmax.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/tasmax.py
@@ -11,6 +11,7 @@ _DISPLAY_NAME_ENGLISH = "Maximum temperature"
 _DISPLAY_NAME_ITALIAN = "Temperatura massima"
 _DESCRIPTION_ENGLISH = "Maximum daily air temperature near the ground"
 _DESCRIPTION_ITALIAN = "Temperatura massima giornaliera dell'aria vicino al suolo"
+_DATA_PRECISION = 1
 
 
 def generate_configurations(
@@ -30,6 +31,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -110,6 +112,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -175,6 +178,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -258,6 +262,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=7,
             color_scale_max=37,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -326,6 +331,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -409,6 +415,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=7,
             color_scale_max=37,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -477,6 +484,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -557,6 +565,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=7,
             color_scale_max=37,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -622,6 +631,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -705,6 +715,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=7,
             color_scale_max=37,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -773,6 +784,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -856,6 +868,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=7,
             color_scale_max=37,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -924,6 +937,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=7,
             color_scale_max=37,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1005,6 +1019,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=7,
             color_scale_max=37,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1086,6 +1101,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=7,
             color_scale_max=37,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1152,6 +1168,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=7,
             color_scale_max=37,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1219,6 +1236,7 @@ def generate_configurations(
             palette="uncert-stippled/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=6,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1305,6 +1323,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=6,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1394,6 +1413,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=6,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1483,6 +1503,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=6,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1569,6 +1590,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=6,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1658,6 +1680,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=6,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[

--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/tasmin.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/tasmin.py
@@ -11,6 +11,7 @@ _DISPLAY_NAME_ENGLISH = "Minimum temperature"
 _DISPLAY_NAME_ITALIAN = "Temperatura minima"
 _DESCRIPTION_ENGLISH = "Minimum daily air temperature near the ground"
 _DESCRIPTION_ITALIAN = "Temperatura minima giornaliera dell'aria vicino al suolo"
+_DATA_PRECISION = 1
 
 
 def generate_configurations(
@@ -30,6 +31,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -110,6 +112,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -175,6 +178,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -258,6 +262,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-13,
             color_scale_max=27,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -326,6 +331,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -409,6 +415,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-13,
             color_scale_max=27,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -477,6 +484,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -557,6 +565,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-13,
             color_scale_max=27,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -622,6 +631,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -705,6 +715,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-13,
             color_scale_max=27,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -773,6 +784,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-3,
             color_scale_max=32,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -856,6 +868,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-13,
             color_scale_max=27,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -924,6 +937,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-13,
             color_scale_max=27,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1005,6 +1019,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-13,
             color_scale_max=27,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1086,6 +1101,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-13,
             color_scale_max=27,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1152,6 +1168,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-13,
             color_scale_max=27,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1219,6 +1236,7 @@ def generate_configurations(
             palette="uncert-stippled/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=6,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1305,6 +1323,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=6,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1394,6 +1413,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=6,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1483,6 +1503,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=6,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1569,6 +1590,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=6,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -1658,6 +1680,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=6,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[

--- a/arpav_ppcv/bootstrapper/coverage_configurations/forecast/tr.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/forecast/tr.py
@@ -11,6 +11,7 @@ _DISPLAY_NAME_ENGLISH = "Tropical nights"
 _DISPLAY_NAME_ITALIAN = "Notti tropicali"
 _DESCRIPTION_ENGLISH = "Number of days with minimum temperature greater than 20 °C"
 _DESCRIPTION_ITALIAN = "Numero di giorni con temperatura minima superiore a 20 °C"
+_DATA_PRECISION = 0
 
 
 def generate_configurations(
@@ -31,6 +32,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=120,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -97,6 +99,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=120,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -166,6 +169,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=120,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -235,6 +239,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=120,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -301,6 +306,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=120,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -370,6 +376,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=120,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -439,6 +446,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=100,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -506,6 +514,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=0,
             color_scale_max=100,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -574,6 +583,7 @@ def generate_configurations(
             palette="uncert-stippled/seq-YlOrRd",
             color_scale_min=-5,
             color_scale_max=75,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -646,6 +656,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-5,
             color_scale_max=75,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -721,6 +732,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-5,
             color_scale_max=75,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -796,6 +808,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-5,
             color_scale_max=75,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -868,6 +881,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-5,
             color_scale_max=75,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -943,6 +957,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=-5,
             color_scale_max=75,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[

--- a/arpav_ppcv/bootstrapper/coverage_configurations/historical/cdds.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/historical/cdds.py
@@ -19,6 +19,7 @@ _VARIABLE = "cdds"
 _UNIT = "ºC"
 _COLOR_SCALE_MIN = 0
 _COLOR_SCALE_MAX = 320
+_DATA_PRECISION = 0
 
 
 def generate_configurations(
@@ -38,6 +39,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=_COLOR_SCALE_MIN,
             color_scale_max=_COLOR_SCALE_MAX,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -84,6 +86,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=_COLOR_SCALE_MIN,
             color_scale_max=_COLOR_SCALE_MAX,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[

--- a/arpav_ppcv/bootstrapper/coverage_configurations/historical/fd.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/historical/fd.py
@@ -18,6 +18,7 @@ _UNIT_ITALIAN = "gg"
 _COLOR_SCALE_MIN = 0
 _COLOR_SCALE_MAX = 260
 _RELATED_OBSERVATION_VARIABLE_NAME = "FD"
+_DATA_PRECISION = 0
 
 
 def generate_configurations(
@@ -38,6 +39,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=_COLOR_SCALE_MIN,
             color_scale_max=_COLOR_SCALE_MAX,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -85,6 +87,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=_COLOR_SCALE_MIN,
             color_scale_max=_COLOR_SCALE_MAX,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[

--- a/arpav_ppcv/bootstrapper/coverage_configurations/historical/hdds.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/historical/hdds.py
@@ -19,6 +19,7 @@ _VARIABLE = "hdds"
 _UNIT = "ºC"
 _COLOR_SCALE_MIN = 2130
 _COLOR_SCALE_MAX = 7800
+_DATA_PRECISION = 0
 
 
 def generate_configurations(
@@ -38,6 +39,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=_COLOR_SCALE_MIN,
             color_scale_max=_COLOR_SCALE_MAX,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -84,6 +86,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=_COLOR_SCALE_MIN,
             color_scale_max=_COLOR_SCALE_MAX,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[

--- a/arpav_ppcv/bootstrapper/coverage_configurations/historical/su30.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/historical/su30.py
@@ -18,6 +18,7 @@ _UNIT_ITALIAN = "gg"
 _COLOR_SCALE_MIN = 0
 _COLOR_SCALE_MAX = 80
 _RELATED_OBSERVATION_VARIABLE_NAME = "SU30"
+_DATA_PRECISION = 0
 
 
 def generate_configurations(
@@ -38,6 +39,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=_COLOR_SCALE_MIN,
             color_scale_max=_COLOR_SCALE_MAX,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -85,6 +87,7 @@ def generate_configurations(
             unit_italian=_UNIT_ITALIAN,
             color_scale_min=_COLOR_SCALE_MIN,
             color_scale_max=_COLOR_SCALE_MAX,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[

--- a/arpav_ppcv/bootstrapper/coverage_configurations/historical/tdd.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/historical/tdd.py
@@ -17,6 +17,7 @@ _UNIT = "ºC"
 _COLOR_SCALE_MIN = -5
 _COLOR_SCALE_MAX = 20
 _RELATED_OBSERVATION_VARIABLE_NAME = "TDd"
+_DATA_PRECISION = 1
 
 
 def generate_configurations(
@@ -36,6 +37,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=_COLOR_SCALE_MIN,
             color_scale_max=_COLOR_SCALE_MAX,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -162,6 +164,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=_COLOR_SCALE_MIN,
             color_scale_max=_COLOR_SCALE_MAX,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -209,6 +212,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=_COLOR_SCALE_MIN,
             color_scale_max=_COLOR_SCALE_MAX,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -271,6 +275,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=_COLOR_SCALE_MIN,
             color_scale_max=_COLOR_SCALE_MAX,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -373,6 +378,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=_COLOR_SCALE_MIN,
             color_scale_max=_COLOR_SCALE_MAX,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[

--- a/arpav_ppcv/bootstrapper/coverage_configurations/historical/tnd.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/historical/tnd.py
@@ -17,6 +17,7 @@ _UNIT = "ºC"
 _COLOR_SCALE_MIN = -5
 _COLOR_SCALE_MAX = 20
 _RELATED_OBSERVATION_VARIABLE_NAME = "TNd"
+_DATA_PRECISION = 1
 
 
 def generate_configurations(
@@ -36,6 +37,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=_COLOR_SCALE_MIN,
             color_scale_max=_COLOR_SCALE_MAX,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -162,6 +164,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=_COLOR_SCALE_MIN,
             color_scale_max=_COLOR_SCALE_MAX,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -209,6 +212,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=_COLOR_SCALE_MIN,
             color_scale_max=_COLOR_SCALE_MAX,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -271,6 +275,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=_COLOR_SCALE_MIN,
             color_scale_max=_COLOR_SCALE_MAX,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[

--- a/arpav_ppcv/bootstrapper/coverage_configurations/historical/tr.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/historical/tr.py
@@ -17,6 +17,7 @@ _UNIT = "gg"
 _COLOR_SCALE_MIN = 0
 _COLOR_SCALE_MAX = 50
 _RELATED_OBSERVATION_VARIABLE_NAME = "TR"
+_DATA_PRECISION = 0
 
 
 def generate_configurations(
@@ -36,6 +37,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=_COLOR_SCALE_MIN,
             color_scale_max=_COLOR_SCALE_MAX,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -82,6 +84,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=_COLOR_SCALE_MIN,
             color_scale_max=_COLOR_SCALE_MAX,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[

--- a/arpav_ppcv/bootstrapper/coverage_configurations/historical/txd.py
+++ b/arpav_ppcv/bootstrapper/coverage_configurations/historical/txd.py
@@ -17,6 +17,7 @@ _UNIT = "ºC"
 _COLOR_SCALE_MIN = -5
 _COLOR_SCALE_MAX = 20
 _RELATED_OBSERVATION_VARIABLE_NAME = "TXd"
+_DATA_PRECISION = 1
 
 
 def generate_configurations(
@@ -36,6 +37,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=_COLOR_SCALE_MIN,
             color_scale_max=_COLOR_SCALE_MAX,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -162,6 +164,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=_COLOR_SCALE_MIN,
             color_scale_max=_COLOR_SCALE_MAX,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -209,6 +212,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=_COLOR_SCALE_MIN,
             color_scale_max=_COLOR_SCALE_MAX,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[
@@ -271,6 +275,7 @@ def generate_configurations(
             palette="default/seq-YlOrRd",
             color_scale_min=_COLOR_SCALE_MIN,
             color_scale_max=_COLOR_SCALE_MAX,
+            data_precision=_DATA_PRECISION,
             possible_values=[
                 ConfigurationParameterPossibleValueCreate(
                     configuration_parameter_value_id=conf_param_values[

--- a/arpav_ppcv/schemas/coverages.py
+++ b/arpav_ppcv/schemas/coverages.py
@@ -50,7 +50,9 @@ class ConfigurationParameterValue(sqlmodel.SQLModel, table=True):
     configuration_parameter: "ConfigurationParameter" = sqlmodel.Relationship(
         back_populates="allowed_values",
     )
-    used_in_configurations: "ConfigurationParameterPossibleValue" = sqlmodel.Relationship(
+    used_in_configurations: list[
+        "ConfigurationParameterPossibleValue"
+    ] = sqlmodel.Relationship(
         back_populates="configuration_parameter_value",
         sa_relationship_kwargs={
             "cascade": "all, delete, delete-orphan",


### PR DESCRIPTION
This PR adds bootstrap values for the `data_precision` property.

It also aligns the bootstrap values according with their latest value on the staging env:

- configuration parameter values

---

- fixes #281