### PR TITLE
Implemented custom search behavior in the admin section for observation measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Production deployment configuration file now accepts the additional `env_http_client_timeout_seconds` parameter,
   which allows customizing the timeout (in seconds) for the HTTP client. The default value is 30.0
+- Implemented custom filtering for the admin section that works with Observation measurements
 
 
 ## [2.0.3] - 2025-08-07

--- a/arpav_cline/db/__init__.py
+++ b/arpav_cline/db/__init__.py
@@ -133,6 +133,7 @@ from .observationstations import (
     delete_observation_station,  # noqa
     get_observation_station,  # noqa
     get_observation_station_by_code,  # noqa
+    get_observation_station_by_name,  # noqa
     list_observation_stations,  # noqa
     update_observation_station,  # noqa
 )

--- a/arpav_cline/db/observationstations.py
+++ b/arpav_cline/db/observationstations.py
@@ -35,12 +35,20 @@ def get_observation_station(
     return session.get(ObservationStation, observation_station_id)
 
 
+def get_observation_station_by_name(
+    session: sqlmodel.Session, name: str
+) -> Optional[ObservationStation]:
+    return session.exec(
+        sqlmodel.select(ObservationStation).where(ObservationStation.name == name)  # noqa
+    ).first()
+
+
 def get_observation_station_by_code(
     session: sqlmodel.Session, code: str
 ) -> Optional[ObservationStation]:
     """Get an observation station by its code"""
     return session.exec(
-        sqlmodel.select(ObservationStation).where(ObservationStation.code == code)  # noqa  # noqa
+        sqlmodel.select(ObservationStation).where(ObservationStation.code == code)  # noqa
     ).first()
 
 

--- a/arpav_cline/webapp/admin/app.py
+++ b/arpav_cline/webapp/admin/app.py
@@ -1,6 +1,8 @@
 import logging
 import typing
 
+from pathlib import Path
+
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.sessions import SessionMiddleware
@@ -78,6 +80,7 @@ def create_admin(settings: "ArpavPpcvSettings") -> ArpavPpcvAdmin:
         engine,
         debug=settings.debug,
         templates_dir=str(settings.templates_dir / "admin"),
+        statics_dir=str(Path(__file__).parent / "statics"),
         auth_provider=auth.UsernameAndPasswordProvider(),
         middlewares=[
             Middleware(SessionMiddleware, secret_key=settings.session_secret_key),

--- a/arpav_cline/webapp/admin/fields.py
+++ b/arpav_cline/webapp/admin/fields.py
@@ -4,6 +4,7 @@ from typing import Any
 import anyio.to_thread
 import starlette_admin
 from starlette.requests import Request
+from starlette_admin import RequestAction
 
 from ... import db
 
@@ -164,8 +165,14 @@ class RelatedObservationSeriesConfigurationField(starlette_admin.EnumField):
 
 class RelatedObservationStationField(starlette_admin.EnumField):
     def __post_init__(self) -> None:
+        self.search_builder_type = "eq_only"
         self.choices_loader = RelatedObservationStationField.choices_loader
         super().__post_init__()
+
+    def additional_js_links(self, request: Request, action: RequestAction) -> list[str]:
+        if action == RequestAction.LIST:
+            return [str(request.url_for("admin:statics", path="eq-only-conditions.js"))]
+        return []
 
     async def serialize_value(
         self, request: Request, value: Any, action: starlette_admin.RequestAction
@@ -237,6 +244,7 @@ class RelatedClimaticIndicatorField(starlette_admin.EnumField):
     """
 
     def __post_init__(self) -> None:
+        self.search_builder_type = "eq_only"
         self.choices_loader = RelatedClimaticIndicatorField.choices_loader
         super().__post_init__()
 

--- a/arpav_cline/webapp/admin/statics/eq-only-conditions.js
+++ b/arpav_cline/webapp/admin/statics/eq-only-conditions.js
@@ -1,0 +1,42 @@
+(function () {
+  // Register a custom SearchBuilder condition type that only exposes the
+  // "Equals" operator. Fields with search_builder_type="eq_only" will use
+  // this instead of the default "string" type, which exposes many operators
+  // (Contains, Starts with, etc.) that the backend cannot handle.
+  function register() {
+    if (typeof $.fn.dataTable === "undefined") {
+      setTimeout(register, 10);
+      return;
+    }
+    $.fn.dataTable.ext.searchBuilder.conditions["eq_only"] = {
+      "=": {
+        conditionName: function (dt) {
+          return dt.i18n(
+            "searchBuilder.conditions.string.equals",
+            "Equals"
+          );
+        },
+        init: function (that, fn, preDefined) {
+          var el = $('<input type="text" class="form-control form-control-sm">');
+          el.on("input.dtsb keypress.dtsb", function () {
+            fn(that);
+          });
+          if (preDefined) {
+            el.val(preDefined[0]);
+          }
+          return el;
+        },
+        inputValue: function (el) {
+          return [el[0].val()];
+        },
+        isInputValid: function (el) {
+          return el[0].val().length > 0;
+        },
+        search: function (value, comparison) {
+          return value === comparison[0];
+        },
+      },
+    };
+  }
+  register();
+})();

--- a/arpav_cline/webapp/admin/views/observations.py
+++ b/arpav_cline/webapp/admin/views/observations.py
@@ -39,9 +39,15 @@ class ObservationMeasurementView(ModelView):
             "measurement_aggregation_type",
             enum=static.MeasurementAggregationType,
             required=True,
+            search_builder_type="eq_only",
         ),
         starlette_admin.DateField("date", required=True),
         starlette_admin.FloatField("value", required=True),
+    )
+    searchable_fields = (
+        "observation_station",
+        "climatic_indicator",
+        "measurement_aggregation_type",
     )
 
     def __init__(self, *args, **kwargs) -> None:
@@ -69,6 +75,90 @@ class ObservationMeasurementView(ModelView):
             climatic_indicator=instance.climatic_indicator_id,
         )
 
+    @staticmethod
+    def _extract_eq_value(where: dict[str, Any], field_name: str) -> Any:
+        for condition in where.get("and", []):
+            if field_name in condition:
+                return condition[field_name].get("eq")
+        return None
+
+    async def _resolve_filters(
+        self, request: Request, where: Union[dict[str, Any], str, None]
+    ) -> tuple[
+        Optional[int], Optional[int], Optional[static.MeasurementAggregationType]
+    ]:
+        session = request.state.session
+        station_id_filter = None
+        indicator_id_filter = None
+        aggregation_type_filter = None
+        if isinstance(where, str):
+            station = await anyio.to_thread.run_sync(
+                db.get_observation_station_by_name, session, where
+            )
+            station_id_filter = station.id if station is not None else None
+        elif isinstance(where, dict):
+            if (
+                station_name := self._extract_eq_value(where, "observation_station")
+            ) is not None:
+                logger.debug(f"{station_name=}")
+                station = await anyio.to_thread.run_sync(
+                    db.get_observation_station_by_name, session, station_name
+                )
+                logger.debug(f"{station=}")
+                station_id_filter = station.id if station is not None else None
+            if (
+                indicator_identifier := self._extract_eq_value(
+                    where, "climatic_indicator"
+                )
+            ) is not None:
+                logger.debug(f"{indicator_identifier=}")
+                try:
+                    indicator = await anyio.to_thread.run_sync(
+                        db.get_climatic_indicator_by_identifier,
+                        session,
+                        indicator_identifier,
+                    )
+                    logger.debug(f"{indicator=}")
+                    indicator_id_filter = (
+                        indicator.id if indicator is not None else None
+                    )
+                except Exception:
+                    indicator_id_filter = None
+            if (
+                raw_aggregation_type := self._extract_eq_value(
+                    where, "measurement_aggregation_type"
+                )
+            ) is not None:
+                try:
+                    aggregation_type_filter = static.MeasurementAggregationType[
+                        raw_aggregation_type.upper()
+                    ]
+                except KeyError:
+                    aggregation_type_filter = None
+        return station_id_filter, indicator_id_filter, aggregation_type_filter
+
+    async def count(
+        self,
+        request: Request,
+        where: Union[dict[str, Any], str, None] = None,
+    ) -> int:
+        (
+            station_id_filter,
+            indicator_id_filter,
+            aggregation_type_filter,
+        ) = await self._resolve_filters(request, where)
+        counter = functools.partial(
+            db.list_observation_measurements,
+            limit=0,
+            offset=0,
+            include_total=True,
+            observation_station_id_filter=station_id_filter,
+            climatic_indicator_id_filter=indicator_id_filter,
+            aggregation_type_filter=aggregation_type_filter,
+        )
+        _, total = await anyio.to_thread.run_sync(counter, request.state.session)
+        return total or 0
+
     async def find_all(
         self,
         request: Request,
@@ -77,11 +167,20 @@ class ObservationMeasurementView(ModelView):
         where: Union[dict[str, Any], str, None] = None,
         order_by: Optional[list[str]] = None,
     ) -> Sequence[read_schemas.ObservationMeasurementRead]:
+        logger.debug(f"{locals()=}")
+        (
+            station_id_filter,
+            indicator_id_filter,
+            aggregation_type_filter,
+        ) = await self._resolve_filters(request, where)
         list_measurements = functools.partial(
             db.list_observation_measurements,
             limit=limit,
             offset=skip,
             include_total=False,
+            observation_station_id_filter=station_id_filter,
+            climatic_indicator_id_filter=indicator_id_filter,
+            aggregation_type_filter=aggregation_type_filter,
         )
         db_measurements, _ = await anyio.to_thread.run_sync(
             list_measurements, request.state.session

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -58,7 +58,7 @@ name: arpav-cline
 services:
 
   reverse-proxy:
-    image: traefik:3.0.2
+    image: traefik:v3
     volumes:
       - type: bind
         source: /var/run/docker.sock


### PR DESCRIPTION
This PR adds custom search behavior for the admin section that deals with observations.

It removes most search operators from the UI, keeping only the 'Equals' operator. The station name, climatic indicator name and measurement aggregatio type are implemented as search filters in the backend too, thus making it possible to perform filtering of the observation list. Moreover, the general search field is mapped to filtering by station name too. Here is a short usage demo:

[Kazam_screencast_00028.webm](https://github.com/user-attachments/assets/51d4746f-875d-474c-a5b8-2e4e95e0fb11)

As a minor change, this also updates the traefik image in use in the compose file, as the previous one is not compatible with current versions of docker engine

---

- fixes venetoarpa/arpav-cline-frontend#11