### PR TITLE
Scoped gh workflow actions to geobeyond remote

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
 
 env:
   COLUMNS: 120
-  PUBLISH_IMAGE: ${{ (github.ref_name == 'main' || github.ref_type == 'tag') && 'TRUE' || 'FALSE'}}
+  PUBLISH_IMAGE: ${{ (github.ref_name == 'main' || github.ref_type == 'tag') && github.repository_owner == 'geobeyond' && 'TRUE' || 'FALSE'}}
   IMAGE_TAG: ${{ github.ref_name == 'main' && 'latest' || github.ref_name }}
   IMAGE_NAME: ghcr.io/${{ github.repository }}/${{ github.event.repository.name }}
 

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -15,6 +15,7 @@ concurrency: staging
 
 jobs:
   initiate-deployment:
+    if: github.repository_owner == 'geobeyond'
     runs-on: ubuntu-22.04
     environment: staging
     steps:


### PR DESCRIPTION
This PR ensures certain actions performed by the GitHub workflows only run when called in the context of the `geobeyond` organization.

---

- Related to venetoarpa/arpav-cline-frontend#13