### PR TITLE
Fix error due to incorrect handling of pandas series and their coercion to scalars for checking for NANs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fixed timeseries handling of empty datasets
 
 
 ## [2.0.4] - 2026-03-19

--- a/arpav_cline/timeseries.py
+++ b/arpav_cline/timeseries.py
@@ -1,6 +1,5 @@
 import datetime as dt
 import functools
-import math
 import logging
 import warnings
 from typing import (
@@ -553,7 +552,7 @@ def get_historical_observation_series(
                 loess_series = generate_loess_derived_observation_station_series(
                     obs_data_series, point_geom
                 )
-                if not math.isnan(loess_series.data_):
+                if not loess_series.data_.isna().all():
                     result.append(loess_series)
             if include_moving_average_series:
                 moving_average_series = (
@@ -561,14 +560,14 @@ def get_historical_observation_series(
                         obs_data_series, point_geom
                     )
                 )
-                if not math.isnan(moving_average_series.data_):
+                if not moving_average_series.data_.isna().all():
                     result.append(moving_average_series)
             if include_decade_aggregation_series:
                 if (
                     decade_series := generate_decade_derived_observation_station_series(
                         obs_data_series, point_geom
                     )
-                ) is not None and not math.isnan(decade_series.data_):
+                ) is not None and not decade_series.data_.isna().all():
                     result.append(decade_series)
             if mann_kendall_params is not None:
                 try:
@@ -617,20 +616,20 @@ def get_historical_time_series(
         result.append(cov_series)
         if include_loess_series:
             loess_series = generate_loess_derived_historical_coverage_series(cov_series)
-            if not math.isnan(loess_series.data_):
+            if not loess_series.data_.isna().all():
                 result.append(loess_series)
         if include_moving_average_series:
             moving_average_series = (
                 generate_moving_average_derived_historical_coverage_series(cov_series)
             )
-            if not math.isnan(moving_average_series.data_):
+            if not moving_average_series.data_.isna().all():
                 result.append(moving_average_series)
         if include_decade_aggregation_series:
             if (
                 decade_series := generate_decade_derived_historical_coverage_series(
                     cov_series
                 )
-            ) is not None and not math.isnan(decade_series.data_):
+            ) is not None and not decade_series.data_.isna().all():
                 result.append(decade_series)
         if mann_kendall_params is not None:
             try:
@@ -723,7 +722,7 @@ def get_forecast_coverage_time_series(
                 cov_data_series,
                 processing_method,
             )
-            if not math.isnan(derived_series.data_):
+            if not derived_series.data_.isna().all():
                 result.append(derived_series)
     return result
 
@@ -795,7 +794,7 @@ def _get_forecast_coverage_observation_time_series(
                         derived_series_name=series.identifier,
                     )
                     series.data_ = smoothed_df[series.identifier].squeeze()
-                    if not math.isnan(series.data_):
+                    if not series.data_.isna().all():
                         result.append(series)
         else:
             logger.info("No station data found, skipping...")
@@ -936,7 +935,7 @@ def get_observation_overview_time_series(
         if pm != static.CoverageTimeSeriesProcessingMethod.NO_PROCESSING
     ):
         derived_series = generate_derived_overview_series(series, processing_method)
-        if not math.isnan(derived_series.data_):
+        if not derived_series.data_.isna().all():
             result.append(derived_series)
     return result
 
@@ -965,7 +964,7 @@ def get_forecast_overview_time_series(
             derived_series = generate_derived_overview_series(
                 overview_series, processing_method
             )
-            if not math.isnan(derived_series.data_):
+            if not derived_series.data_.isna().all():
                 result.append(derived_series)
     return result
 


### PR DESCRIPTION
This PR fixes an incorrect handling of pandas Series when coercing them to a scalar and checking for NAN values. The previous usage of `math.isnan()` broke if the underlying pandas Series had multiple elements.