### PR TITLE
Changed dev stack to have the frontend use a local backend

### DIFF
--- a/docker/compose.dev.yaml
+++ b/docker/compose.dev.yaml
@@ -57,6 +57,9 @@ services:
     ports:
       - target: 80
         published: 5003
+    environment:
+      ARPAV_BACKEND_API_BASE_URL: http://localhost:8877
+      ARPAV_TOLGEE_BASE_URL: http://localhost:8899
 
   webapp:
     image: *webapp-image
@@ -159,7 +162,7 @@ services:
       - "traefik.http.routers.martin-router.entrypoints=web"
     ports:
       - target: 3000
-        published: 3000
+        published: 4000
     environment:
       DATABASE_URL: postgres://arpav:arpavpassword@db/arpav_ppcv
       RUST_LOG: actix_web=info,martin=debug,tokio_postgres=debug


### PR DESCRIPTION
This PR makes use of the new frontend support for being configured via env variables, as introduced in geobeyond/arpav-ppcv#17 to configure the dev stack in such a way to make use of a local backend. 

This allows running all of the system locally when in development