### PR TITLE
Enlarge default coverage grid in order to ensure correct NCSS requests

### DIFF
--- a/arpav_ppcv/config.py
+++ b/arpav_ppcv/config.py
@@ -80,10 +80,10 @@ class AdminUserSettings(pydantic.BaseModel):
 
 
 class CoverageDownloadSpatialGrid(pydantic.BaseModel):
-    min_lon: decimal.Decimal = Decimal("10.2")
-    min_lat: decimal.Decimal = Decimal("44.697")
-    max_lon: decimal.Decimal = Decimal("14.2")
-    max_lat: decimal.Decimal = Decimal("47.097")
+    min_lon: decimal.Decimal = Decimal("9.90843")
+    min_lat: decimal.Decimal = Decimal("44.40394")
+    max_lon: decimal.Decimal = Decimal("14.45177")
+    max_lat: decimal.Decimal = Decimal("47.49636")
 
     num_rows: int = 24
     num_cols: int = 37


### PR DESCRIPTION
This PR makes the default coverages grid large enough to cover the full extent of NetCDF files and not just their relevant extent.


The grid now covers an area larger than the full extent of NetCDF files:

![image](https://github.com/user-attachments/assets/63746022-aecf-4507-89cf-504fd389d26f)

In the image above:

- green rectangle shows the current extent of the grid
- red rectangle shows the proposed change in this PR
- below these two rectangles there are two sample coverages with both areas used in the system (ARPAV area and ARPAV+ARPAFVG area)




This makes NCSS requests work correctly.

Here is a sample request with the default bbox:

![image](https://github.com/user-attachments/assets/0d680d62-b068-4b25-ad52-e2de162ae1f5)


And the corresponding NetCDF file, loaded in QGIS after having been downloaded:

![image](https://github.com/user-attachments/assets/1cb9737f-a2d6-459f-a846-dddc7a98acd2)



Another sample request (made with the frontend UI) that asks for a smaller spatial region:

![image](https://github.com/user-attachments/assets/3e429f13-a9a7-4891-ae3d-476d0d5675b0)


and the corresponding NetCDF file, loaded in QGIS after having been downloaded:

![image](https://github.com/user-attachments/assets/ffbd9820-448c-4902-9a90-28cb31c6c31b)


---

- fixes #295