### PR TITLE
Added station blacklist and prefect cron schedules to the list of prod-customizable settings

### DIFF
--- a/deployments/deploy.py
+++ b/deployments/deploy.py
@@ -52,6 +52,10 @@ class DeploymentConfiguration:
     )  # is copied to inside the deployment_root dir
     martin_env_database_url: str = dataclasses.field(init=False)
     martin_image_tag: str
+    observation_station_blacklist: str
+    observation_stations_refresher_flow_cron_schedule: str
+    observation_measurements_refresher_flow_cron_schedule: str
+    station_variables_refresher_flow_cron_schedule: str
     prefect_db_name: str
     prefect_db_password: str
     prefect_db_user: str
@@ -191,6 +195,11 @@ class DeploymentConfiguration:
     def from_config_parser(cls, config_parser: configparser.ConfigParser):
         tls_cert_path = config_parser["reverse_proxy"].get("tls_cert_path")
         tls_cert_key_path = config_parser["reverse_proxy"].get("tls_cert_key_path")
+        station_blacklist = [
+            i.strip()
+            for i in config_parser["main"]["observation_station_blacklist"].split(",")
+            if i != ""
+        ]
         return cls(
             arpa_fvg_auth_token_path=Path(
                 config_parser["main"]["arpa_fvg_auth_token_path"]
@@ -214,6 +223,20 @@ class DeploymentConfiguration:
             frontend_image=config_parser["main"]["frontend_image"],
             martin_image_tag=config_parser["martin"]["image_tag"],
             martin_config_source=config_parser["martin"]["config_source"],
+            observation_station_blacklist=json.dumps(station_blacklist),
+            observation_stations_refresher_flow_cron_schedule=(
+                config_parser["main"][
+                    "observation_stations_refresher_flow_cron_schedule"
+                ]
+            ),
+            observation_measurements_refresher_flow_cron_schedule=(
+                config_parser["main"][
+                    "observation_measurements_refresher_flow_cron_schedule"
+                ]
+            ),
+            station_variables_refresher_flow_cron_schedule=(
+                config_parser["main"]["station_variables_refresher_flow_cron_schedule"]
+            ),
             prefect_db_name=config_parser["prefect_db"]["name"],
             prefect_db_password=config_parser["prefect_db"]["password"],
             prefect_db_user=config_parser["prefect_db"]["user"],
@@ -281,7 +304,7 @@ class DeploymentConfiguration:
             ],
         )
 
-    def ensure_paths_exist(self):
+    def ensure_paths_exist(self, raise_error: bool = True) -> None:
         paths_to_test = (
             self.deployment_root,
             self.tls_cert_path,
@@ -289,9 +312,11 @@ class DeploymentConfiguration:
         )
         for path in (p for p in paths_to_test if p is not None):
             if not path.exists():
-                raise RuntimeError(
-                    f"Could not find referenced configuration file {path!r}"
-                )
+                message = f"Could not find referenced configuration file {path!r}"
+                if raise_error:
+                    raise RuntimeError(message)
+                else:
+                    logger.warning(message)
 
 
 class DeployStepProtocol(Protocol):
@@ -639,7 +664,7 @@ if __name__ == "__main__":
             deployment_config.backend_image = backend_image_name
         if (frontend_image_name := parsed_args.frontend_image) is not None:
             deployment_config.frontend_image = frontend_image_name
-        deployment_config.ensure_paths_exist()
+        deployment_config.ensure_paths_exist(raise_error=parsed_args.confirm)
         logger.debug("Configuration:")
         for k, v in dataclasses.asdict(deployment_config).items():
             logger.debug(f"{k}: {v}")

--- a/deployments/sample-prod-deployment.cfg
+++ b/deployments/sample-prod-deployment.cfg
@@ -40,6 +40,17 @@ deployment_files_repo_clone_destination = /tmp/arpav-cline
 # tag name of the `prefecthq/prefect` image to use
 prefect_server_image_tag = 3.0.0rc17-python3.10
 
+# list of comma-delimited observation station codes denoting stations that should be ignored
+observation_station_blacklist =
+    <SOME-STATION-CODE>,
+    <ANOTHER-STATION-CODE>,
+
+# cron expression with the periodicity of recurrent tasks related to observation stations
+# and measurements from both ARPAV and ARPA FVG APIs
+observation_stations_refresher_flow_cron_schedule = "0 1 * * *"  # runs everyday at 01h
+observation_measurements_refresher_flow_cron_schedule = "0 2 * * *"  # runs everyday at 02h
+station_variables_refresher_flow_cron_schedule = "0 5 * * *"  # runs everyday at 05h
+
 
 [db]
 

--- a/docker/compose.production.template.yaml
+++ b/docker/compose.production.template.yaml
@@ -177,6 +177,10 @@ services:
     environment:
       ARPAV_PPCV__DEBUG: "${prefect_static_worker_env_arpav_ppcv_debug}"
       ARPAV_PPCV__DB_DSN: "${prefect_static_worker_env_arpav_ppcv_db_dsn}"
+      ARPAV_PPCV__OBSERVATION_STATIONS_BLACKLIST: '${observation_stations_blacklist}'
+      ARPAV_PPCV__PREFECT__OBSERVATION_STATIONS_REFRESHER_FLOW_CRON_SCHEDULE: "${observation_stations_refresher_flow_cron_schedule}"
+      ARPAV_PPCV__PREFECT__OBSERVATION_MEASUREMENTS_REFRESHER_FLOW_CRON_SCHEDULE: "${observation_measurements_refresher_flow_cron_schedule}"
+      ARPAV_PPCV__PREFECT__STATION_VARIABLES_REFRESHER_FLOW_CRON_SCHEDULE: "${station_variables_refresher_flow_cron_schedule}"
       PREFECT_API_URL: "${prefect_static_worker_env_prefect_api_url}"
       PREFECT_DEBUG_MODE: "${prefect_static_worker_env_prefect_debug_mode}"
       PREFECT_LOGGING_EXTRA_LOGGERS: "arpav_cline"


### PR DESCRIPTION
This PR adds a couple more configuration parameters to the production deployment script in order to be able to configure:

    station blacklist
    schedules for the prefect flows

---

- fixes #431
- fixes #432
- fixes #434 