### PR TITLE
Fixed missing update of uncertainty base path when saving a climatic indicator

### DIFF
--- a/arpav_cline/bootstrapper/climaticindicators/pr.py
+++ b/arpav_cline/bootstrapper/climaticindicators/pr.py
@@ -88,7 +88,7 @@ def generate_climatic_indicators(
                 ClimaticIndicatorForecastModelLinkCreateEmbeddedInClimaticIndicator(
                     forecast_model_id=forecast_model_ids["model_ensemble"],
                     thredds_url_base_path="ens5ym/clipped",
-                    thredds_url_uncertainties_base_path="ens5ym/clipped",
+                    thredds_url_uncertainties_base_path="ens5ym/std/clipped",
                 ),
                 ClimaticIndicatorForecastModelLinkCreateEmbeddedInClimaticIndicator(
                     forecast_model_id=forecast_model_ids["ec_earth_cclm_4_8_17"],

--- a/arpav_cline/db/climaticindicators.py
+++ b/arpav_cline/db/climaticindicators.py
@@ -255,6 +255,9 @@ def _update_climatic_indicator_forecast_model_links(
         else:  # already exists, just update
             existing_fm_link = existing_forecast_model_links[requested_fm_id]
             existing_fm_link.thredds_url_base_path = requested_fm.thredds_url_base_path
+            existing_fm_link.thredds_url_uncertainties_base_path = (
+                requested_fm.thredds_url_uncertainties_base_path
+            )
             session.add(existing_fm_link)
     return climatic_indicator
 


### PR DESCRIPTION
This PR fixes an error in the update of climatic indicators whereby modifications to the uncertainties base path were not being taken into account.

Also fixed bootstrap values of PR annual anomaly to point to the correct path when looking for uncertainty datasets

---

- fixes #426