### PR TITLE
Filter observation stations according to a year period

### DIFF
--- a/arpav_cline/schemas/static.py
+++ b/arpav_cline/schemas/static.py
@@ -201,6 +201,27 @@ class ObservationYearPeriod(str, enum.Enum):
     NOVEMBER = "november"
     DECEMBER = "december"
 
+    def get_month_filter(self) -> list[int]:
+        return {
+            ObservationYearPeriod.ALL_YEAR: (7,),
+            ObservationYearPeriod.WINTER: (1, 2, 12),
+            ObservationYearPeriod.SPRING: (3, 4, 5),
+            ObservationYearPeriod.SUMMER: (6, 7, 8),
+            ObservationYearPeriod.AUTUMN: (9, 10, 11),
+            ObservationYearPeriod.JANUARY: (1,),
+            ObservationYearPeriod.FEBRUARY: (2,),
+            ObservationYearPeriod.MARCH: (3,),
+            ObservationYearPeriod.APRIL: (4,),
+            ObservationYearPeriod.MAY: (5,),
+            ObservationYearPeriod.JUNE: (6,),
+            ObservationYearPeriod.JULY: (7,),
+            ObservationYearPeriod.AUGUST: (8,),
+            ObservationYearPeriod.SEPTEMBER: (9,),
+            ObservationYearPeriod.OCTOBER: (10,),
+            ObservationYearPeriod.NOVEMBER: (11,),
+            ObservationYearPeriod.DECEMBER: (12,),
+        }[self]
+
 
 class HistoricalYearPeriod(str, enum.Enum):
     ALL_YEAR = "all_year"

--- a/arpav_cline/timeseries.py
+++ b/arpav_cline/timeseries.py
@@ -217,12 +217,19 @@ def find_nearby_observation_station(
     return nearby_stations[0] if len(nearby_stations) > 0 else None
 
 
+def filter_series_by_year_period(
+    series: pd.Series, year_period: static.ObservationYearPeriod
+) -> pd.Series:
+    return series[series.index.month.isin(year_period.get_month_filter())]
+
+
 def get_nearby_observation_station_time_series(
     session: "sqlmodel.Session",
     location: shapely.Point,
     observation_series_configuration: "observations.ObservationSeriesConfiguration",
     distance_threshold_meters: int,
     temporal_range: tuple[Optional[dt.datetime], Optional[dt.datetime]],
+    year_period: static.ObservationYearPeriod | None = None,
 ) -> Optional[dataseries.ObservationStationDataSeries]:
     result = None
     nearby_station = find_nearby_observation_station(
@@ -248,6 +255,8 @@ def get_nearby_observation_station_time_series(
                 base_name=result.identifier,
                 temporal_range=temporal_range,
             )
+            if year_period is not None:
+                parsed_data = filter_series_by_year_period(parsed_data, year_period)
             result.data_ = parsed_data
         else:
             result = None
@@ -499,6 +508,7 @@ def get_historical_time_series(
             obs_series_conf,
             distance_threshold_meters=settings.nearest_station_radius_meters,
             temporal_range=temporal_range,
+            year_period=static.ObservationYearPeriod(coverage.year_period.value),
         )
         if obs_data_series is not None:
             result.append(obs_data_series)
@@ -613,6 +623,7 @@ def get_forecast_coverage_time_series(
             point_geom=point_geom,
             processing_methods=observation_processing_methods,
             temporal_range=temporal_range,
+            year_period=static.ObservationYearPeriod(coverage.year_period.value),
         )
     return coverage_series, observation_series
 
@@ -702,6 +713,7 @@ def _get_forecast_coverage_observation_time_series(
     point_geom: shapely.Point,
     processing_methods: list[static.ObservationTimeSeriesProcessingMethod],
     temporal_range: tuple[Optional[dt.datetime], Optional[dt.datetime]],
+    year_period: static.ObservationYearPeriod | None = None,
 ) -> list[dataseries.ObservationStationDataSeries]:
     result = []
     for observation_series_conf in observation_series_configurations:
@@ -711,6 +723,7 @@ def _get_forecast_coverage_observation_time_series(
             observation_series_conf,
             distance_threshold_meters=settings.nearest_station_radius_meters,
             temporal_range=temporal_range,
+            year_period=year_period,
         )
         if observation_data_series is not None:
             result.append(observation_data_series)

--- a/arpav_cline/webapp/api_v2/routers/coverages.py
+++ b/arpav_cline/webapp/api_v2/routers/coverages.py
@@ -1009,7 +1009,7 @@ def get_forecast_time_series(
             ) from err
         else:
             series = []
-            for forecast_cov_series in forecast_series:
+            for forecast_cov_series in forecast_series or []:
                 series.append(
                     LegacyTimeSeries.from_forecast_data_series(forecast_cov_series)
                 )


### PR DESCRIPTION
This PR implements the missing filtering of observation stations measurements by the current year period. This fixes a regression introduced upon refactoring into the simpler structure that was merged recently.

With this PR the backend API now returns single values for each year, and they are relevant to the current year period. Example request and response:

```shell
http http://localhost:8877/api/v2/coverages/forecast-time-series/\
    forecast-tas-absolute-annual-arpa_vfvg-all_seasons-ensemble-model_ensemble-rcp26-winter \
    "coords==POINT(12.0071 45.8820)" \
    "datetime==../.." \
    include_coverage_data==false \
    coverage_data_smoothing==NO_SMOOTHING \
    include_observation_data==true \
    observation_data_smoothing==NO_SMOOTHING \
| jq '.series[0] | .name, .values[0:5]'
```
```json
"station-arpa_v-189-tas-absolute-annual-arpa_v:arpa_fvg-seasonal-no_processing"
[
  {
    "value": 3.387,
    "datetime": "1993-01-01T00:00:00"
  },
  {
    "value": 3.986,
    "datetime": "1994-01-01T00:00:00"
  },
  {
    "value": 3.769,
    "datetime": "1995-01-01T00:00:00"
  },
  {
    "value": 3.471,
    "datetime": "1996-01-01T00:00:00"
  },
  {
    "value": 4.402,
    "datetime": "1997-01-01T00:00:00"
  }
]

```

---

- fixes #378