### PR TITLE
Add better error handling when providing data downloads from THREDDS

### DIFF
--- a/arpav_ppcv/datadownloads.py
+++ b/arpav_ppcv/datadownloads.py
@@ -45,13 +45,12 @@ async def retrieve_coverage_data(
             )
         )
         logger.debug(f"{ncss_url=}")
-        async for chunk in ncss.async_query_dataset_area(
+        return await ncss.async_query_dataset_area(
             http_client,
             ncss_url,
             bbox=bbox,
             temporal_range=temporal_range,
-        ):
-            yield chunk
+        )
 
 
 def get_cache_key(

--- a/arpav_ppcv/thredds/ncss.py
+++ b/arpav_ppcv/thredds/ncss.py
@@ -142,11 +142,8 @@ async def async_query_dataset_area(
         **temporal_parameters,
         **spatial_parameters,
     }
-    async with http_client.stream(
-        "GET", thredds_ncss_url, params=ncss_params
-    ) as response:
-        async for chunk in response.aiter_bytes():
-            yield chunk
+    request = http_client.build_request("GET", thredds_ncss_url, params=ncss_params)
+    return await http_client.send(request, stream=True)
 
 
 async def async_query_dataset(


### PR DESCRIPTION
This PR adds better error handling to the API path operation that performs forecast coverage data download.

The system will ask the upstream THREDDS server for data and simply relay the response (which can be an error) back to the client.

---

- Fixes #293