### PR TITLE
disable admin search builder for most views

### DIFF
--- a/arpav_cline/webapp/admin/views/analytics.py
+++ b/arpav_cline/webapp/admin/views/analytics.py
@@ -33,6 +33,7 @@ class ForecastCoverageDownloadRequestView(ModelView):
 
     exclude_fields_from_list = ("id",)
     exclude_fields_from_detail = ("id",)
+    search_builder = False
 
     fields = (
         starlette_admin.IntegerField("id"),
@@ -111,6 +112,7 @@ class HistoricalCoverageDownloadRequestView(ModelView):
 
     exclude_fields_from_list = ("id",)
     exclude_fields_from_detail = ("id",)
+    search_builder = False
 
     fields = (
         starlette_admin.IntegerField("id"),
@@ -188,6 +190,7 @@ class TimeSeriesDownloadRequestView(ModelView):
 
     exclude_fields_from_list = ("id",)
     exclude_fields_from_detail = ("id",)
+    search_builder = False
 
     fields = (
         starlette_admin.IntegerField("id"),

--- a/arpav_cline/webapp/admin/views/base.py
+++ b/arpav_cline/webapp/admin/views/base.py
@@ -42,6 +42,7 @@ class SpatialRegionView(ModelView):
         starlette_admin.IntegerField("sort_order"),
         starlette_admin.JSONField("geom", required=True),
     )
+    search_builder = False
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)

--- a/arpav_cline/webapp/admin/views/climaticindicators.py
+++ b/arpav_cline/webapp/admin/views/climaticindicators.py
@@ -55,6 +55,7 @@ class ClimaticIndicatorView(ModelView):
     exclude_fields_from_detail = ("id",)
     exclude_fields_from_edit = ("identifier",)
     exclude_fields_from_create = ("identifier",)
+    search_builder = False
 
     fields = (
         starlette_admin.IntegerField("id"),

--- a/arpav_cline/webapp/admin/views/coverages.py
+++ b/arpav_cline/webapp/admin/views/coverages.py
@@ -65,6 +65,7 @@ class ForecastTimeWindowView(ModelView):
         starlette_admin.StringField("description_italian"),
         starlette_admin.IntegerField("sort_order"),
     )
+    search_builder = False
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -164,6 +165,7 @@ class ForecastModelView(ModelView):
         starlette_admin.StringField("description_italian"),
         starlette_admin.IntegerField("sort_order"),
     )
+    search_builder = False
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -264,6 +266,7 @@ class ForecastModelGroupView(ModelView):
             "forecast_models", multiple=True, required=True
         ),
     )
+    search_builder = False
 
     @staticmethod
     def _serialize_instance(
@@ -365,6 +368,7 @@ class ForecastYearPeriodGroupView(ModelView):
             "year_periods", multiple=True, enum=static.ForecastYearPeriod, required=True
         ),
     )
+    search_builder = False
 
     @staticmethod
     def _serialize_instance(
@@ -468,6 +472,7 @@ class HistoricalYearPeriodGroupView(ModelView):
             required=True,
         ),
     )
+    search_builder = False
 
     @staticmethod
     def _serialize_instance(
@@ -570,6 +575,7 @@ class ForecastCoverageConfigurationView(ModelView):
     exclude_fields_from_edit = ("identifier",)
     exclude_fields_from_create = ("identifier",)
     searchable_fields = ("climatic_indicator",)
+    search_builder = False
 
     fields = (
         starlette_admin.IntegerField("id"),
@@ -852,6 +858,7 @@ class HistoricalCoverageConfigurationView(ModelView):
     exclude_fields_from_edit = ("identifier",)
     exclude_fields_from_create = ("identifier",)
     searchable_fields = ("climatic_indicator",)
+    search_builder = False
 
     fields = (
         starlette_admin.IntegerField("id"),

--- a/arpav_cline/webapp/admin/views/observations.py
+++ b/arpav_cline/webapp/admin/views/observations.py
@@ -211,6 +211,7 @@ class ObservationStationView(ModelView):
         starlette_admin.DateField("active_until"),
         starlette_admin.FloatField("altitude_m"),
     )
+    search_builder = False
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -329,6 +330,7 @@ class ObservationSeriesConfigurationView(ModelView):
         "identifier",
     )
     exclude_fields_from_create = ("identifier",)
+    search_builder = False
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)

--- a/arpav_cline/webapp/admin/views/overviews.py
+++ b/arpav_cline/webapp/admin/views/overviews.py
@@ -49,6 +49,7 @@ class ObservationOverviewSeriesConfigurationView(ModelView):
     exclude_fields_from_edit = ("identifier",)
     exclude_fields_from_create = ("identifier",)
     searchable_fields = ("climatic_indicator",)
+    search_builder = False
 
     fields = (
         starlette_admin.IntegerField("id"),
@@ -191,6 +192,7 @@ class ForecastOverviewSeriesConfigurationView(ModelView):
     exclude_fields_from_edit = ("identifier",)
     exclude_fields_from_create = ("identifier",)
     searchable_fields = ("climatic_indicator",)
+    search_builder = False
 
     fields = (
         starlette_admin.IntegerField("id"),


### PR DESCRIPTION
This PR disables the admin search_builder in most admin views, as the code does not implement complex search filters. Keeping the search builder is confusing to the end user, because it does not work