### PR TITLE
Add missing download data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Added missing historical coverage download detail
+
 
 ## [2.0.1] - 2025-06-30
 

--- a/arpav_cline/webapp/admin/views/analytics.py
+++ b/arpav_cline/webapp/admin/views/analytics.py
@@ -119,6 +119,9 @@ class HistoricalCoverageDownloadRequestView(ModelView):
         starlette_admin.BooleanField("is_public_sector"),
         starlette_admin.StringField("download_reason"),
         starlette_admin.StringField("climatological_variable"),
+        starlette_admin.StringField("aggregation_period"),
+        starlette_admin.StringField("measure_type"),
+        starlette_admin.StringField("year_period"),
         starlette_admin.StringField("decade"),
         starlette_admin.StringField("reference_period"),
     )


### PR DESCRIPTION
This PR adds some properties to the admin section that shows download requests for historical data. The following properties are added:

- `aggregation_period`
- `measure_type`
- `year_period`

---

- fixes #436