### PR TITLE
Added config option for controlling number of uvicorn workers

### DIFF
--- a/arpav_ppcv/config.py
+++ b/arpav_ppcv/config.py
@@ -129,6 +129,7 @@ class ArpavPpcvSettings(BaseSettings):  # noqa
     allow_cors_credentials: bool = False
     coverage_download_settings: CoverageDownloadSettings = CoverageDownloadSettings()
     variable_stations_db_schema: str = "stations"
+    num_uvicorn_worker_processes: int = 1
 
     @pydantic.model_validator(mode="after")
     def ensure_test_db_dsn(self):

--- a/arpav_ppcv/main.py
+++ b/arpav_ppcv/main.py
@@ -122,6 +122,7 @@ def run_server(ctx: typer.Context):
         f"--port={settings.bind_port}",
         f"--host={settings.bind_host}",
         "--factory",
+        f"--workers={settings.num_uvicorn_worker_processes}",
         "--access-log",
     ]
     if settings.debug:


### PR DESCRIPTION
This PR adds the `ARPAV_PPCV__NUM_UVICORN_WORKER_PROCESSES` environment variable, which can be used to control the number of uvicorn workers which are spawned on the backend. It defaults to `1`, which is appropriate for development.

The staging env is already updated with a more reasonable value for it.

---

- fixes #289